### PR TITLE
Default APIVersion and Kind for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,30 @@ type MyResourceDie interface {
     // unstructured object.
     DieReleaseUnstructured() *unstructured.Unstructured
 
+    // DieDefaultTypeMetadata sets the APIVersion and Kind
+    DieDefaultTypeMetadata() *MyResourceDie
+
+    // APIVersion defines the versioned schema of this representation of an
+    // object. Servers should convert recognized schemas to the latest internal
+    // value, and may reject unrecognized values. More info:
+    // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+    APIVersion(v string) *MyResourceDie
+
+    // Kind is a string value representing the REST resource this object
+    // represents. Servers may infer this from the endpoint the client submits
+    // requests to. Cannot be updated. In CamelCase. More info:
+    // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+    Kind(v string) *MyResourceDie
+
+    // TypeMetadata standard object's type metadata.
+    TypeMetadata(v metav1.TypeMeta) *MyResourceDie
+
+    // TypeMetaDie stamps the resource's TypeMeta field with a mutable die.
+    TypeMetaDie(fn func(d *diemetav1.TypeMetaDie)) *MyResourceDie
+
+    // Metadata standard object's metadata.
+    Metadata(v metav1.ObjectMeta) *MyResourceDie
+
     // MetadataDie stamps the resource's ObjectMeta field with a mutable die.
     MetadataDie(fn func(d *diemetav1.ObjectMetaDie)) *MyResourceDie
 
@@ -285,7 +309,7 @@ import (
     appsv1 "k8s.io/api/apps/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apps/v1,kind=Deployment
 type _ = appsv1.Deployment
 
 // +die
@@ -298,7 +322,7 @@ type _ = appsv1.DeploymentStatus
 For packages you control, dies can be created in the same package as the resource they model by adding the markers to existing types.
 
 ```go
-// +die:object=true
+// +die:object=true,apiVersion=example.reconciler.io/v1,kind=MyResource
 type MyResource struct {
     metav1.TypeMeta   `json:",inline"`
     metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -321,4 +345,6 @@ type MyResourceStatus struct {
 
 Properties:
 - **object** `bool` (optional): indicates the target type implements `metav1.Object` and `runtime.Object`
+- **apiVersion** `string` (optional): defaults the blanks die's APIVersion (only for objects)
+- **kind** `string` (optional): defaults the blank die's Kind (only for objects)
 - **ignore** `[]string` (optional): set of fields to ignore on the type

--- a/apis/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/apis/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=admissionregistration.k8s.io/v1,kind=MutatingWebhookConfiguration
 type _ = admissionregistrationv1.MutatingWebhookConfiguration
 
 func (d *MutatingWebhookConfigurationDie) WebhookDie(name string, fn func(d *MutatingWebhookDie)) *MutatingWebhookConfigurationDie {

--- a/apis/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/apis/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=admissionregistration.k8s.io/v1,kind=ValidatingWebhookConfiguration
 type _ = admissionregistrationv1.ValidatingWebhookConfiguration
 
 func (d *ValidatingWebhookConfigurationDie) WebhookDie(name string, fn func(d *ValidatingWebhookDie)) *ValidatingWebhookConfigurationDie {

--- a/apis/admissionregistration/v1/zz_generated.die.go
+++ b/apis/admissionregistration/v1/zz_generated.die.go
@@ -1405,9 +1405,6 @@ func (d *MutatingWebhookConfigurationDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *MutatingWebhookConfigurationDie) UnmarshalJSON(b []byte) error {
-	if d == MutatingWebhookConfigurationBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -1415,6 +1412,14 @@ func (d *MutatingWebhookConfigurationDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "admissionregistration.k8s.io/v1" and "MutatingWebhookConfiguration" respectively.
+func (d *MutatingWebhookConfigurationDie) DieDefaultTypeMetadata() *MutatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhookConfiguration) {
+		r.APIVersion = "admissionregistration.k8s.io/v1"
+		r.Kind = "MutatingWebhookConfiguration"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -1428,6 +1433,29 @@ func (d *MutatingWebhookConfigurationDie) APIVersion(v string) *MutatingWebhookC
 func (d *MutatingWebhookConfigurationDie) Kind(v string) *MutatingWebhookConfigurationDie {
 	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhookConfiguration) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *MutatingWebhookConfigurationDie) TypeMetadata(v apismetav1.TypeMeta) *MutatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhookConfiguration) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *MutatingWebhookConfigurationDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *MutatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhookConfiguration) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *MutatingWebhookConfigurationDie) Metadata(v apismetav1.ObjectMeta) *MutatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhookConfiguration) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -2135,9 +2163,6 @@ func (d *ValidatingWebhookConfigurationDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ValidatingWebhookConfigurationDie) UnmarshalJSON(b []byte) error {
-	if d == ValidatingWebhookConfigurationBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -2145,6 +2170,14 @@ func (d *ValidatingWebhookConfigurationDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "admissionregistration.k8s.io/v1" and "ValidatingWebhookConfiguration" respectively.
+func (d *ValidatingWebhookConfigurationDie) DieDefaultTypeMetadata() *ValidatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhookConfiguration) {
+		r.APIVersion = "admissionregistration.k8s.io/v1"
+		r.Kind = "ValidatingWebhookConfiguration"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -2158,6 +2191,29 @@ func (d *ValidatingWebhookConfigurationDie) APIVersion(v string) *ValidatingWebh
 func (d *ValidatingWebhookConfigurationDie) Kind(v string) *ValidatingWebhookConfigurationDie {
 	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhookConfiguration) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ValidatingWebhookConfigurationDie) TypeMetadata(v apismetav1.TypeMeta) *ValidatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhookConfiguration) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ValidatingWebhookConfigurationDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ValidatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhookConfiguration) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ValidatingWebhookConfigurationDie) Metadata(v apismetav1.ObjectMeta) *ValidatingWebhookConfigurationDie {
+	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhookConfiguration) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/apiextensions/v1/customresourcedefinition.go
+++ b/apis/apiextensions/v1/customresourcedefinition.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition
 type _ = apiextensionsv1.CustomResourceDefinition
 
 // +die

--- a/apis/apiregistration/v1/apiservice.go
+++ b/apis/apiregistration/v1/apiservice.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apiregistration.k8s.io/v1,kind=APIService
 type _ = apiregistrationv1.APIService
 
 // +die

--- a/apis/apiserver/flowcontrol/v1beta1/flowschema.go
+++ b/apis/apiserver/flowcontrol/v1beta1/flowschema.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=flowcontrol.apiserver.k8s.io/v1beta1,kind=FlowSchema
 type _ = flowcontrolv1beta1.FlowSchema
 
 // +die

--- a/apis/apiserver/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/apis/apiserver/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=flowcontrol.apiserver.k8s.io/v1beta1,kind=PriorityLevelConfiguration
 type _ = flowcontrolv1beta1.PriorityLevelConfiguration
 
 // +die

--- a/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
+++ b/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
@@ -25,6 +25,7 @@ import (
 	json "encoding/json"
 	fmtx "fmt"
 	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -249,9 +250,6 @@ func (d *FlowSchemaDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *FlowSchemaDie) UnmarshalJSON(b []byte) error {
-	if d == FlowSchemaBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -259,6 +257,14 @@ func (d *FlowSchemaDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "flowcontrol.apiserver.k8s.io/v1beta1" and "FlowSchema" respectively.
+func (d *FlowSchemaDie) DieDefaultTypeMetadata() *FlowSchemaDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchema) {
+		r.APIVersion = "flowcontrol.apiserver.k8s.io/v1beta1"
+		r.Kind = "FlowSchema"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -272,6 +278,29 @@ func (d *FlowSchemaDie) APIVersion(v string) *FlowSchemaDie {
 func (d *FlowSchemaDie) Kind(v string) *FlowSchemaDie {
 	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchema) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *FlowSchemaDie) TypeMetadata(v metav1.TypeMeta) *FlowSchemaDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchema) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *FlowSchemaDie) TypeMetadataDie(fn func(d *v1.TypeMetaDie)) *FlowSchemaDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchema) {
+		d := v1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *FlowSchemaDie) Metadata(v metav1.ObjectMeta) *FlowSchemaDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchema) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -2817,9 +2846,6 @@ func (d *PriorityLevelConfigurationDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *PriorityLevelConfigurationDie) UnmarshalJSON(b []byte) error {
-	if d == PriorityLevelConfigurationBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -2827,6 +2853,14 @@ func (d *PriorityLevelConfigurationDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "flowcontrol.apiserver.k8s.io/v1beta1" and "PriorityLevelConfiguration" respectively.
+func (d *PriorityLevelConfigurationDie) DieDefaultTypeMetadata() *PriorityLevelConfigurationDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.PriorityLevelConfiguration) {
+		r.APIVersion = "flowcontrol.apiserver.k8s.io/v1beta1"
+		r.Kind = "PriorityLevelConfiguration"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -2840,6 +2874,29 @@ func (d *PriorityLevelConfigurationDie) APIVersion(v string) *PriorityLevelConfi
 func (d *PriorityLevelConfigurationDie) Kind(v string) *PriorityLevelConfigurationDie {
 	return d.DieStamp(func(r *flowcontrolv1beta1.PriorityLevelConfiguration) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *PriorityLevelConfigurationDie) TypeMetadata(v metav1.TypeMeta) *PriorityLevelConfigurationDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.PriorityLevelConfiguration) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *PriorityLevelConfigurationDie) TypeMetadataDie(fn func(d *v1.TypeMetaDie)) *PriorityLevelConfigurationDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.PriorityLevelConfiguration) {
+		d := v1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *PriorityLevelConfigurationDie) Metadata(v metav1.ObjectMeta) *PriorityLevelConfigurationDie {
+	return d.DieStamp(func(r *flowcontrolv1beta1.PriorityLevelConfiguration) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/apps/v1/controllerrevision.go
+++ b/apis/apps/v1/controllerrevision.go
@@ -20,5 +20,5 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apps/v1,kind=ControllerRevision
 type _ = appsv1.ControllerRevision

--- a/apis/apps/v1/daemonset.go
+++ b/apis/apps/v1/daemonset.go
@@ -23,7 +23,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apps/v1,kind=DaemonSet
 type _ = appsv1.DaemonSet
 
 // +die

--- a/apis/apps/v1/deployment.go
+++ b/apis/apps/v1/deployment.go
@@ -23,7 +23,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apps/v1,kind=Deployment
 type _ = appsv1.Deployment
 
 // +die

--- a/apis/apps/v1/replicaset.go
+++ b/apis/apps/v1/replicaset.go
@@ -23,7 +23,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apps/v1,kind=ReplicaSet
 type _ = appsv1.ReplicaSet
 
 // +die

--- a/apis/apps/v1/statefulset.go
+++ b/apis/apps/v1/statefulset.go
@@ -23,7 +23,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=apps/v1,kind=StatefulSet
 type _ = appsv1.StatefulSet
 
 // +die

--- a/apis/apps/v1/statefulset_test.go
+++ b/apis/apps/v1/statefulset_test.go
@@ -97,6 +97,7 @@ func TestStatefulSet(t *testing.T) {
 				SpecDie(func(d *dieappsv1.StatefulSetSpecDie) {
 					d.VolumeClaimTemplatesDie(
 						diecorev1.PersistentVolumeClaimBlank.
+							TypeMetadata(metav1.TypeMeta{}).
 							SpecDie(func(d *diecorev1.PersistentVolumeClaimSpecDie) {
 								d.VolumeName("my-volume")
 							}),

--- a/apis/apps/v1/zz_generated.die.go
+++ b/apis/apps/v1/zz_generated.die.go
@@ -252,9 +252,6 @@ func (d *ControllerRevisionDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ControllerRevisionDie) UnmarshalJSON(b []byte) error {
-	if d == ControllerRevisionBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -262,6 +259,14 @@ func (d *ControllerRevisionDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "apps/v1" and "ControllerRevision" respectively.
+func (d *ControllerRevisionDie) DieDefaultTypeMetadata() *ControllerRevisionDie {
+	return d.DieStamp(func(r *appsv1.ControllerRevision) {
+		r.APIVersion = "apps/v1"
+		r.Kind = "ControllerRevision"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -275,6 +280,29 @@ func (d *ControllerRevisionDie) APIVersion(v string) *ControllerRevisionDie {
 func (d *ControllerRevisionDie) Kind(v string) *ControllerRevisionDie {
 	return d.DieStamp(func(r *appsv1.ControllerRevision) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ControllerRevisionDie) TypeMetadata(v apismetav1.TypeMeta) *ControllerRevisionDie {
+	return d.DieStamp(func(r *appsv1.ControllerRevision) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ControllerRevisionDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ControllerRevisionDie {
+	return d.DieStamp(func(r *appsv1.ControllerRevision) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ControllerRevisionDie) Metadata(v apismetav1.ObjectMeta) *ControllerRevisionDie {
+	return d.DieStamp(func(r *appsv1.ControllerRevision) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -515,9 +543,6 @@ func (d *DaemonSetDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *DaemonSetDie) UnmarshalJSON(b []byte) error {
-	if d == DaemonSetBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -525,6 +550,14 @@ func (d *DaemonSetDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "apps/v1" and "DaemonSet" respectively.
+func (d *DaemonSetDie) DieDefaultTypeMetadata() *DaemonSetDie {
+	return d.DieStamp(func(r *appsv1.DaemonSet) {
+		r.APIVersion = "apps/v1"
+		r.Kind = "DaemonSet"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -538,6 +571,29 @@ func (d *DaemonSetDie) APIVersion(v string) *DaemonSetDie {
 func (d *DaemonSetDie) Kind(v string) *DaemonSetDie {
 	return d.DieStamp(func(r *appsv1.DaemonSet) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *DaemonSetDie) TypeMetadata(v apismetav1.TypeMeta) *DaemonSetDie {
+	return d.DieStamp(func(r *appsv1.DaemonSet) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *DaemonSetDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *DaemonSetDie {
+	return d.DieStamp(func(r *appsv1.DaemonSet) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *DaemonSetDie) Metadata(v apismetav1.ObjectMeta) *DaemonSetDie {
+	return d.DieStamp(func(r *appsv1.DaemonSet) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -1815,9 +1871,6 @@ func (d *DeploymentDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *DeploymentDie) UnmarshalJSON(b []byte) error {
-	if d == DeploymentBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -1825,6 +1878,14 @@ func (d *DeploymentDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "apps/v1" and "Deployment" respectively.
+func (d *DeploymentDie) DieDefaultTypeMetadata() *DeploymentDie {
+	return d.DieStamp(func(r *appsv1.Deployment) {
+		r.APIVersion = "apps/v1"
+		r.Kind = "Deployment"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -1838,6 +1899,29 @@ func (d *DeploymentDie) APIVersion(v string) *DeploymentDie {
 func (d *DeploymentDie) Kind(v string) *DeploymentDie {
 	return d.DieStamp(func(r *appsv1.Deployment) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *DeploymentDie) TypeMetadata(v apismetav1.TypeMeta) *DeploymentDie {
+	return d.DieStamp(func(r *appsv1.Deployment) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *DeploymentDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *DeploymentDie {
+	return d.DieStamp(func(r *appsv1.Deployment) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *DeploymentDie) Metadata(v apismetav1.ObjectMeta) *DeploymentDie {
+	return d.DieStamp(func(r *appsv1.Deployment) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -3070,9 +3154,6 @@ func (d *ReplicaSetDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ReplicaSetDie) UnmarshalJSON(b []byte) error {
-	if d == ReplicaSetBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -3080,6 +3161,14 @@ func (d *ReplicaSetDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "apps/v1" and "ReplicaSet" respectively.
+func (d *ReplicaSetDie) DieDefaultTypeMetadata() *ReplicaSetDie {
+	return d.DieStamp(func(r *appsv1.ReplicaSet) {
+		r.APIVersion = "apps/v1"
+		r.Kind = "ReplicaSet"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -3093,6 +3182,29 @@ func (d *ReplicaSetDie) APIVersion(v string) *ReplicaSetDie {
 func (d *ReplicaSetDie) Kind(v string) *ReplicaSetDie {
 	return d.DieStamp(func(r *appsv1.ReplicaSet) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ReplicaSetDie) TypeMetadata(v apismetav1.TypeMeta) *ReplicaSetDie {
+	return d.DieStamp(func(r *appsv1.ReplicaSet) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ReplicaSetDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ReplicaSetDie {
+	return d.DieStamp(func(r *appsv1.ReplicaSet) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ReplicaSetDie) Metadata(v apismetav1.ObjectMeta) *ReplicaSetDie {
+	return d.DieStamp(func(r *appsv1.ReplicaSet) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -3817,9 +3929,6 @@ func (d *StatefulSetDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *StatefulSetDie) UnmarshalJSON(b []byte) error {
-	if d == StatefulSetBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -3827,6 +3936,14 @@ func (d *StatefulSetDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "apps/v1" and "StatefulSet" respectively.
+func (d *StatefulSetDie) DieDefaultTypeMetadata() *StatefulSetDie {
+	return d.DieStamp(func(r *appsv1.StatefulSet) {
+		r.APIVersion = "apps/v1"
+		r.Kind = "StatefulSet"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -3840,6 +3957,29 @@ func (d *StatefulSetDie) APIVersion(v string) *StatefulSetDie {
 func (d *StatefulSetDie) Kind(v string) *StatefulSetDie {
 	return d.DieStamp(func(r *appsv1.StatefulSet) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *StatefulSetDie) TypeMetadata(v apismetav1.TypeMeta) *StatefulSetDie {
+	return d.DieStamp(func(r *appsv1.StatefulSet) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *StatefulSetDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *StatefulSetDie {
+	return d.DieStamp(func(r *appsv1.StatefulSet) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *StatefulSetDie) Metadata(v apismetav1.ObjectMeta) *StatefulSetDie {
+	return d.DieStamp(func(r *appsv1.StatefulSet) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/authentication/v1/tokenreview.go
+++ b/apis/authentication/v1/tokenreview.go
@@ -20,7 +20,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=authentication.k8s.io/v1,kind=TokenReview
 type _ = authenticationv1.TokenReview
 
 // +die

--- a/apis/authentication/v1/zz_generated.die.go
+++ b/apis/authentication/v1/zz_generated.die.go
@@ -251,9 +251,6 @@ func (d *TokenReviewDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *TokenReviewDie) UnmarshalJSON(b []byte) error {
-	if d == TokenReviewBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -261,6 +258,14 @@ func (d *TokenReviewDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "authentication.k8s.io/v1" and "TokenReview" respectively.
+func (d *TokenReviewDie) DieDefaultTypeMetadata() *TokenReviewDie {
+	return d.DieStamp(func(r *authenticationv1.TokenReview) {
+		r.APIVersion = "authentication.k8s.io/v1"
+		r.Kind = "TokenReview"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -274,6 +279,29 @@ func (d *TokenReviewDie) APIVersion(v string) *TokenReviewDie {
 func (d *TokenReviewDie) Kind(v string) *TokenReviewDie {
 	return d.DieStamp(func(r *authenticationv1.TokenReview) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *TokenReviewDie) TypeMetadata(v apismetav1.TypeMeta) *TokenReviewDie {
+	return d.DieStamp(func(r *authenticationv1.TokenReview) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *TokenReviewDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *TokenReviewDie {
+	return d.DieStamp(func(r *authenticationv1.TokenReview) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *TokenReviewDie) Metadata(v apismetav1.ObjectMeta) *TokenReviewDie {
+	return d.DieStamp(func(r *authenticationv1.TokenReview) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/authorization/rbac/v1/clusterrole.go
+++ b/apis/authorization/rbac/v1/clusterrole.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=ClusterRole
 type _ = rbacv1.ClusterRole
 
 func (d *ClusterRoleDie) RulesDie(rules ...*PolicyRuleDie) *ClusterRoleDie {

--- a/apis/authorization/rbac/v1/clusterrolebinding.go
+++ b/apis/authorization/rbac/v1/clusterrolebinding.go
@@ -20,7 +20,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=ClusterRoleBinding
 type _ = rbacv1.ClusterRoleBinding
 
 func (d *ClusterRoleBindingDie) SubjectsDie(subjects ...*SubjectDie) *ClusterRoleBindingDie {

--- a/apis/authorization/rbac/v1/role.go
+++ b/apis/authorization/rbac/v1/role.go
@@ -20,7 +20,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=Role
 type _ = rbacv1.Role
 
 func (d *RoleDie) RulesDie(rules ...*PolicyRuleDie) *RoleDie {

--- a/apis/authorization/rbac/v1/rolebinding.go
+++ b/apis/authorization/rbac/v1/rolebinding.go
@@ -20,7 +20,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=RoleBinding
 type _ = rbacv1.RoleBinding
 
 func (d *RoleBindingDie) SubjectsDie(subjects ...*SubjectDie) *RoleBindingDie {

--- a/apis/authorization/rbac/v1/zz_generated.die.go
+++ b/apis/authorization/rbac/v1/zz_generated.die.go
@@ -250,9 +250,6 @@ func (d *ClusterRoleDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ClusterRoleDie) UnmarshalJSON(b []byte) error {
-	if d == ClusterRoleBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -260,6 +257,14 @@ func (d *ClusterRoleDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "rbac.authorization.k8s.io/v1" and "ClusterRole" respectively.
+func (d *ClusterRoleDie) DieDefaultTypeMetadata() *ClusterRoleDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRole) {
+		r.APIVersion = "rbac.authorization.k8s.io/v1"
+		r.Kind = "ClusterRole"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -273,6 +278,29 @@ func (d *ClusterRoleDie) APIVersion(v string) *ClusterRoleDie {
 func (d *ClusterRoleDie) Kind(v string) *ClusterRoleDie {
 	return d.DieStamp(func(r *rbacv1.ClusterRole) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ClusterRoleDie) TypeMetadata(v apismetav1.TypeMeta) *ClusterRoleDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRole) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ClusterRoleDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ClusterRoleDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRole) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ClusterRoleDie) Metadata(v apismetav1.ObjectMeta) *ClusterRoleDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRole) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -708,9 +736,6 @@ func (d *ClusterRoleBindingDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ClusterRoleBindingDie) UnmarshalJSON(b []byte) error {
-	if d == ClusterRoleBindingBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -718,6 +743,14 @@ func (d *ClusterRoleBindingDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "rbac.authorization.k8s.io/v1" and "ClusterRoleBinding" respectively.
+func (d *ClusterRoleBindingDie) DieDefaultTypeMetadata() *ClusterRoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRoleBinding) {
+		r.APIVersion = "rbac.authorization.k8s.io/v1"
+		r.Kind = "ClusterRoleBinding"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -731,6 +764,29 @@ func (d *ClusterRoleBindingDie) APIVersion(v string) *ClusterRoleBindingDie {
 func (d *ClusterRoleBindingDie) Kind(v string) *ClusterRoleBindingDie {
 	return d.DieStamp(func(r *rbacv1.ClusterRoleBinding) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ClusterRoleBindingDie) TypeMetadata(v apismetav1.TypeMeta) *ClusterRoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRoleBinding) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ClusterRoleBindingDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ClusterRoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRoleBinding) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ClusterRoleBindingDie) Metadata(v apismetav1.ObjectMeta) *ClusterRoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.ClusterRoleBinding) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -975,9 +1031,6 @@ func (d *RoleDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *RoleDie) UnmarshalJSON(b []byte) error {
-	if d == RoleBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -985,6 +1038,14 @@ func (d *RoleDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "rbac.authorization.k8s.io/v1" and "Role" respectively.
+func (d *RoleDie) DieDefaultTypeMetadata() *RoleDie {
+	return d.DieStamp(func(r *rbacv1.Role) {
+		r.APIVersion = "rbac.authorization.k8s.io/v1"
+		r.Kind = "Role"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -998,6 +1059,29 @@ func (d *RoleDie) APIVersion(v string) *RoleDie {
 func (d *RoleDie) Kind(v string) *RoleDie {
 	return d.DieStamp(func(r *rbacv1.Role) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *RoleDie) TypeMetadata(v apismetav1.TypeMeta) *RoleDie {
+	return d.DieStamp(func(r *rbacv1.Role) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *RoleDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *RoleDie {
+	return d.DieStamp(func(r *rbacv1.Role) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *RoleDie) Metadata(v apismetav1.ObjectMeta) *RoleDie {
+	return d.DieStamp(func(r *rbacv1.Role) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -1454,9 +1538,6 @@ func (d *RoleBindingDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *RoleBindingDie) UnmarshalJSON(b []byte) error {
-	if d == RoleBindingBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -1464,6 +1545,14 @@ func (d *RoleBindingDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "rbac.authorization.k8s.io/v1" and "RoleBinding" respectively.
+func (d *RoleBindingDie) DieDefaultTypeMetadata() *RoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.RoleBinding) {
+		r.APIVersion = "rbac.authorization.k8s.io/v1"
+		r.Kind = "RoleBinding"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -1477,6 +1566,29 @@ func (d *RoleBindingDie) APIVersion(v string) *RoleBindingDie {
 func (d *RoleBindingDie) Kind(v string) *RoleBindingDie {
 	return d.DieStamp(func(r *rbacv1.RoleBinding) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *RoleBindingDie) TypeMetadata(v apismetav1.TypeMeta) *RoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.RoleBinding) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *RoleBindingDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *RoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.RoleBinding) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *RoleBindingDie) Metadata(v apismetav1.ObjectMeta) *RoleBindingDie {
+	return d.DieStamp(func(r *rbacv1.RoleBinding) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/authorization/v1/localsubjectaccessreview.go
+++ b/apis/authorization/v1/localsubjectaccessreview.go
@@ -20,5 +20,5 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=authorization.k8s.io/v1,kind=LocalSubjectAccessReview
 type _ = authorizationv1.LocalSubjectAccessReview

--- a/apis/authorization/v1/selfsubjectaccessreview.go
+++ b/apis/authorization/v1/selfsubjectaccessreview.go
@@ -20,7 +20,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
-// +die:object=true,status=SubjectAccessReviewStatus
+// +die:object=true,apiVersion=authorization.k8s.io/v1,kind=SelfSubjectAccessReview,status=SubjectAccessReviewStatus
 type _ = authorizationv1.SelfSubjectAccessReview
 
 // +die

--- a/apis/authorization/v1/selfsubjectrulesreview.go
+++ b/apis/authorization/v1/selfsubjectrulesreview.go
@@ -20,7 +20,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
-// +die:object=true,status=SubjectRulesReviewStatus
+// +die:object=true,apiVersion=authorization.k8s.io/v1,kind=SelfSubjectRulesReview,status=SubjectRulesReviewStatus
 type _ = authorizationv1.SelfSubjectRulesReview
 
 // +die

--- a/apis/authorization/v1/subjectaccessreview.go
+++ b/apis/authorization/v1/subjectaccessreview.go
@@ -20,7 +20,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=authorization.k8s.io/v1,kind=SubjectAccessReview
 type _ = authorizationv1.SubjectAccessReview
 
 // TODO(scothis) fix import for maps with struct values, ignore the 'Extra' field until then

--- a/apis/authorization/v1/zz_generated.die.go
+++ b/apis/authorization/v1/zz_generated.die.go
@@ -25,6 +25,7 @@ import (
 	json "encoding/json"
 	fmtx "fmt"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -249,9 +250,6 @@ func (d *LocalSubjectAccessReviewDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *LocalSubjectAccessReviewDie) UnmarshalJSON(b []byte) error {
-	if d == LocalSubjectAccessReviewBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -259,6 +257,14 @@ func (d *LocalSubjectAccessReviewDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "authorization.k8s.io/v1" and "LocalSubjectAccessReview" respectively.
+func (d *LocalSubjectAccessReviewDie) DieDefaultTypeMetadata() *LocalSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.LocalSubjectAccessReview) {
+		r.APIVersion = "authorization.k8s.io/v1"
+		r.Kind = "LocalSubjectAccessReview"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -272,6 +278,29 @@ func (d *LocalSubjectAccessReviewDie) APIVersion(v string) *LocalSubjectAccessRe
 func (d *LocalSubjectAccessReviewDie) Kind(v string) *LocalSubjectAccessReviewDie {
 	return d.DieStamp(func(r *authorizationv1.LocalSubjectAccessReview) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *LocalSubjectAccessReviewDie) TypeMetadata(v apismetav1.TypeMeta) *LocalSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.LocalSubjectAccessReview) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *LocalSubjectAccessReviewDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *LocalSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.LocalSubjectAccessReview) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *LocalSubjectAccessReviewDie) Metadata(v apismetav1.ObjectMeta) *LocalSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.LocalSubjectAccessReview) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -514,9 +543,6 @@ func (d *SelfSubjectAccessReviewDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *SelfSubjectAccessReviewDie) UnmarshalJSON(b []byte) error {
-	if d == SelfSubjectAccessReviewBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -524,6 +550,14 @@ func (d *SelfSubjectAccessReviewDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "authorization.k8s.io/v1" and "SelfSubjectAccessReview" respectively.
+func (d *SelfSubjectAccessReviewDie) DieDefaultTypeMetadata() *SelfSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReview) {
+		r.APIVersion = "authorization.k8s.io/v1"
+		r.Kind = "SelfSubjectAccessReview"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -537,6 +571,29 @@ func (d *SelfSubjectAccessReviewDie) APIVersion(v string) *SelfSubjectAccessRevi
 func (d *SelfSubjectAccessReviewDie) Kind(v string) *SelfSubjectAccessReviewDie {
 	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReview) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *SelfSubjectAccessReviewDie) TypeMetadata(v apismetav1.TypeMeta) *SelfSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReview) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *SelfSubjectAccessReviewDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *SelfSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReview) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *SelfSubjectAccessReviewDie) Metadata(v apismetav1.ObjectMeta) *SelfSubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReview) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -991,9 +1048,6 @@ func (d *SelfSubjectRulesReviewDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *SelfSubjectRulesReviewDie) UnmarshalJSON(b []byte) error {
-	if d == SelfSubjectRulesReviewBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -1001,6 +1055,14 @@ func (d *SelfSubjectRulesReviewDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "authorization.k8s.io/v1" and "SelfSubjectRulesReview" respectively.
+func (d *SelfSubjectRulesReviewDie) DieDefaultTypeMetadata() *SelfSubjectRulesReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectRulesReview) {
+		r.APIVersion = "authorization.k8s.io/v1"
+		r.Kind = "SelfSubjectRulesReview"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -1014,6 +1076,29 @@ func (d *SelfSubjectRulesReviewDie) APIVersion(v string) *SelfSubjectRulesReview
 func (d *SelfSubjectRulesReviewDie) Kind(v string) *SelfSubjectRulesReviewDie {
 	return d.DieStamp(func(r *authorizationv1.SelfSubjectRulesReview) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *SelfSubjectRulesReviewDie) TypeMetadata(v apismetav1.TypeMeta) *SelfSubjectRulesReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectRulesReview) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *SelfSubjectRulesReviewDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *SelfSubjectRulesReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectRulesReview) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *SelfSubjectRulesReviewDie) Metadata(v apismetav1.ObjectMeta) *SelfSubjectRulesReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectRulesReview) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -2093,9 +2178,6 @@ func (d *SubjectAccessReviewDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *SubjectAccessReviewDie) UnmarshalJSON(b []byte) error {
-	if d == SubjectAccessReviewBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -2103,6 +2185,14 @@ func (d *SubjectAccessReviewDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "authorization.k8s.io/v1" and "SubjectAccessReview" respectively.
+func (d *SubjectAccessReviewDie) DieDefaultTypeMetadata() *SubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectAccessReview) {
+		r.APIVersion = "authorization.k8s.io/v1"
+		r.Kind = "SubjectAccessReview"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -2116,6 +2206,29 @@ func (d *SubjectAccessReviewDie) APIVersion(v string) *SubjectAccessReviewDie {
 func (d *SubjectAccessReviewDie) Kind(v string) *SubjectAccessReviewDie {
 	return d.DieStamp(func(r *authorizationv1.SubjectAccessReview) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *SubjectAccessReviewDie) TypeMetadata(v apismetav1.TypeMeta) *SubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectAccessReview) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *SubjectAccessReviewDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *SubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectAccessReview) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *SubjectAccessReviewDie) Metadata(v apismetav1.ObjectMeta) *SubjectAccessReviewDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectAccessReview) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/autoscaling/v1/horizontalpodautoscaler.go
+++ b/apis/autoscaling/v1/horizontalpodautoscaler.go
@@ -20,7 +20,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=autoscaling/v1,kind=HorizontalPodAutoscaler
 type _ = autoscalingv1.HorizontalPodAutoscaler
 
 // +die

--- a/apis/autoscaling/v1/zz_generated.die.go
+++ b/apis/autoscaling/v1/zz_generated.die.go
@@ -250,9 +250,6 @@ func (d *HorizontalPodAutoscalerDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *HorizontalPodAutoscalerDie) UnmarshalJSON(b []byte) error {
-	if d == HorizontalPodAutoscalerBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -260,6 +257,14 @@ func (d *HorizontalPodAutoscalerDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "autoscaling/v1" and "HorizontalPodAutoscaler" respectively.
+func (d *HorizontalPodAutoscalerDie) DieDefaultTypeMetadata() *HorizontalPodAutoscalerDie {
+	return d.DieStamp(func(r *autoscalingv1.HorizontalPodAutoscaler) {
+		r.APIVersion = "autoscaling/v1"
+		r.Kind = "HorizontalPodAutoscaler"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -273,6 +278,29 @@ func (d *HorizontalPodAutoscalerDie) APIVersion(v string) *HorizontalPodAutoscal
 func (d *HorizontalPodAutoscalerDie) Kind(v string) *HorizontalPodAutoscalerDie {
 	return d.DieStamp(func(r *autoscalingv1.HorizontalPodAutoscaler) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *HorizontalPodAutoscalerDie) TypeMetadata(v apismetav1.TypeMeta) *HorizontalPodAutoscalerDie {
+	return d.DieStamp(func(r *autoscalingv1.HorizontalPodAutoscaler) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *HorizontalPodAutoscalerDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *HorizontalPodAutoscalerDie {
+	return d.DieStamp(func(r *autoscalingv1.HorizontalPodAutoscaler) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *HorizontalPodAutoscalerDie) Metadata(v apismetav1.ObjectMeta) *HorizontalPodAutoscalerDie {
+	return d.DieStamp(func(r *autoscalingv1.HorizontalPodAutoscaler) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/batch/v1/cronjob.go
+++ b/apis/batch/v1/cronjob.go
@@ -20,7 +20,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=batch/v1,kind=CronJob
 type _ = batchv1.CronJob
 
 // +die

--- a/apis/batch/v1/job.go
+++ b/apis/batch/v1/job.go
@@ -23,7 +23,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=batch/v1,kind=Job
 type _ = batchv1.Job
 
 // +die

--- a/apis/batch/v1/zz_generated.die.go
+++ b/apis/batch/v1/zz_generated.die.go
@@ -252,9 +252,6 @@ func (d *CronJobDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *CronJobDie) UnmarshalJSON(b []byte) error {
-	if d == CronJobBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -262,6 +259,14 @@ func (d *CronJobDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "batch/v1" and "CronJob" respectively.
+func (d *CronJobDie) DieDefaultTypeMetadata() *CronJobDie {
+	return d.DieStamp(func(r *batchv1.CronJob) {
+		r.APIVersion = "batch/v1"
+		r.Kind = "CronJob"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -275,6 +280,29 @@ func (d *CronJobDie) APIVersion(v string) *CronJobDie {
 func (d *CronJobDie) Kind(v string) *CronJobDie {
 	return d.DieStamp(func(r *batchv1.CronJob) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *CronJobDie) TypeMetadata(v apismetav1.TypeMeta) *CronJobDie {
+	return d.DieStamp(func(r *batchv1.CronJob) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *CronJobDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *CronJobDie {
+	return d.DieStamp(func(r *batchv1.CronJob) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *CronJobDie) Metadata(v apismetav1.ObjectMeta) *CronJobDie {
+	return d.DieStamp(func(r *batchv1.CronJob) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -1010,9 +1038,6 @@ func (d *JobDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *JobDie) UnmarshalJSON(b []byte) error {
-	if d == JobBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -1020,6 +1045,14 @@ func (d *JobDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "batch/v1" and "Job" respectively.
+func (d *JobDie) DieDefaultTypeMetadata() *JobDie {
+	return d.DieStamp(func(r *batchv1.Job) {
+		r.APIVersion = "batch/v1"
+		r.Kind = "Job"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -1033,6 +1066,29 @@ func (d *JobDie) APIVersion(v string) *JobDie {
 func (d *JobDie) Kind(v string) *JobDie {
 	return d.DieStamp(func(r *batchv1.Job) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *JobDie) TypeMetadata(v apismetav1.TypeMeta) *JobDie {
+	return d.DieStamp(func(r *batchv1.Job) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *JobDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *JobDie {
+	return d.DieStamp(func(r *batchv1.Job) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *JobDie) Metadata(v apismetav1.ObjectMeta) *JobDie {
+	return d.DieStamp(func(r *batchv1.Job) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/certificates/v1/certificatesigningrequest.go
+++ b/apis/certificates/v1/certificatesigningrequest.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=certificates.k8s.io/v1,kind=CertificateSigningRequest
 type _ = certificatesv1.CertificateSigningRequest
 
 // TODO(scothis) fix import for maps with struct values, ignore the 'Extra' field until then

--- a/apis/certificates/v1/zz_generated.die.go
+++ b/apis/certificates/v1/zz_generated.die.go
@@ -25,6 +25,7 @@ import (
 	json "encoding/json"
 	fmtx "fmt"
 	certificatesv1 "k8s.io/api/certificates/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -249,9 +250,6 @@ func (d *CertificateSigningRequestDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *CertificateSigningRequestDie) UnmarshalJSON(b []byte) error {
-	if d == CertificateSigningRequestBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -259,6 +257,14 @@ func (d *CertificateSigningRequestDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "certificates.k8s.io/v1" and "CertificateSigningRequest" respectively.
+func (d *CertificateSigningRequestDie) DieDefaultTypeMetadata() *CertificateSigningRequestDie {
+	return d.DieStamp(func(r *certificatesv1.CertificateSigningRequest) {
+		r.APIVersion = "certificates.k8s.io/v1"
+		r.Kind = "CertificateSigningRequest"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -272,6 +278,29 @@ func (d *CertificateSigningRequestDie) APIVersion(v string) *CertificateSigningR
 func (d *CertificateSigningRequestDie) Kind(v string) *CertificateSigningRequestDie {
 	return d.DieStamp(func(r *certificatesv1.CertificateSigningRequest) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *CertificateSigningRequestDie) TypeMetadata(v apismetav1.TypeMeta) *CertificateSigningRequestDie {
+	return d.DieStamp(func(r *certificatesv1.CertificateSigningRequest) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *CertificateSigningRequestDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *CertificateSigningRequestDie {
+	return d.DieStamp(func(r *certificatesv1.CertificateSigningRequest) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *CertificateSigningRequestDie) Metadata(v apismetav1.ObjectMeta) *CertificateSigningRequestDie {
+	return d.DieStamp(func(r *certificatesv1.CertificateSigningRequest) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/coordination/v1/lease.go
+++ b/apis/coordination/v1/lease.go
@@ -20,7 +20,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=coordination.k8s.io/v1,kind=Lease
 type _ = coordinationv1.Lease
 
 // +die

--- a/apis/coordination/v1/zz_generated.die.go
+++ b/apis/coordination/v1/zz_generated.die.go
@@ -250,9 +250,6 @@ func (d *LeaseDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *LeaseDie) UnmarshalJSON(b []byte) error {
-	if d == LeaseBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -260,6 +257,14 @@ func (d *LeaseDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "coordination.k8s.io/v1" and "Lease" respectively.
+func (d *LeaseDie) DieDefaultTypeMetadata() *LeaseDie {
+	return d.DieStamp(func(r *coordinationv1.Lease) {
+		r.APIVersion = "coordination.k8s.io/v1"
+		r.Kind = "Lease"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -273,6 +278,29 @@ func (d *LeaseDie) APIVersion(v string) *LeaseDie {
 func (d *LeaseDie) Kind(v string) *LeaseDie {
 	return d.DieStamp(func(r *coordinationv1.Lease) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *LeaseDie) TypeMetadata(v apismetav1.TypeMeta) *LeaseDie {
+	return d.DieStamp(func(r *coordinationv1.Lease) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *LeaseDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *LeaseDie {
+	return d.DieStamp(func(r *coordinationv1.Lease) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *LeaseDie) Metadata(v apismetav1.ObjectMeta) *LeaseDie {
+	return d.DieStamp(func(r *coordinationv1.Lease) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/core/v1/binding.go
+++ b/apis/core/v1/binding.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=Binding
 type _ = corev1.Binding
 
 func (d *BindingDie) TargetDie(fn func(d *ObjectReferenceDie)) *BindingDie {

--- a/apis/core/v1/componentstatus.go
+++ b/apis/core/v1/componentstatus.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=ComponentStatus
 type _ = corev1.ComponentStatus
 
 func (d *ComponentStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *ComponentStatusDie {

--- a/apis/core/v1/configmap.go
+++ b/apis/core/v1/configmap.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// +die:object=true,ignore={BinaryData,Data}
+// +die:object=true,apiVersion=v1,kind=ConfigMap,ignore={BinaryData,Data}
 type _ = corev1.ConfigMap
 
 func (d *ConfigMapDie) Data(v map[string]string) *ConfigMapDie {

--- a/apis/core/v1/endpoints.go
+++ b/apis/core/v1/endpoints.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=Endpoints
 type _ = corev1.Endpoints
 
 func (d *EndpointsDie) SubsetsDie(subsets ...*EndpointSubsetDie) *EndpointsDie {

--- a/apis/core/v1/event.go
+++ b/apis/core/v1/event.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=Event
 type _ = corev1.Event
 
 func (d *EventDie) InvolvedObjectDie(fn func(d *ObjectReferenceDie)) *EventDie {

--- a/apis/core/v1/limitrange.go
+++ b/apis/core/v1/limitrange.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=LimitRange
 type _ = corev1.LimitRange
 
 // +die

--- a/apis/core/v1/namespace.go
+++ b/apis/core/v1/namespace.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=Namespace
 type _ = corev1.Namespace
 
 // +die

--- a/apis/core/v1/node.go
+++ b/apis/core/v1/node.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=Node
 type _ = corev1.Node
 
 // +die

--- a/apis/core/v1/persistantvolume.go
+++ b/apis/core/v1/persistantvolume.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=PersistentVolume
 type _ = corev1.PersistentVolume
 
 // +die

--- a/apis/core/v1/persistantvolumeclaim.go
+++ b/apis/core/v1/persistantvolumeclaim.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=PersistentVolumeClaim
 type _ = corev1.PersistentVolumeClaim
 
 // +die

--- a/apis/core/v1/pod.go
+++ b/apis/core/v1/pod.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=Pod
 type _ = corev1.Pod
 
 // +die

--- a/apis/core/v1/replicationcontroller.go
+++ b/apis/core/v1/replicationcontroller.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=ReplicationController
 type _ = corev1.ReplicationController
 
 // +die

--- a/apis/core/v1/resourcequota.go
+++ b/apis/core/v1/resourcequota.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=ResourceQuota
 type _ = corev1.ResourceQuota
 
 // +die

--- a/apis/core/v1/secret.go
+++ b/apis/core/v1/secret.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// +die:object=true,ignore={Data,StringData}
+// +die:object=true,apiVersion=v1,kind=Secret,ignore={Data,StringData}
 type Secret = corev1.Secret
 
 func (d *SecretDie) Data(v map[string][]byte) *SecretDie {

--- a/apis/core/v1/service.go
+++ b/apis/core/v1/service.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=Service
 type _ = corev1.Service
 
 // +die

--- a/apis/core/v1/serviceaccount.go
+++ b/apis/core/v1/serviceaccount.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=v1,kind=ServiceAccount
 type _ = corev1.ServiceAccount
 
 func (d *ServiceAccountDie) SecretsDie(secrets ...*ObjectReferenceDie) *ServiceAccountDie {

--- a/apis/core/v1/zz_generated.die.go
+++ b/apis/core/v1/zz_generated.die.go
@@ -253,9 +253,6 @@ func (d *BindingDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *BindingDie) UnmarshalJSON(b []byte) error {
-	if d == BindingBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -263,6 +260,14 @@ func (d *BindingDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Binding" respectively.
+func (d *BindingDie) DieDefaultTypeMetadata() *BindingDie {
+	return d.DieStamp(func(r *corev1.Binding) {
+		r.APIVersion = "v1"
+		r.Kind = "Binding"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -276,6 +281,29 @@ func (d *BindingDie) APIVersion(v string) *BindingDie {
 func (d *BindingDie) Kind(v string) *BindingDie {
 	return d.DieStamp(func(r *corev1.Binding) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *BindingDie) TypeMetadata(v apismetav1.TypeMeta) *BindingDie {
+	return d.DieStamp(func(r *corev1.Binding) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *BindingDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *BindingDie {
+	return d.DieStamp(func(r *corev1.Binding) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *BindingDie) Metadata(v apismetav1.ObjectMeta) *BindingDie {
+	return d.DieStamp(func(r *corev1.Binding) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -1965,9 +1993,6 @@ func (d *ComponentStatusDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ComponentStatusDie) UnmarshalJSON(b []byte) error {
-	if d == ComponentStatusBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -1975,6 +2000,14 @@ func (d *ComponentStatusDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "ComponentStatus" respectively.
+func (d *ComponentStatusDie) DieDefaultTypeMetadata() *ComponentStatusDie {
+	return d.DieStamp(func(r *corev1.ComponentStatus) {
+		r.APIVersion = "v1"
+		r.Kind = "ComponentStatus"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -1988,6 +2021,29 @@ func (d *ComponentStatusDie) APIVersion(v string) *ComponentStatusDie {
 func (d *ComponentStatusDie) Kind(v string) *ComponentStatusDie {
 	return d.DieStamp(func(r *corev1.ComponentStatus) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ComponentStatusDie) TypeMetadata(v apismetav1.TypeMeta) *ComponentStatusDie {
+	return d.DieStamp(func(r *corev1.ComponentStatus) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ComponentStatusDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ComponentStatusDie {
+	return d.DieStamp(func(r *corev1.ComponentStatus) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ComponentStatusDie) Metadata(v apismetav1.ObjectMeta) *ComponentStatusDie {
+	return d.DieStamp(func(r *corev1.ComponentStatus) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -2221,9 +2277,6 @@ func (d *ConfigMapDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ConfigMapDie) UnmarshalJSON(b []byte) error {
-	if d == ConfigMapBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -2231,6 +2284,14 @@ func (d *ConfigMapDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "ConfigMap" respectively.
+func (d *ConfigMapDie) DieDefaultTypeMetadata() *ConfigMapDie {
+	return d.DieStamp(func(r *corev1.ConfigMap) {
+		r.APIVersion = "v1"
+		r.Kind = "ConfigMap"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -2244,6 +2305,29 @@ func (d *ConfigMapDie) APIVersion(v string) *ConfigMapDie {
 func (d *ConfigMapDie) Kind(v string) *ConfigMapDie {
 	return d.DieStamp(func(r *corev1.ConfigMap) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ConfigMapDie) TypeMetadata(v apismetav1.TypeMeta) *ConfigMapDie {
+	return d.DieStamp(func(r *corev1.ConfigMap) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ConfigMapDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ConfigMapDie {
+	return d.DieStamp(func(r *corev1.ConfigMap) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ConfigMapDie) Metadata(v apismetav1.ObjectMeta) *ConfigMapDie {
+	return d.DieStamp(func(r *corev1.ConfigMap) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -11061,9 +11145,6 @@ func (d *EndpointsDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *EndpointsDie) UnmarshalJSON(b []byte) error {
-	if d == EndpointsBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -11071,6 +11152,14 @@ func (d *EndpointsDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Endpoints" respectively.
+func (d *EndpointsDie) DieDefaultTypeMetadata() *EndpointsDie {
+	return d.DieStamp(func(r *corev1.Endpoints) {
+		r.APIVersion = "v1"
+		r.Kind = "Endpoints"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -11084,6 +11173,29 @@ func (d *EndpointsDie) APIVersion(v string) *EndpointsDie {
 func (d *EndpointsDie) Kind(v string) *EndpointsDie {
 	return d.DieStamp(func(r *corev1.Endpoints) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *EndpointsDie) TypeMetadata(v apismetav1.TypeMeta) *EndpointsDie {
+	return d.DieStamp(func(r *corev1.Endpoints) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *EndpointsDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *EndpointsDie {
+	return d.DieStamp(func(r *corev1.Endpoints) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *EndpointsDie) Metadata(v apismetav1.ObjectMeta) *EndpointsDie {
+	return d.DieStamp(func(r *corev1.Endpoints) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -11994,9 +12106,6 @@ func (d *EventDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *EventDie) UnmarshalJSON(b []byte) error {
-	if d == EventBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -12004,6 +12113,14 @@ func (d *EventDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Event" respectively.
+func (d *EventDie) DieDefaultTypeMetadata() *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		r.APIVersion = "v1"
+		r.Kind = "Event"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -12017,6 +12134,29 @@ func (d *EventDie) APIVersion(v string) *EventDie {
 func (d *EventDie) Kind(v string) *EventDie {
 	return d.DieStamp(func(r *corev1.Event) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *EventDie) TypeMetadata(v apismetav1.TypeMeta) *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *EventDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *EventDie) Metadata(v apismetav1.ObjectMeta) *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -12739,9 +12879,6 @@ func (d *LimitRangeDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *LimitRangeDie) UnmarshalJSON(b []byte) error {
-	if d == LimitRangeBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -12749,6 +12886,14 @@ func (d *LimitRangeDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "LimitRange" respectively.
+func (d *LimitRangeDie) DieDefaultTypeMetadata() *LimitRangeDie {
+	return d.DieStamp(func(r *corev1.LimitRange) {
+		r.APIVersion = "v1"
+		r.Kind = "LimitRange"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -12762,6 +12907,29 @@ func (d *LimitRangeDie) APIVersion(v string) *LimitRangeDie {
 func (d *LimitRangeDie) Kind(v string) *LimitRangeDie {
 	return d.DieStamp(func(r *corev1.LimitRange) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *LimitRangeDie) TypeMetadata(v apismetav1.TypeMeta) *LimitRangeDie {
+	return d.DieStamp(func(r *corev1.LimitRange) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *LimitRangeDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *LimitRangeDie {
+	return d.DieStamp(func(r *corev1.LimitRange) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *LimitRangeDie) Metadata(v apismetav1.ObjectMeta) *LimitRangeDie {
+	return d.DieStamp(func(r *corev1.LimitRange) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -13419,9 +13587,6 @@ func (d *NamespaceDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *NamespaceDie) UnmarshalJSON(b []byte) error {
-	if d == NamespaceBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -13429,6 +13594,14 @@ func (d *NamespaceDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Namespace" respectively.
+func (d *NamespaceDie) DieDefaultTypeMetadata() *NamespaceDie {
+	return d.DieStamp(func(r *corev1.Namespace) {
+		r.APIVersion = "v1"
+		r.Kind = "Namespace"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -13442,6 +13615,29 @@ func (d *NamespaceDie) APIVersion(v string) *NamespaceDie {
 func (d *NamespaceDie) Kind(v string) *NamespaceDie {
 	return d.DieStamp(func(r *corev1.Namespace) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *NamespaceDie) TypeMetadata(v apismetav1.TypeMeta) *NamespaceDie {
+	return d.DieStamp(func(r *corev1.Namespace) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *NamespaceDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *NamespaceDie {
+	return d.DieStamp(func(r *corev1.Namespace) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *NamespaceDie) Metadata(v apismetav1.ObjectMeta) *NamespaceDie {
+	return d.DieStamp(func(r *corev1.Namespace) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -14093,9 +14289,6 @@ func (d *NodeDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *NodeDie) UnmarshalJSON(b []byte) error {
-	if d == NodeBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -14103,6 +14296,14 @@ func (d *NodeDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Node" respectively.
+func (d *NodeDie) DieDefaultTypeMetadata() *NodeDie {
+	return d.DieStamp(func(r *corev1.Node) {
+		r.APIVersion = "v1"
+		r.Kind = "Node"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -14116,6 +14317,29 @@ func (d *NodeDie) APIVersion(v string) *NodeDie {
 func (d *NodeDie) Kind(v string) *NodeDie {
 	return d.DieStamp(func(r *corev1.Node) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *NodeDie) TypeMetadata(v apismetav1.TypeMeta) *NodeDie {
+	return d.DieStamp(func(r *corev1.Node) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *NodeDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *NodeDie {
+	return d.DieStamp(func(r *corev1.Node) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *NodeDie) Metadata(v apismetav1.ObjectMeta) *NodeDie {
+	return d.DieStamp(func(r *corev1.Node) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -17436,9 +17660,6 @@ func (d *PersistentVolumeDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *PersistentVolumeDie) UnmarshalJSON(b []byte) error {
-	if d == PersistentVolumeBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -17446,6 +17667,14 @@ func (d *PersistentVolumeDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "PersistentVolume" respectively.
+func (d *PersistentVolumeDie) DieDefaultTypeMetadata() *PersistentVolumeDie {
+	return d.DieStamp(func(r *corev1.PersistentVolume) {
+		r.APIVersion = "v1"
+		r.Kind = "PersistentVolume"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -17459,6 +17688,29 @@ func (d *PersistentVolumeDie) APIVersion(v string) *PersistentVolumeDie {
 func (d *PersistentVolumeDie) Kind(v string) *PersistentVolumeDie {
 	return d.DieStamp(func(r *corev1.PersistentVolume) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *PersistentVolumeDie) TypeMetadata(v apismetav1.TypeMeta) *PersistentVolumeDie {
+	return d.DieStamp(func(r *corev1.PersistentVolume) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *PersistentVolumeDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *PersistentVolumeDie {
+	return d.DieStamp(func(r *corev1.PersistentVolume) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *PersistentVolumeDie) Metadata(v apismetav1.ObjectMeta) *PersistentVolumeDie {
+	return d.DieStamp(func(r *corev1.PersistentVolume) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -21711,9 +21963,6 @@ func (d *PersistentVolumeClaimDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *PersistentVolumeClaimDie) UnmarshalJSON(b []byte) error {
-	if d == PersistentVolumeClaimBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -21721,6 +21970,14 @@ func (d *PersistentVolumeClaimDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "PersistentVolumeClaim" respectively.
+func (d *PersistentVolumeClaimDie) DieDefaultTypeMetadata() *PersistentVolumeClaimDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaim) {
+		r.APIVersion = "v1"
+		r.Kind = "PersistentVolumeClaim"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -21734,6 +21991,29 @@ func (d *PersistentVolumeClaimDie) APIVersion(v string) *PersistentVolumeClaimDi
 func (d *PersistentVolumeClaimDie) Kind(v string) *PersistentVolumeClaimDie {
 	return d.DieStamp(func(r *corev1.PersistentVolumeClaim) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *PersistentVolumeClaimDie) TypeMetadata(v apismetav1.TypeMeta) *PersistentVolumeClaimDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaim) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *PersistentVolumeClaimDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *PersistentVolumeClaimDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaim) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *PersistentVolumeClaimDie) Metadata(v apismetav1.ObjectMeta) *PersistentVolumeClaimDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaim) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -23240,9 +23520,6 @@ func (d *PodDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *PodDie) UnmarshalJSON(b []byte) error {
-	if d == PodBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -23250,6 +23527,14 @@ func (d *PodDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Pod" respectively.
+func (d *PodDie) DieDefaultTypeMetadata() *PodDie {
+	return d.DieStamp(func(r *corev1.Pod) {
+		r.APIVersion = "v1"
+		r.Kind = "Pod"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -23263,6 +23548,29 @@ func (d *PodDie) APIVersion(v string) *PodDie {
 func (d *PodDie) Kind(v string) *PodDie {
 	return d.DieStamp(func(r *corev1.Pod) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *PodDie) TypeMetadata(v apismetav1.TypeMeta) *PodDie {
+	return d.DieStamp(func(r *corev1.Pod) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *PodDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *PodDie {
+	return d.DieStamp(func(r *corev1.Pod) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *PodDie) Metadata(v apismetav1.ObjectMeta) *PodDie {
+	return d.DieStamp(func(r *corev1.Pod) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -27407,9 +27715,6 @@ func (d *PodTemplateDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *PodTemplateDie) UnmarshalJSON(b []byte) error {
-	if d == PodTemplateBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -27430,6 +27735,29 @@ func (d *PodTemplateDie) APIVersion(v string) *PodTemplateDie {
 func (d *PodTemplateDie) Kind(v string) *PodTemplateDie {
 	return d.DieStamp(func(r *corev1.PodTemplate) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *PodTemplateDie) TypeMetadata(v apismetav1.TypeMeta) *PodTemplateDie {
+	return d.DieStamp(func(r *corev1.PodTemplate) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *PodTemplateDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *PodTemplateDie {
+	return d.DieStamp(func(r *corev1.PodTemplate) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *PodTemplateDie) Metadata(v apismetav1.ObjectMeta) *PodTemplateDie {
+	return d.DieStamp(func(r *corev1.PodTemplate) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -27865,9 +28193,6 @@ func (d *ReplicationControllerDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ReplicationControllerDie) UnmarshalJSON(b []byte) error {
-	if d == ReplicationControllerBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -27875,6 +28200,14 @@ func (d *ReplicationControllerDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "ReplicationController" respectively.
+func (d *ReplicationControllerDie) DieDefaultTypeMetadata() *ReplicationControllerDie {
+	return d.DieStamp(func(r *corev1.ReplicationController) {
+		r.APIVersion = "v1"
+		r.Kind = "ReplicationController"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -27888,6 +28221,29 @@ func (d *ReplicationControllerDie) APIVersion(v string) *ReplicationControllerDi
 func (d *ReplicationControllerDie) Kind(v string) *ReplicationControllerDie {
 	return d.DieStamp(func(r *corev1.ReplicationController) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ReplicationControllerDie) TypeMetadata(v apismetav1.TypeMeta) *ReplicationControllerDie {
+	return d.DieStamp(func(r *corev1.ReplicationController) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ReplicationControllerDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ReplicationControllerDie {
+	return d.DieStamp(func(r *corev1.ReplicationController) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ReplicationControllerDie) Metadata(v apismetav1.ObjectMeta) *ReplicationControllerDie {
+	return d.DieStamp(func(r *corev1.ReplicationController) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -28616,9 +28972,6 @@ func (d *ResourceQuotaDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ResourceQuotaDie) UnmarshalJSON(b []byte) error {
-	if d == ResourceQuotaBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -28626,6 +28979,14 @@ func (d *ResourceQuotaDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "ResourceQuota" respectively.
+func (d *ResourceQuotaDie) DieDefaultTypeMetadata() *ResourceQuotaDie {
+	return d.DieStamp(func(r *corev1.ResourceQuota) {
+		r.APIVersion = "v1"
+		r.Kind = "ResourceQuota"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -28639,6 +29000,29 @@ func (d *ResourceQuotaDie) APIVersion(v string) *ResourceQuotaDie {
 func (d *ResourceQuotaDie) Kind(v string) *ResourceQuotaDie {
 	return d.DieStamp(func(r *corev1.ResourceQuota) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ResourceQuotaDie) TypeMetadata(v apismetav1.TypeMeta) *ResourceQuotaDie {
+	return d.DieStamp(func(r *corev1.ResourceQuota) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ResourceQuotaDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ResourceQuotaDie {
+	return d.DieStamp(func(r *corev1.ResourceQuota) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ResourceQuotaDie) Metadata(v apismetav1.ObjectMeta) *ResourceQuotaDie {
+	return d.DieStamp(func(r *corev1.ResourceQuota) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -29710,9 +30094,6 @@ func (d *SecretDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *SecretDie) UnmarshalJSON(b []byte) error {
-	if d == SecretBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -29720,6 +30101,14 @@ func (d *SecretDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Secret" respectively.
+func (d *SecretDie) DieDefaultTypeMetadata() *SecretDie {
+	return d.DieStamp(func(r *corev1.Secret) {
+		r.APIVersion = "v1"
+		r.Kind = "Secret"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -29733,6 +30122,29 @@ func (d *SecretDie) APIVersion(v string) *SecretDie {
 func (d *SecretDie) Kind(v string) *SecretDie {
 	return d.DieStamp(func(r *corev1.Secret) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *SecretDie) TypeMetadata(v apismetav1.TypeMeta) *SecretDie {
+	return d.DieStamp(func(r *corev1.Secret) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *SecretDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *SecretDie {
+	return d.DieStamp(func(r *corev1.Secret) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *SecretDie) Metadata(v apismetav1.ObjectMeta) *SecretDie {
+	return d.DieStamp(func(r *corev1.Secret) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -29981,9 +30393,6 @@ func (d *ServiceDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ServiceDie) UnmarshalJSON(b []byte) error {
-	if d == ServiceBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -29991,6 +30400,14 @@ func (d *ServiceDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "Service" respectively.
+func (d *ServiceDie) DieDefaultTypeMetadata() *ServiceDie {
+	return d.DieStamp(func(r *corev1.Service) {
+		r.APIVersion = "v1"
+		r.Kind = "Service"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -30004,6 +30421,29 @@ func (d *ServiceDie) APIVersion(v string) *ServiceDie {
 func (d *ServiceDie) Kind(v string) *ServiceDie {
 	return d.DieStamp(func(r *corev1.Service) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ServiceDie) TypeMetadata(v apismetav1.TypeMeta) *ServiceDie {
+	return d.DieStamp(func(r *corev1.Service) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ServiceDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ServiceDie {
+	return d.DieStamp(func(r *corev1.Service) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ServiceDie) Metadata(v apismetav1.ObjectMeta) *ServiceDie {
+	return d.DieStamp(func(r *corev1.Service) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -32408,9 +32848,6 @@ func (d *ServiceAccountDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *ServiceAccountDie) UnmarshalJSON(b []byte) error {
-	if d == ServiceAccountBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -32418,6 +32855,14 @@ func (d *ServiceAccountDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "v1" and "ServiceAccount" respectively.
+func (d *ServiceAccountDie) DieDefaultTypeMetadata() *ServiceAccountDie {
+	return d.DieStamp(func(r *corev1.ServiceAccount) {
+		r.APIVersion = "v1"
+		r.Kind = "ServiceAccount"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -32431,6 +32876,29 @@ func (d *ServiceAccountDie) APIVersion(v string) *ServiceAccountDie {
 func (d *ServiceAccountDie) Kind(v string) *ServiceAccountDie {
 	return d.DieStamp(func(r *corev1.ServiceAccount) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *ServiceAccountDie) TypeMetadata(v apismetav1.TypeMeta) *ServiceAccountDie {
+	return d.DieStamp(func(r *corev1.ServiceAccount) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *ServiceAccountDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *ServiceAccountDie {
+	return d.DieStamp(func(r *corev1.ServiceAccount) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *ServiceAccountDie) Metadata(v apismetav1.ObjectMeta) *ServiceAccountDie {
+	return d.DieStamp(func(r *corev1.ServiceAccount) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/discovery/v1/endpointslice.go
+++ b/apis/discovery/v1/endpointslice.go
@@ -21,7 +21,7 @@ import (
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=discovery.k8s.io/v1,kind=EndpointSlice
 type _ = discoveryv1.EndpointSlice
 
 func (d *EndpointSliceDie) EndpointsDie(endpoints ...*EndpointDie) *EndpointSliceDie {

--- a/apis/events/v1/event.go
+++ b/apis/events/v1/event.go
@@ -21,7 +21,7 @@ import (
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=events.k8s.io/v1,kind=Event
 type _ = eventsv1.Event
 
 func (d *EventDie) SeriesDie(fn func(d *EventSeriesDie)) *EventDie {

--- a/apis/meta/v1/typemeta.go
+++ b/apis/meta/v1/typemeta.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var TypeMetaBlank = (&TypeMetaDie{}).DieFeed(metav1.TypeMeta{})
@@ -123,5 +124,29 @@ func (d *TypeMetaDie) Kind(v string) *TypeMetaDie {
 func (d *TypeMetaDie) APIVersion(v string) *TypeMetaDie {
 	return d.DieStamp(func(r *metav1.TypeMeta) {
 		r.APIVersion = v
+	})
+}
+
+// Group defines the group component of the API version.
+func (d *TypeMetaDie) Group(v string) *TypeMetaDie {
+	return d.DieStamp(func(r *metav1.TypeMeta) {
+		gv, err := schema.ParseGroupVersion(r.APIVersion)
+		if err != nil {
+			panic(err)
+		}
+		gv.Group = v
+		r.APIVersion = gv.String()
+	})
+}
+
+// Version defines the version component of the API version.
+func (d *TypeMetaDie) Version(v string) *TypeMetaDie {
+	return d.DieStamp(func(r *metav1.TypeMeta) {
+		gv, err := schema.ParseGroupVersion(r.APIVersion)
+		if err != nil {
+			panic(err)
+		}
+		gv.Version = v
+		r.APIVersion = gv.String()
 	})
 }

--- a/apis/networking/v1/ingress.go
+++ b/apis/networking/v1/ingress.go
@@ -21,7 +21,7 @@ import (
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=networking.k8s.io/v1,kind=Ingress
 type _ = networkingv1.Ingress
 
 // +die

--- a/apis/networking/v1/ingressclass.go
+++ b/apis/networking/v1/ingressclass.go
@@ -20,7 +20,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=networking.k8s.io/v1,kind=IngressClass
 type _ = networkingv1.IngressClass
 
 // +die

--- a/apis/networking/v1/networkpolicy.go
+++ b/apis/networking/v1/networkpolicy.go
@@ -21,7 +21,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=networking.k8s.io/v1,kind=NetworkPolicy
 type _ = networkingv1.NetworkPolicy
 
 // +die

--- a/apis/networking/v1/zz_generated.die.go
+++ b/apis/networking/v1/zz_generated.die.go
@@ -252,9 +252,6 @@ func (d *IngressDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *IngressDie) UnmarshalJSON(b []byte) error {
-	if d == IngressBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -262,6 +259,14 @@ func (d *IngressDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "networking.k8s.io/v1" and "Ingress" respectively.
+func (d *IngressDie) DieDefaultTypeMetadata() *IngressDie {
+	return d.DieStamp(func(r *networkingv1.Ingress) {
+		r.APIVersion = "networking.k8s.io/v1"
+		r.Kind = "Ingress"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -275,6 +280,29 @@ func (d *IngressDie) APIVersion(v string) *IngressDie {
 func (d *IngressDie) Kind(v string) *IngressDie {
 	return d.DieStamp(func(r *networkingv1.Ingress) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *IngressDie) TypeMetadata(v apismetav1.TypeMeta) *IngressDie {
+	return d.DieStamp(func(r *networkingv1.Ingress) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *IngressDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *IngressDie {
+	return d.DieStamp(func(r *networkingv1.Ingress) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *IngressDie) Metadata(v apismetav1.ObjectMeta) *IngressDie {
+	return d.DieStamp(func(r *networkingv1.Ingress) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -3065,9 +3093,6 @@ func (d *IngressClassDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *IngressClassDie) UnmarshalJSON(b []byte) error {
-	if d == IngressClassBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -3075,6 +3100,14 @@ func (d *IngressClassDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "networking.k8s.io/v1" and "IngressClass" respectively.
+func (d *IngressClassDie) DieDefaultTypeMetadata() *IngressClassDie {
+	return d.DieStamp(func(r *networkingv1.IngressClass) {
+		r.APIVersion = "networking.k8s.io/v1"
+		r.Kind = "IngressClass"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -3088,6 +3121,29 @@ func (d *IngressClassDie) APIVersion(v string) *IngressClassDie {
 func (d *IngressClassDie) Kind(v string) *IngressClassDie {
 	return d.DieStamp(func(r *networkingv1.IngressClass) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *IngressClassDie) TypeMetadata(v apismetav1.TypeMeta) *IngressClassDie {
+	return d.DieStamp(func(r *networkingv1.IngressClass) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *IngressClassDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *IngressClassDie {
+	return d.DieStamp(func(r *networkingv1.IngressClass) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *IngressClassDie) Metadata(v apismetav1.ObjectMeta) *IngressClassDie {
+	return d.DieStamp(func(r *networkingv1.IngressClass) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -3769,9 +3825,6 @@ func (d *NetworkPolicyDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *NetworkPolicyDie) UnmarshalJSON(b []byte) error {
-	if d == NetworkPolicyBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -3779,6 +3832,14 @@ func (d *NetworkPolicyDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "networking.k8s.io/v1" and "NetworkPolicy" respectively.
+func (d *NetworkPolicyDie) DieDefaultTypeMetadata() *NetworkPolicyDie {
+	return d.DieStamp(func(r *networkingv1.NetworkPolicy) {
+		r.APIVersion = "networking.k8s.io/v1"
+		r.Kind = "NetworkPolicy"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -3792,6 +3853,29 @@ func (d *NetworkPolicyDie) APIVersion(v string) *NetworkPolicyDie {
 func (d *NetworkPolicyDie) Kind(v string) *NetworkPolicyDie {
 	return d.DieStamp(func(r *networkingv1.NetworkPolicy) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *NetworkPolicyDie) TypeMetadata(v apismetav1.TypeMeta) *NetworkPolicyDie {
+	return d.DieStamp(func(r *networkingv1.NetworkPolicy) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *NetworkPolicyDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *NetworkPolicyDie {
+	return d.DieStamp(func(r *networkingv1.NetworkPolicy) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *NetworkPolicyDie) Metadata(v apismetav1.ObjectMeta) *NetworkPolicyDie {
+	return d.DieStamp(func(r *networkingv1.NetworkPolicy) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/node/v1/runtimeclass.go
+++ b/apis/node/v1/runtimeclass.go
@@ -23,7 +23,7 @@ import (
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=node.k8s.io/v1,kind=RuntimeClass
 type _ = nodev1.RuntimeClass
 
 // +die

--- a/apis/policy/v1/poddisruptionbudget.go
+++ b/apis/policy/v1/poddisruptionbudget.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=policy/v1,kind=PodDisruptionBudget
 type _ = policyv1.PodDisruptionBudget
 
 // +die

--- a/apis/policy/v1/zz_generated.die.go
+++ b/apis/policy/v1/zz_generated.die.go
@@ -251,9 +251,6 @@ func (d *PodDisruptionBudgetDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *PodDisruptionBudgetDie) UnmarshalJSON(b []byte) error {
-	if d == PodDisruptionBudgetBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -261,6 +258,14 @@ func (d *PodDisruptionBudgetDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "policy/v1" and "PodDisruptionBudget" respectively.
+func (d *PodDisruptionBudgetDie) DieDefaultTypeMetadata() *PodDisruptionBudgetDie {
+	return d.DieStamp(func(r *policyv1.PodDisruptionBudget) {
+		r.APIVersion = "policy/v1"
+		r.Kind = "PodDisruptionBudget"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -274,6 +279,29 @@ func (d *PodDisruptionBudgetDie) APIVersion(v string) *PodDisruptionBudgetDie {
 func (d *PodDisruptionBudgetDie) Kind(v string) *PodDisruptionBudgetDie {
 	return d.DieStamp(func(r *policyv1.PodDisruptionBudget) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *PodDisruptionBudgetDie) TypeMetadata(v apismetav1.TypeMeta) *PodDisruptionBudgetDie {
+	return d.DieStamp(func(r *policyv1.PodDisruptionBudget) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *PodDisruptionBudgetDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *PodDisruptionBudgetDie {
+	return d.DieStamp(func(r *policyv1.PodDisruptionBudget) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *PodDisruptionBudgetDie) Metadata(v apismetav1.ObjectMeta) *PodDisruptionBudgetDie {
+	return d.DieStamp(func(r *policyv1.PodDisruptionBudget) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/scheduling/v1/priorityclass.go
+++ b/apis/scheduling/v1/priorityclass.go
@@ -20,5 +20,5 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=scheduling.k8s.io/v1,kind=PriorityClass
 type _ = schedulingv1.PriorityClass

--- a/apis/scheduling/v1/zz_generated.die.go
+++ b/apis/scheduling/v1/zz_generated.die.go
@@ -26,6 +26,7 @@ import (
 	fmtx "fmt"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -250,9 +251,6 @@ func (d *PriorityClassDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *PriorityClassDie) UnmarshalJSON(b []byte) error {
-	if d == PriorityClassBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -260,6 +258,14 @@ func (d *PriorityClassDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "scheduling.k8s.io/v1" and "PriorityClass" respectively.
+func (d *PriorityClassDie) DieDefaultTypeMetadata() *PriorityClassDie {
+	return d.DieStamp(func(r *schedulingv1.PriorityClass) {
+		r.APIVersion = "scheduling.k8s.io/v1"
+		r.Kind = "PriorityClass"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -273,6 +279,29 @@ func (d *PriorityClassDie) APIVersion(v string) *PriorityClassDie {
 func (d *PriorityClassDie) Kind(v string) *PriorityClassDie {
 	return d.DieStamp(func(r *schedulingv1.PriorityClass) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *PriorityClassDie) TypeMetadata(v apismetav1.TypeMeta) *PriorityClassDie {
+	return d.DieStamp(func(r *schedulingv1.PriorityClass) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *PriorityClassDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *PriorityClassDie {
+	return d.DieStamp(func(r *schedulingv1.PriorityClass) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *PriorityClassDie) Metadata(v apismetav1.ObjectMeta) *PriorityClassDie {
+	return d.DieStamp(func(r *schedulingv1.PriorityClass) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/storage/v1/csidriver.go
+++ b/apis/storage/v1/csidriver.go
@@ -20,7 +20,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=storage.k8s.io/v1,kind=CSIDriver
 type _ = storagev1.CSIDriver
 
 // +die

--- a/apis/storage/v1/csinode.go
+++ b/apis/storage/v1/csinode.go
@@ -20,7 +20,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=storage.k8s.io/v1,kind=CSINode
 type _ = storagev1.CSINode
 
 // +die

--- a/apis/storage/v1/storageclass.go
+++ b/apis/storage/v1/storageclass.go
@@ -22,7 +22,7 @@ import (
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=storage.k8s.io/v1,kind=StorageClass
 type _ = storagev1.StorageClass
 
 func (d *StorageClassDie) AddParameter(key, value string) *StorageClassDie {

--- a/apis/storage/v1/volumeattachment.go
+++ b/apis/storage/v1/volumeattachment.go
@@ -21,7 +21,7 @@ import (
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=storage.k8s.io/v1,kind=VolumeAttachment
 type _ = storagev1.VolumeAttachment
 
 // +die

--- a/apis/storage/v1/zz_generated.die.go
+++ b/apis/storage/v1/zz_generated.die.go
@@ -251,9 +251,6 @@ func (d *CSIDriverDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *CSIDriverDie) UnmarshalJSON(b []byte) error {
-	if d == CSIDriverBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -261,6 +258,14 @@ func (d *CSIDriverDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "storage.k8s.io/v1" and "CSIDriver" respectively.
+func (d *CSIDriverDie) DieDefaultTypeMetadata() *CSIDriverDie {
+	return d.DieStamp(func(r *storagev1.CSIDriver) {
+		r.APIVersion = "storage.k8s.io/v1"
+		r.Kind = "CSIDriver"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -274,6 +279,29 @@ func (d *CSIDriverDie) APIVersion(v string) *CSIDriverDie {
 func (d *CSIDriverDie) Kind(v string) *CSIDriverDie {
 	return d.DieStamp(func(r *storagev1.CSIDriver) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *CSIDriverDie) TypeMetadata(v apismetav1.TypeMeta) *CSIDriverDie {
+	return d.DieStamp(func(r *storagev1.CSIDriver) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *CSIDriverDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *CSIDriverDie {
+	return d.DieStamp(func(r *storagev1.CSIDriver) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *CSIDriverDie) Metadata(v apismetav1.ObjectMeta) *CSIDriverDie {
+	return d.DieStamp(func(r *storagev1.CSIDriver) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -1130,9 +1158,6 @@ func (d *CSINodeDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *CSINodeDie) UnmarshalJSON(b []byte) error {
-	if d == CSINodeBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -1140,6 +1165,14 @@ func (d *CSINodeDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "storage.k8s.io/v1" and "CSINode" respectively.
+func (d *CSINodeDie) DieDefaultTypeMetadata() *CSINodeDie {
+	return d.DieStamp(func(r *storagev1.CSINode) {
+		r.APIVersion = "storage.k8s.io/v1"
+		r.Kind = "CSINode"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -1153,6 +1186,29 @@ func (d *CSINodeDie) APIVersion(v string) *CSINodeDie {
 func (d *CSINodeDie) Kind(v string) *CSINodeDie {
 	return d.DieStamp(func(r *storagev1.CSINode) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *CSINodeDie) TypeMetadata(v apismetav1.TypeMeta) *CSINodeDie {
+	return d.DieStamp(func(r *storagev1.CSINode) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *CSINodeDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *CSINodeDie {
+	return d.DieStamp(func(r *storagev1.CSINode) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *CSINodeDie) Metadata(v apismetav1.ObjectMeta) *CSINodeDie {
+	return d.DieStamp(func(r *storagev1.CSINode) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -2031,9 +2087,6 @@ func (d *StorageClassDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *StorageClassDie) UnmarshalJSON(b []byte) error {
-	if d == StorageClassBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -2041,6 +2094,14 @@ func (d *StorageClassDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "storage.k8s.io/v1" and "StorageClass" respectively.
+func (d *StorageClassDie) DieDefaultTypeMetadata() *StorageClassDie {
+	return d.DieStamp(func(r *storagev1.StorageClass) {
+		r.APIVersion = "storage.k8s.io/v1"
+		r.Kind = "StorageClass"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -2054,6 +2115,29 @@ func (d *StorageClassDie) APIVersion(v string) *StorageClassDie {
 func (d *StorageClassDie) Kind(v string) *StorageClassDie {
 	return d.DieStamp(func(r *storagev1.StorageClass) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *StorageClassDie) TypeMetadata(v apismetav1.TypeMeta) *StorageClassDie {
+	return d.DieStamp(func(r *storagev1.StorageClass) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *StorageClassDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *StorageClassDie {
+	return d.DieStamp(func(r *storagev1.StorageClass) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *StorageClassDie) Metadata(v apismetav1.ObjectMeta) *StorageClassDie {
+	return d.DieStamp(func(r *storagev1.StorageClass) {
+		r.ObjectMeta = v
 	})
 }
 
@@ -2347,9 +2431,6 @@ func (d *VolumeAttachmentDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *VolumeAttachmentDie) UnmarshalJSON(b []byte) error {
-	if d == VolumeAttachmentBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -2357,6 +2438,14 @@ func (d *VolumeAttachmentDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "storage.k8s.io/v1" and "VolumeAttachment" respectively.
+func (d *VolumeAttachmentDie) DieDefaultTypeMetadata() *VolumeAttachmentDie {
+	return d.DieStamp(func(r *storagev1.VolumeAttachment) {
+		r.APIVersion = "storage.k8s.io/v1"
+		r.Kind = "VolumeAttachment"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -2370,6 +2459,29 @@ func (d *VolumeAttachmentDie) APIVersion(v string) *VolumeAttachmentDie {
 func (d *VolumeAttachmentDie) Kind(v string) *VolumeAttachmentDie {
 	return d.DieStamp(func(r *storagev1.VolumeAttachment) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *VolumeAttachmentDie) TypeMetadata(v apismetav1.TypeMeta) *VolumeAttachmentDie {
+	return d.DieStamp(func(r *storagev1.VolumeAttachment) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *VolumeAttachmentDie) TypeMetadataDie(fn func(d *metav1.TypeMetaDie)) *VolumeAttachmentDie {
+	return d.DieStamp(func(r *storagev1.VolumeAttachment) {
+		d := metav1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *VolumeAttachmentDie) Metadata(v apismetav1.ObjectMeta) *VolumeAttachmentDie {
+	return d.DieStamp(func(r *storagev1.VolumeAttachment) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/apis/storage/v1beta1/csistoragecapacity.go
+++ b/apis/storage/v1beta1/csistoragecapacity.go
@@ -22,7 +22,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
-// +die:object=true
+// +die:object=true,apiVersion=storage.k8s.io/v1beta1,kind=CSIStorageCapacity
 type _ = storagev1beta1.CSIStorageCapacity
 
 func (d *CSIStorageCapacityDie) NodeTopologyDie(fn func(d *diemetav1.LabelSelectorDie)) *CSIStorageCapacityDie {

--- a/apis/storage/v1beta1/csistoragecapacity_test.go
+++ b/apis/storage/v1beta1/csistoragecapacity_test.go
@@ -45,6 +45,7 @@ func TestCSIStorageCapacity(t *testing.T) {
 					d.Name("my-name")
 				}),
 			expected: storagev1beta1.CSIStorageCapacity{
+				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "my-namespace",
 					Name:      "my-name",

--- a/apis/storage/v1beta1/zz_generated.die.go
+++ b/apis/storage/v1beta1/zz_generated.die.go
@@ -251,9 +251,6 @@ func (d *CSIStorageCapacityDie) MarshalJSON() ([]byte, error) {
 }
 
 func (d *CSIStorageCapacityDie) UnmarshalJSON(b []byte) error {
-	if d == CSIStorageCapacityBlank {
-		return fmtx.Errorf("cannot unmarshal into the blank die, create a copy first")
-	}
 	if !d.mutable {
 		return fmtx.Errorf("cannot unmarshal into immutable dies, create a mutable version first")
 	}
@@ -261,6 +258,14 @@ func (d *CSIStorageCapacityDie) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, r)
 	*d = *d.DieFeed(*r)
 	return err
+}
+
+// DieDefaultTypeMetadata sets the APIVersion and Kind to "storage.k8s.io/v1beta1" and "CSIStorageCapacity" respectively.
+func (d *CSIStorageCapacityDie) DieDefaultTypeMetadata() *CSIStorageCapacityDie {
+	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
+		r.APIVersion = "storage.k8s.io/v1beta1"
+		r.Kind = "CSIStorageCapacity"
+	})
 }
 
 // APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -274,6 +279,29 @@ func (d *CSIStorageCapacityDie) APIVersion(v string) *CSIStorageCapacityDie {
 func (d *CSIStorageCapacityDie) Kind(v string) *CSIStorageCapacityDie {
 	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
 		r.Kind = v
+	})
+}
+
+// TypeMetadata standard object's type metadata.
+func (d *CSIStorageCapacityDie) TypeMetadata(v metav1.TypeMeta) *CSIStorageCapacityDie {
+	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
+		r.TypeMeta = v
+	})
+}
+
+// TypeMetadataDie stamps the resource's TypeMeta field with a mutable die.
+func (d *CSIStorageCapacityDie) TypeMetadataDie(fn func(d *v1.TypeMetaDie)) *CSIStorageCapacityDie {
+	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
+		d := v1.TypeMetaBlank.DieImmutable(false).DieFeed(r.TypeMeta)
+		fn(d)
+		r.TypeMeta = d.DieRelease()
+	})
+}
+
+// Metadata standard object's metadata.
+func (d *CSIStorageCapacityDie) Metadata(v metav1.ObjectMeta) *CSIStorageCapacityDie {
+	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
+		r.ObjectMeta = v
 	})
 }
 

--- a/diegen/die/gen.go
+++ b/diegen/die/gen.go
@@ -37,6 +37,8 @@ var (
 
 type Die struct {
 	Object       bool     `marker:"object,optional"`
+	APIVersion   string   `marker:"apiVersion,optional"`
+	Kind         string   `marker:"kind,optional"`
 	IgnoreFields []string `marker:"ignore,optional"`
 
 	Target        string `marker:",optional"`


### PR DESCRIPTION
Setting the APIVersion and Kind isn't necessary for typed objects, it is essential for unstructured objects. Set the default values on object dies by calling `d.DieDefaultTypeMeta()`. This behavior is opt-in to avoid mass changes to existing objects.