### PR TITLE
Generate Quantity helper methods for dies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 - [Using dies](#using-dies)
   - [Common methods](#common-methods)
+  - [Helper methods](#helper-methods)
+    - [k8s.io/apimachinery/pkg/util/intstr#IntOrString](#k8sioapimachinerypkgutilintstrintorstring)
+    - [k8s.io/apimachinery/pkg/api/resource#Quantity](#k8sioapimachinerypkgapiresourcequantity)
+    - [k8s.io/api/core/v1#ResourceList](#k8sioapicorev1resourcelist)
 - [Creating dies](#creating-dies)
   - [diegen](#diegen)
   - [die markers](#die-markers)
@@ -241,6 +245,58 @@ type MyResourceDie interface {
 }
 ```
 
+### Helper methods
+
+Each exported field on the resource backing the die has a setter method defined. Some types offer additional helper methods to make common conversions easier.
+
+####  k8s.io/apimachinery/pkg/util/intstr#IntOrString
+
+```go
+type MyResourceDie interface {
+    // continued
+
+    Port(port intstr.IntOrString) *MyResourceDie
+
+    // PortInt sets Port with the int value.
+    PortInt(port int) *MyResourceDie
+
+    // PortString sets Port with the string value.
+    PortString(port string) *MyResourceDie
+}
+```
+
+#### k8s.io/apimachinery/pkg/api/resource#Quantity
+
+```go
+type MyResourceDie interface {
+    // continued
+
+    Memory(memory resource.Quantity) *MyResourceDie
+
+    // MemoryString sets Memory by parsing the string as a Quantity. Panics if
+    // the string is not parsable.
+    MemoryString(memory string) *MyResourceDie
+}
+```
+
+#### k8s.io/api/core/v1#ResourceList
+
+```go
+type MyResourceDie interface {
+    // continued
+
+    Limits(limits corev1.ResourceList) *MyResourceDie
+
+    // AddLimit sets a single quantity on the Limits resource list.
+    AddLimit(name string, limit resource.Quantity) *MyResourceDie
+
+    // AddLimitString parses the quantity setting a single value on the Limits
+    // resource list. Panics if the string is not parsable.
+    AddLimitString(name string, limit string) *MyResourceDie
+}
+
+```
+
 ## Creating dies
 
 Dies are primarily generated for types from [die markers](#die-markers) using
@@ -283,6 +339,8 @@ func (d *DeploymentStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDi
     })
 }
 ```
+
+
 
 ### diegen
 

--- a/apis/apps/v1/zz_generated.die.go
+++ b/apis/apps/v1/zz_generated.die.go
@@ -1310,6 +1310,35 @@ func (d *RollingUpdateDaemonSetDie) MaxUnavailable(v *intstr.IntOrString) *Rolli
 	})
 }
 
+// MaxUnavailableInt sets MaxUnavailable with the int value.
+//
+// # The maximum number of DaemonSet pods that can be unavailable during the
+//
+// update. Value can be an absolute number (ex: 5) or a percentage of total
+//
+// number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+//
+// number is calculated from percentage by rounding up.
+//
+// # This cannot be 0 if MaxSurge is 0
+//
+// Default value is 1.
+//
+// Example: when this is set to 30%, at most 30% of the total number of nodes
+//
+// that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+//
+// can have their pods stopped for an update at any given time. The update
+//
+// starts by stopping at most 30% of those DaemonSet pods and then brings
+//
+// up new DaemonSet pods in their place. Once the new pods are available,
+//
+// it then proceeds onto other DaemonSet pods, thus ensuring that at least
+//
+// 70% of original number of DaemonSet pods are available at all times during
+//
+// the update.
 func (d *RollingUpdateDaemonSetDie) MaxUnavailableInt(i int) *RollingUpdateDaemonSetDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDaemonSet) {
 		v := intstr.FromInt(i)
@@ -1317,6 +1346,35 @@ func (d *RollingUpdateDaemonSetDie) MaxUnavailableInt(i int) *RollingUpdateDaemo
 	})
 }
 
+// MaxUnavailableString sets MaxUnavailable with the string value.
+//
+// # The maximum number of DaemonSet pods that can be unavailable during the
+//
+// update. Value can be an absolute number (ex: 5) or a percentage of total
+//
+// number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+//
+// number is calculated from percentage by rounding up.
+//
+// # This cannot be 0 if MaxSurge is 0
+//
+// Default value is 1.
+//
+// Example: when this is set to 30%, at most 30% of the total number of nodes
+//
+// that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+//
+// can have their pods stopped for an update at any given time. The update
+//
+// starts by stopping at most 30% of those DaemonSet pods and then brings
+//
+// up new DaemonSet pods in their place. Once the new pods are available,
+//
+// it then proceeds onto other DaemonSet pods, thus ensuring that at least
+//
+// 70% of original number of DaemonSet pods are available at all times during
+//
+// the update.
 func (d *RollingUpdateDaemonSetDie) MaxUnavailableString(s string) *RollingUpdateDaemonSetDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDaemonSet) {
 		v := intstr.FromString(s)
@@ -1365,6 +1423,43 @@ func (d *RollingUpdateDaemonSetDie) MaxSurge(v *intstr.IntOrString) *RollingUpda
 	})
 }
 
+// MaxSurgeInt sets MaxSurge with the int value.
+//
+// # The maximum number of nodes with an existing available DaemonSet pod that
+//
+// can have an updated DaemonSet pod during during an update.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// This can not be 0 if MaxUnavailable is 0.
+//
+// Absolute number is calculated from percentage by rounding up to a minimum of 1.
+//
+// Default value is 0.
+//
+// Example: when this is set to 30%, at most 30% of the total number of nodes
+//
+// that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+//
+// can have their a new pod created before the old pod is marked as deleted.
+//
+// The update starts by launching new pods on 30% of nodes. Once an updated
+//
+// pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+//
+// on that node is marked deleted. If the old pod becomes unavailable for any
+//
+// reason (Ready transitions to false, is evicted, or is drained) an updated
+//
+// pod is immediatedly created on that node without considering surge limits.
+//
+// # Allowing surge implies the possibility that the resources consumed by the
+//
+// daemonset on any given node can double if the readiness check fails, and
+//
+// so resource intensive daemonsets should take into account that they may
+//
+// cause evictions during disruption.
 func (d *RollingUpdateDaemonSetDie) MaxSurgeInt(i int) *RollingUpdateDaemonSetDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDaemonSet) {
 		v := intstr.FromInt(i)
@@ -1372,6 +1467,43 @@ func (d *RollingUpdateDaemonSetDie) MaxSurgeInt(i int) *RollingUpdateDaemonSetDi
 	})
 }
 
+// MaxSurgeString sets MaxSurge with the string value.
+//
+// # The maximum number of nodes with an existing available DaemonSet pod that
+//
+// can have an updated DaemonSet pod during during an update.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// This can not be 0 if MaxUnavailable is 0.
+//
+// Absolute number is calculated from percentage by rounding up to a minimum of 1.
+//
+// Default value is 0.
+//
+// Example: when this is set to 30%, at most 30% of the total number of nodes
+//
+// that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+//
+// can have their a new pod created before the old pod is marked as deleted.
+//
+// The update starts by launching new pods on 30% of nodes. Once an updated
+//
+// pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+//
+// on that node is marked deleted. If the old pod becomes unavailable for any
+//
+// reason (Ready transitions to false, is evicted, or is drained) an updated
+//
+// pod is immediatedly created on that node without considering surge limits.
+//
+// # Allowing surge implies the possibility that the resources consumed by the
+//
+// daemonset on any given node can double if the readiness check fails, and
+//
+// so resource intensive daemonsets should take into account that they may
+//
+// cause evictions during disruption.
 func (d *RollingUpdateDaemonSetDie) MaxSurgeString(s string) *RollingUpdateDaemonSetDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDaemonSet) {
 		v := intstr.FromString(s)
@@ -2639,6 +2771,27 @@ func (d *RollingUpdateDeploymentDie) MaxUnavailable(v *intstr.IntOrString) *Roll
 	})
 }
 
+// MaxUnavailableInt sets MaxUnavailable with the int value.
+//
+// The maximum number of pods that can be unavailable during the update.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// Absolute number is calculated from percentage by rounding down.
+//
+// This can not be 0 if MaxSurge is 0.
+//
+// Defaults to 25%.
+//
+// Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+//
+// immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+//
+// can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+//
+// that the total number of pods available at all times during the update is at
+//
+// least 70% of desired pods.
 func (d *RollingUpdateDeploymentDie) MaxUnavailableInt(i int) *RollingUpdateDeploymentDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDeployment) {
 		v := intstr.FromInt(i)
@@ -2646,6 +2799,27 @@ func (d *RollingUpdateDeploymentDie) MaxUnavailableInt(i int) *RollingUpdateDepl
 	})
 }
 
+// MaxUnavailableString sets MaxUnavailable with the string value.
+//
+// The maximum number of pods that can be unavailable during the update.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// Absolute number is calculated from percentage by rounding down.
+//
+// This can not be 0 if MaxSurge is 0.
+//
+// Defaults to 25%.
+//
+// Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+//
+// immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+//
+// can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+//
+// that the total number of pods available at all times during the update is at
+//
+// least 70% of desired pods.
 func (d *RollingUpdateDeploymentDie) MaxUnavailableString(s string) *RollingUpdateDeploymentDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDeployment) {
 		v := intstr.FromString(s)
@@ -2680,6 +2854,29 @@ func (d *RollingUpdateDeploymentDie) MaxSurge(v *intstr.IntOrString) *RollingUpd
 	})
 }
 
+// MaxSurgeInt sets MaxSurge with the int value.
+//
+// # The maximum number of pods that can be scheduled above the desired number of
+//
+// pods.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// This can not be 0 if MaxUnavailable is 0.
+//
+// Absolute number is calculated from percentage by rounding up.
+//
+// Defaults to 25%.
+//
+// Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+//
+// the rolling update starts, such that the total number of old and new pods do not exceed
+//
+// 130% of desired pods. Once old pods have been killed,
+//
+// new ReplicaSet can be scaled up further, ensuring that total number of pods running
+//
+// at any time during the update is at most 130% of desired pods.
 func (d *RollingUpdateDeploymentDie) MaxSurgeInt(i int) *RollingUpdateDeploymentDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDeployment) {
 		v := intstr.FromInt(i)
@@ -2687,6 +2884,29 @@ func (d *RollingUpdateDeploymentDie) MaxSurgeInt(i int) *RollingUpdateDeployment
 	})
 }
 
+// MaxSurgeString sets MaxSurge with the string value.
+//
+// # The maximum number of pods that can be scheduled above the desired number of
+//
+// pods.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// This can not be 0 if MaxUnavailable is 0.
+//
+// Absolute number is calculated from percentage by rounding up.
+//
+// Defaults to 25%.
+//
+// Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+//
+// the rolling update starts, such that the total number of old and new pods do not exceed
+//
+// 130% of desired pods. Once old pods have been killed,
+//
+// new ReplicaSet can be scaled up further, ensuring that total number of pods running
+//
+// at any time during the update is at most 130% of desired pods.
 func (d *RollingUpdateDeploymentDie) MaxSurgeString(s string) *RollingUpdateDeploymentDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateDeployment) {
 		v := intstr.FromString(s)
@@ -4789,6 +5009,21 @@ func (d *RollingUpdateStatefulSetStrategyDie) MaxUnavailable(v *intstr.IntOrStri
 	})
 }
 
+// MaxUnavailableInt sets MaxUnavailable with the int value.
+//
+// The maximum number of pods that can be unavailable during the update.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// Absolute number is calculated from percentage by rounding up. This can not be 0.
+//
+// Defaults to 1. This field is alpha-level and is only honored by servers that enable the
+//
+// MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to
+//
+// Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
+//
+// will be counted towards MaxUnavailable.
 func (d *RollingUpdateStatefulSetStrategyDie) MaxUnavailableInt(i int) *RollingUpdateStatefulSetStrategyDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateStatefulSetStrategy) {
 		v := intstr.FromInt(i)
@@ -4796,6 +5031,21 @@ func (d *RollingUpdateStatefulSetStrategyDie) MaxUnavailableInt(i int) *RollingU
 	})
 }
 
+// MaxUnavailableString sets MaxUnavailable with the string value.
+//
+// The maximum number of pods that can be unavailable during the update.
+//
+// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+//
+// Absolute number is calculated from percentage by rounding up. This can not be 0.
+//
+// Defaults to 1. This field is alpha-level and is only honored by servers that enable the
+//
+// MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to
+//
+// Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
+//
+// will be counted towards MaxUnavailable.
 func (d *RollingUpdateStatefulSetStrategyDie) MaxUnavailableString(s string) *RollingUpdateStatefulSetStrategyDie {
 	return d.DieStamp(func(r *appsv1.RollingUpdateStatefulSetStrategy) {
 		v := intstr.FromString(s)

--- a/apis/autoscaling/v2/horizontalpodautoscaler.go
+++ b/apis/autoscaling/v2/horizontalpodautoscaler.go
@@ -19,7 +19,6 @@ package v2
 import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -129,16 +128,6 @@ func (d *ObjectMetricSourceDie) MetricDie(fn func(d *MetricIdentifierDie)) *Obje
 
 // +die
 type _ = autoscalingv2.MetricTarget
-
-func (d *MetricTargetDie) ValueString(quantity string) *MetricTargetDie {
-	q := resource.MustParse(quantity)
-	return d.Value(&q)
-}
-
-func (d *MetricTargetDie) AverageValueString(quantity string) *MetricTargetDie {
-	q := resource.MustParse(quantity)
-	return d.AverageValue(&q)
-}
 
 // +die
 type _ = autoscalingv2.MetricIdentifier
@@ -345,16 +334,6 @@ func (d *ObjectMetricStatusDie) DescribedObjectDie(fn func(d *CrossVersionObject
 
 // +die
 type _ = autoscalingv2.MetricValueStatus
-
-func (d *MetricValueStatusDie) ValueString(quantity string) *MetricValueStatusDie {
-	q := resource.MustParse(quantity)
-	return d.Value(&q)
-}
-
-func (d *MetricValueStatusDie) AverageValueString(quantity string) *MetricValueStatusDie {
-	q := resource.MustParse(quantity)
-	return d.AverageValue(&q)
-}
 
 // +die
 type _ = autoscalingv2.PodsMetricStatus

--- a/apis/autoscaling/v2/zz_generated.die.go
+++ b/apis/autoscaling/v2/zz_generated.die.go
@@ -26,7 +26,7 @@ import (
 	fmtx "fmt"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -1460,6 +1460,14 @@ func (d *MetricTargetDie) Value(v *resource.Quantity) *MetricTargetDie {
 	})
 }
 
+// ValueString sets Value by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// value is the target value of the metric (as a quantity).
+func (d *MetricTargetDie) ValueString(s string) *MetricTargetDie {
+	q := resource.MustParse(s)
+	return d.Value(&q)
+}
+
 // averageValue is the target value of the average of the
 //
 // metric across all relevant pods (as a quantity)
@@ -1467,6 +1475,16 @@ func (d *MetricTargetDie) AverageValue(v *resource.Quantity) *MetricTargetDie {
 	return d.DieStamp(func(r *autoscalingv2.MetricTarget) {
 		r.AverageValue = v
 	})
+}
+
+// AverageValueString sets AverageValue by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// averageValue is the target value of the average of the
+//
+// metric across all relevant pods (as a quantity)
+func (d *MetricTargetDie) AverageValueString(s string) *MetricTargetDie {
+	q := resource.MustParse(s)
+	return d.AverageValue(&q)
 }
 
 // averageUtilization is the target value of the average of the
@@ -3991,6 +4009,14 @@ func (d *MetricValueStatusDie) Value(v *resource.Quantity) *MetricValueStatusDie
 	})
 }
 
+// ValueString sets Value by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// value is the current value of the metric (as a quantity).
+func (d *MetricValueStatusDie) ValueString(s string) *MetricValueStatusDie {
+	q := resource.MustParse(s)
+	return d.Value(&q)
+}
+
 // averageValue is the current value of the average of the
 //
 // metric across all relevant pods (as a quantity)
@@ -3998,6 +4024,16 @@ func (d *MetricValueStatusDie) AverageValue(v *resource.Quantity) *MetricValueSt
 	return d.DieStamp(func(r *autoscalingv2.MetricValueStatus) {
 		r.AverageValue = v
 	})
+}
+
+// AverageValueString sets AverageValue by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// averageValue is the current value of the average of the
+//
+// metric across all relevant pods (as a quantity)
+func (d *MetricValueStatusDie) AverageValueString(s string) *MetricValueStatusDie {
+	q := resource.MustParse(s)
+	return d.AverageValue(&q)
 }
 
 // currentAverageUtilization is the current value of the average of the

--- a/apis/core/v1/container.go
+++ b/apis/core/v1/container.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // +die
@@ -279,32 +278,6 @@ func (d *SecretKeySelectorDie) Name(v string) *SecretKeySelectorDie {
 // +die
 type _ = corev1.ResourceRequirements
 
-func (d *ResourceRequirementsDie) AddLimit(name corev1.ResourceName, quantity resource.Quantity) *ResourceRequirementsDie {
-	return d.DieStamp(func(r *corev1.ResourceRequirements) {
-		if r.Limits == nil {
-			r.Limits = corev1.ResourceList{}
-		}
-		r.Limits[name] = quantity
-	})
-}
-
-func (d *ResourceRequirementsDie) AddLimitString(name corev1.ResourceName, quantity string) *ResourceRequirementsDie {
-	return d.AddLimit(name, resource.MustParse(quantity))
-}
-
-func (d *ResourceRequirementsDie) AddRequest(name corev1.ResourceName, quantity resource.Quantity) *ResourceRequirementsDie {
-	return d.DieStamp(func(r *corev1.ResourceRequirements) {
-		if r.Requests == nil {
-			r.Requests = corev1.ResourceList{}
-		}
-		r.Requests[name] = quantity
-	})
-}
-
-func (d *ResourceRequirementsDie) AddRequestString(name corev1.ResourceName, quantity string) *ResourceRequirementsDie {
-	return d.AddRequest(name, resource.MustParse(quantity))
-}
-
 func (d *ResourceRequirementsDie) ClaimsDie(claims ...*ResourceClaimDie) *ResourceRequirementsDie {
 	return d.DieStamp(func(r *corev1.ResourceRequirements) {
 		r.Claims = make([]corev1.ResourceClaim, len(claims))
@@ -558,19 +531,6 @@ func (d *ContainerStatusDie) LastTerminationStateDie(fn func(d *ContainerStateDi
 		fn(d)
 		r.LastTerminationState = d.DieRelease()
 	})
-}
-
-func (d *ContainerStatusDie) AddAllocatedResource(name corev1.ResourceName, quantity resource.Quantity) *ContainerStatusDie {
-	return d.DieStamp(func(r *corev1.ContainerStatus) {
-		if r.AllocatedResources == nil {
-			r.AllocatedResources = corev1.ResourceList{}
-		}
-		r.AllocatedResources[name] = quantity
-	})
-}
-
-func (d *ContainerStatusDie) AddAllocatedResourceString(name corev1.ResourceName, quantity string) *ContainerStatusDie {
-	return d.AddAllocatedResource(name, resource.MustParse(quantity))
 }
 
 func (d *ContainerStatusDie) ResourcesDie(fn func(d *ResourceRequirementsDie)) *ContainerStatusDie {

--- a/apis/core/v1/limitrange.go
+++ b/apis/core/v1/limitrange.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // +die:object=true,apiVersion=v1,kind=LimitRange
@@ -38,68 +37,3 @@ func (d *LimitRangeSpecDie) LimitsDie(limits ...*LimitRangeItemDie) *LimitRangeS
 
 // +die
 type _ = corev1.LimitRangeItem
-
-func (d *LimitRangeItemDie) AddMax(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
-	return d.DieStamp(func(r *corev1.LimitRangeItem) {
-		if r.Max == nil {
-			r.Max = corev1.ResourceList{}
-		}
-		r.Max[name] = quantity
-	})
-}
-
-func (d *LimitRangeItemDie) AddMaxString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
-	return d.AddMax(name, resource.MustParse(quantity))
-}
-
-func (d *LimitRangeItemDie) AddMin(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
-	return d.DieStamp(func(r *corev1.LimitRangeItem) {
-		if r.Min == nil {
-			r.Min = corev1.ResourceList{}
-		}
-		r.Min[name] = quantity
-	})
-}
-
-func (d *LimitRangeItemDie) AddMinString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
-	return d.AddMin(name, resource.MustParse(quantity))
-}
-
-func (d *LimitRangeItemDie) AddDefault(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
-	return d.DieStamp(func(r *corev1.LimitRangeItem) {
-		if r.Default == nil {
-			r.Default = corev1.ResourceList{}
-		}
-		r.Default[name] = quantity
-	})
-}
-
-func (d *LimitRangeItemDie) AddDefaultString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
-	return d.AddDefault(name, resource.MustParse(quantity))
-}
-
-func (d *LimitRangeItemDie) AddDefaultRequest(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
-	return d.DieStamp(func(r *corev1.LimitRangeItem) {
-		if r.DefaultRequest == nil {
-			r.DefaultRequest = corev1.ResourceList{}
-		}
-		r.DefaultRequest[name] = quantity
-	})
-}
-
-func (d *LimitRangeItemDie) AddDefaultRequestString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
-	return d.AddDefaultRequest(name, resource.MustParse(quantity))
-}
-
-func (d *LimitRangeItemDie) AddMaxLimitRequestRatio(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
-	return d.DieStamp(func(r *corev1.LimitRangeItem) {
-		if r.MaxLimitRequestRatio == nil {
-			r.MaxLimitRequestRatio = corev1.ResourceList{}
-		}
-		r.MaxLimitRequestRatio[name] = quantity
-	})
-}
-
-func (d *LimitRangeItemDie) AddMaxLimitRequestRatioString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
-	return d.AddMaxLimitRequestRatio(name, resource.MustParse(quantity))
-}

--- a/apis/core/v1/node.go
+++ b/apis/core/v1/node.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -72,32 +71,6 @@ type _ = corev1.ConfigMapNodeConfigSource
 
 // +die
 type _ = corev1.NodeStatus
-
-func (d *NodeStatusDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		if r.Capacity == nil {
-			r.Capacity = corev1.ResourceList{}
-		}
-		r.Capacity[name] = quantity
-	})
-}
-
-func (d *NodeStatusDie) AddCapacityString(name corev1.ResourceName, quantity string) *NodeStatusDie {
-	return d.AddCapacity(name, resource.MustParse(quantity))
-}
-
-func (d *NodeStatusDie) AddAllocatable(name corev1.ResourceName, quantity resource.Quantity) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		if r.Allocatable == nil {
-			r.Allocatable = corev1.ResourceList{}
-		}
-		r.Allocatable[name] = quantity
-	})
-}
-
-func (d *NodeStatusDie) AddAllocatableString(name corev1.ResourceName, quantity string) *NodeStatusDie {
-	return d.AddAllocatable(name, resource.MustParse(quantity))
-}
 
 func (d *NodeStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *NodeStatusDie {
 	return d.DieStamp(func(r *corev1.NodeStatus) {

--- a/apis/core/v1/persistantvolume.go
+++ b/apis/core/v1/persistantvolume.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // +die:object=true,apiVersion=v1,kind=PersistentVolume
@@ -26,19 +25,6 @@ type _ = corev1.PersistentVolume
 
 // +die
 type _ = corev1.PersistentVolumeSpec
-
-func (d *PersistentVolumeSpecDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeSpecDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeSpec) {
-		if r.Capacity == nil {
-			r.Capacity = corev1.ResourceList{}
-		}
-		r.Capacity[name] = quantity
-	})
-}
-
-func (d *PersistentVolumeSpecDie) AddCapacityString(name corev1.ResourceName, quantity string) *PersistentVolumeSpecDie {
-	return d.AddCapacity(name, resource.MustParse(quantity))
-}
 
 func (d *PersistentVolumeSpecDie) GCEPersistentDiskDie(fn func(d *GCEPersistentDiskVolumeSourceDie)) *PersistentVolumeSpecDie {
 	return d.DieStamp(func(r *corev1.PersistentVolumeSpec) {

--- a/apis/core/v1/persistantvolumeclaim.go
+++ b/apis/core/v1/persistantvolumeclaim.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -63,47 +62,8 @@ func (d *PersistentVolumeClaimSpecDie) DataSourceRefDie(fn func(d *TypedObjectRe
 // +die
 type _ = corev1.VolumeResourceRequirements
 
-func (d *VolumeResourceRequirementsDie) AddLimit(name corev1.ResourceName, quantity resource.Quantity) *VolumeResourceRequirementsDie {
-	return d.DieStamp(func(r *corev1.VolumeResourceRequirements) {
-		if r.Limits == nil {
-			r.Limits = corev1.ResourceList{}
-		}
-		r.Limits[name] = quantity
-	})
-}
-
-func (d *VolumeResourceRequirementsDie) AddLimitString(name corev1.ResourceName, quantity string) *VolumeResourceRequirementsDie {
-	return d.AddLimit(name, resource.MustParse(quantity))
-}
-
-func (d *VolumeResourceRequirementsDie) AddRequest(name corev1.ResourceName, quantity resource.Quantity) *VolumeResourceRequirementsDie {
-	return d.DieStamp(func(r *corev1.VolumeResourceRequirements) {
-		if r.Requests == nil {
-			r.Requests = corev1.ResourceList{}
-		}
-		r.Requests[name] = quantity
-	})
-}
-
-func (d *VolumeResourceRequirementsDie) AddRequestString(name corev1.ResourceName, quantity string) *VolumeResourceRequirementsDie {
-	return d.AddRequest(name, resource.MustParse(quantity))
-}
-
 // +die:ignore={AllocatedResourceStatuses}
 type _ = corev1.PersistentVolumeClaimStatus
-
-func (d *PersistentVolumeClaimStatusDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeClaimStatusDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
-		if r.Capacity == nil {
-			r.Capacity = corev1.ResourceList{}
-		}
-		r.Capacity[name] = quantity
-	})
-}
-
-func (d *PersistentVolumeClaimStatusDie) AddCapacityString(name corev1.ResourceName, quantity string) *PersistentVolumeClaimStatusDie {
-	return d.AddCapacity(name, resource.MustParse(quantity))
-}
 
 func (d *PersistentVolumeClaimStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *PersistentVolumeClaimStatusDie {
 	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
@@ -119,19 +79,6 @@ func (d *PersistentVolumeClaimStatusDie) ConditionsDie(conditions ...*diemetav1.
 			}
 		}
 	})
-}
-
-func (d *PersistentVolumeClaimStatusDie) AddAllocatedResources(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeClaimStatusDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
-		if r.AllocatedResources == nil {
-			r.AllocatedResources = corev1.ResourceList{}
-		}
-		r.AllocatedResources[name] = quantity
-	})
-}
-
-func (d *PersistentVolumeClaimStatusDie) AddAllocatedResourcesString(name corev1.ResourceName, quantity string) *PersistentVolumeClaimStatusDie {
-	return d.AddAllocatedResources(name, resource.MustParse(quantity))
 }
 
 // allocatedResourceStatuses stores status of resource being resized for the given PVC.

--- a/apis/core/v1/pod.go
+++ b/apis/core/v1/pod.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -128,19 +127,6 @@ func (d *PodSpecDie) ReadinessGatesDie(gates ...*PodReadinessGateDie) *PodSpecDi
 			r.ReadinessGates[i] = gates[i].DieRelease()
 		}
 	})
-}
-
-func (d *PodSpecDie) AddOverhead(name corev1.ResourceName, quantity resource.Quantity) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		if r.Overhead == nil {
-			r.Overhead = corev1.ResourceList{}
-		}
-		r.Overhead[name] = quantity
-	})
-}
-
-func (d *PodSpecDie) AddOverheadString(name corev1.ResourceName, quantity string) *PodSpecDie {
-	return d.AddOverhead(name, resource.MustParse(quantity))
 }
 
 func (d *PodSpecDie) TopologySpreadConstraintDie(topologyKey string, fn func(d *TopologySpreadConstraintDie)) *PodSpecDie {

--- a/apis/core/v1/resourcequota.go
+++ b/apis/core/v1/resourcequota.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // +die:object=true,apiVersion=v1,kind=ResourceQuota
@@ -26,19 +25,6 @@ type _ = corev1.ResourceQuota
 
 // +die
 type _ = corev1.ResourceQuotaSpec
-
-func (d *ResourceQuotaSpecDie) AddHard(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaSpecDie {
-	return d.DieStamp(func(r *corev1.ResourceQuotaSpec) {
-		if r.Hard == nil {
-			r.Hard = corev1.ResourceList{}
-		}
-		r.Hard[name] = quantity
-	})
-}
-
-func (d *ResourceQuotaSpecDie) AddHardString(name corev1.ResourceName, quantity string) *ResourceQuotaSpecDie {
-	return d.AddHard(name, resource.MustParse(quantity))
-}
 
 func (d *ResourceQuotaSpecDie) ScopeSelectorDie(fn func(d *ScopeSelectorDie)) *ResourceQuotaSpecDie {
 	return d.DieStamp(func(r *corev1.ResourceQuotaSpec) {
@@ -73,29 +59,3 @@ type _ = corev1.ScopedResourceSelectorRequirement
 
 // +die
 type _ = corev1.ResourceQuotaStatus
-
-func (d *ResourceQuotaStatusDie) AddHard(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaStatusDie {
-	return d.DieStamp(func(r *corev1.ResourceQuotaStatus) {
-		if r.Hard == nil {
-			r.Hard = corev1.ResourceList{}
-		}
-		r.Hard[name] = quantity
-	})
-}
-
-func (d *ResourceQuotaStatusDie) AddHardString(name corev1.ResourceName, quantity string) *ResourceQuotaStatusDie {
-	return d.AddHard(name, resource.MustParse(quantity))
-}
-
-func (d *ResourceQuotaStatusDie) AddUsed(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaStatusDie {
-	return d.DieStamp(func(r *corev1.ResourceQuotaStatus) {
-		if r.Used == nil {
-			r.Used = corev1.ResourceList{}
-		}
-		r.Used[name] = quantity
-	})
-}
-
-func (d *ResourceQuotaStatusDie) AddUsedString(name corev1.ResourceName, quantity string) *ResourceQuotaStatusDie {
-	return d.AddUsed(name, resource.MustParse(quantity))
-}

--- a/apis/core/v1/zz_generated.die.go
+++ b/apis/core/v1/zz_generated.die.go
@@ -25,7 +25,7 @@ import (
 	json "encoding/json"
 	fmtx "fmt"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -4543,6 +4543,14 @@ func (d *ResourceFieldSelectorDie) Divisor(v resource.Quantity) *ResourceFieldSe
 	})
 }
 
+// DivisorString sets Divisor by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// Specifies the output format of the exposed resources, defaults to "1"
+func (d *ResourceFieldSelectorDie) DivisorString(s string) *ResourceFieldSelectorDie {
+	q := resource.MustParse(s)
+	return d.Divisor(q)
+}
+
 var ConfigMapKeySelectorBlank = (&ConfigMapKeySelectorDie{}).DieFeed(corev1.ConfigMapKeySelector{})
 
 type ConfigMapKeySelectorDie struct {
@@ -5140,6 +5148,30 @@ func (d *ResourceRequirementsDie) Limits(v corev1.ResourceList) *ResourceRequire
 	})
 }
 
+// AddLimit sets a single quantity on the Limits resource list.
+//
+// Limits describes the maximum amount of compute resources allowed.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *ResourceRequirementsDie) AddLimit(name corev1.ResourceName, quantity resource.Quantity) *ResourceRequirementsDie {
+	return d.DieStamp(func(r *corev1.ResourceRequirements) {
+		if r.Limits == nil {
+			r.Limits = corev1.ResourceList{}
+		}
+		r.Limits[name] = quantity
+	})
+}
+
+// AddLimitString parses the quantity setting a single value on the Limits resource list. Panics if the string is not parsable.
+//
+// Limits describes the maximum amount of compute resources allowed.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *ResourceRequirementsDie) AddLimitString(name corev1.ResourceName, quantity string) *ResourceRequirementsDie {
+	q := resource.MustParse(quantity)
+	return d.AddLimit(name, q)
+}
+
 // Requests describes the minimum amount of compute resources required.
 //
 // If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -5151,6 +5183,38 @@ func (d *ResourceRequirementsDie) Requests(v corev1.ResourceList) *ResourceRequi
 	return d.DieStamp(func(r *corev1.ResourceRequirements) {
 		r.Requests = v
 	})
+}
+
+// AddRequest sets a single quantity on the Requests resource list.
+//
+// Requests describes the minimum amount of compute resources required.
+//
+// If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+//
+// otherwise to an implementation-defined value. Requests cannot exceed Limits.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *ResourceRequirementsDie) AddRequest(name corev1.ResourceName, quantity resource.Quantity) *ResourceRequirementsDie {
+	return d.DieStamp(func(r *corev1.ResourceRequirements) {
+		if r.Requests == nil {
+			r.Requests = corev1.ResourceList{}
+		}
+		r.Requests[name] = quantity
+	})
+}
+
+// AddRequestString parses the quantity setting a single value on the Requests resource list. Panics if the string is not parsable.
+//
+// Requests describes the minimum amount of compute resources required.
+//
+// If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+//
+// otherwise to an implementation-defined value. Requests cannot exceed Limits.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *ResourceRequirementsDie) AddRequestString(name corev1.ResourceName, quantity string) *ResourceRequirementsDie {
+	q := resource.MustParse(quantity)
+	return d.AddRequest(name, q)
 }
 
 // Claims lists the names of resources, defined in spec.resourceClaims,
@@ -7332,6 +7396,13 @@ func (d *HTTPGetActionDie) Port(v intstr.IntOrString) *HTTPGetActionDie {
 	})
 }
 
+// PortInt sets Port with the int value.
+//
+// Name or number of the port to access on the container.
+//
+// Number must be in the range 1 to 65535.
+//
+// Name must be an IANA_SVC_NAME.
 func (d *HTTPGetActionDie) PortInt(i int) *HTTPGetActionDie {
 	return d.DieStamp(func(r *corev1.HTTPGetAction) {
 		v := intstr.FromInt(i)
@@ -7339,6 +7410,13 @@ func (d *HTTPGetActionDie) PortInt(i int) *HTTPGetActionDie {
 	})
 }
 
+// PortString sets Port with the string value.
+//
+// Name or number of the port to access on the container.
+//
+// Number must be in the range 1 to 65535.
+//
+// Name must be an IANA_SVC_NAME.
 func (d *HTTPGetActionDie) PortString(s string) *HTTPGetActionDie {
 	return d.DieStamp(func(r *corev1.HTTPGetAction) {
 		v := intstr.FromString(s)
@@ -7762,6 +7840,13 @@ func (d *TCPSocketActionDie) Port(v intstr.IntOrString) *TCPSocketActionDie {
 	})
 }
 
+// PortInt sets Port with the int value.
+//
+// Number or name of the port to access on the container.
+//
+// Number must be in the range 1 to 65535.
+//
+// Name must be an IANA_SVC_NAME.
 func (d *TCPSocketActionDie) PortInt(i int) *TCPSocketActionDie {
 	return d.DieStamp(func(r *corev1.TCPSocketAction) {
 		v := intstr.FromInt(i)
@@ -7769,6 +7854,13 @@ func (d *TCPSocketActionDie) PortInt(i int) *TCPSocketActionDie {
 	})
 }
 
+// PortString sets Port with the string value.
+//
+// Number or name of the port to access on the container.
+//
+// Number must be in the range 1 to 65535.
+//
+// Name must be an IANA_SVC_NAME.
 func (d *TCPSocketActionDie) PortString(s string) *TCPSocketActionDie {
 	return d.DieStamp(func(r *corev1.TCPSocketAction) {
 		v := intstr.FromString(s)
@@ -9880,6 +9972,34 @@ func (d *ContainerStatusDie) AllocatedResources(v corev1.ResourceList) *Containe
 	return d.DieStamp(func(r *corev1.ContainerStatus) {
 		r.AllocatedResources = v
 	})
+}
+
+// AddAllocatedResource sets a single quantity on the AllocatedResources resource list.
+//
+// # AllocatedResources represents the compute resources allocated for this container by the
+//
+// node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
+//
+// and after successfully admitting desired pod resize.
+func (d *ContainerStatusDie) AddAllocatedResource(name corev1.ResourceName, quantity resource.Quantity) *ContainerStatusDie {
+	return d.DieStamp(func(r *corev1.ContainerStatus) {
+		if r.AllocatedResources == nil {
+			r.AllocatedResources = corev1.ResourceList{}
+		}
+		r.AllocatedResources[name] = quantity
+	})
+}
+
+// AddAllocatedResourceString parses the quantity setting a single value on the AllocatedResources resource list. Panics if the string is not parsable.
+//
+// # AllocatedResources represents the compute resources allocated for this container by the
+//
+// node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission
+//
+// and after successfully admitting desired pod resize.
+func (d *ContainerStatusDie) AddAllocatedResourceString(name corev1.ResourceName, quantity string) *ContainerStatusDie {
+	q := resource.MustParse(quantity)
+	return d.AddAllocatedResource(name, q)
 }
 
 // Resources represents the compute resource requests and limits that have been successfully
@@ -13345,11 +13465,51 @@ func (d *LimitRangeItemDie) Max(v corev1.ResourceList) *LimitRangeItemDie {
 	})
 }
 
+// AddMax sets a single quantity on the Max resource list.
+//
+// Max usage constraints on this kind by resource name.
+func (d *LimitRangeItemDie) AddMax(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
+	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.Max == nil {
+			r.Max = corev1.ResourceList{}
+		}
+		r.Max[name] = quantity
+	})
+}
+
+// AddMaxString parses the quantity setting a single value on the Max resource list. Panics if the string is not parsable.
+//
+// Max usage constraints on this kind by resource name.
+func (d *LimitRangeItemDie) AddMaxString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
+	q := resource.MustParse(quantity)
+	return d.AddMax(name, q)
+}
+
 // Min usage constraints on this kind by resource name.
 func (d *LimitRangeItemDie) Min(v corev1.ResourceList) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
 		r.Min = v
 	})
+}
+
+// AddMin sets a single quantity on the Min resource list.
+//
+// Min usage constraints on this kind by resource name.
+func (d *LimitRangeItemDie) AddMin(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
+	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.Min == nil {
+			r.Min = corev1.ResourceList{}
+		}
+		r.Min[name] = quantity
+	})
+}
+
+// AddMinString parses the quantity setting a single value on the Min resource list. Panics if the string is not parsable.
+//
+// Min usage constraints on this kind by resource name.
+func (d *LimitRangeItemDie) AddMinString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
+	q := resource.MustParse(quantity)
+	return d.AddMin(name, q)
 }
 
 // Default resource requirement limit value by resource name if resource limit is omitted.
@@ -13359,6 +13519,26 @@ func (d *LimitRangeItemDie) Default(v corev1.ResourceList) *LimitRangeItemDie {
 	})
 }
 
+// AddDefault sets a single quantity on the Default resource list.
+//
+// Default resource requirement limit value by resource name if resource limit is omitted.
+func (d *LimitRangeItemDie) AddDefault(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
+	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.Default == nil {
+			r.Default = corev1.ResourceList{}
+		}
+		r.Default[name] = quantity
+	})
+}
+
+// AddDefaultString parses the quantity setting a single value on the Default resource list. Panics if the string is not parsable.
+//
+// Default resource requirement limit value by resource name if resource limit is omitted.
+func (d *LimitRangeItemDie) AddDefaultString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
+	q := resource.MustParse(quantity)
+	return d.AddDefault(name, q)
+}
+
 // DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
 func (d *LimitRangeItemDie) DefaultRequest(v corev1.ResourceList) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
@@ -13366,11 +13546,51 @@ func (d *LimitRangeItemDie) DefaultRequest(v corev1.ResourceList) *LimitRangeIte
 	})
 }
 
+// AddDefaultRequest sets a single quantity on the DefaultRequest resource list.
+//
+// DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+func (d *LimitRangeItemDie) AddDefaultRequest(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
+	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.DefaultRequest == nil {
+			r.DefaultRequest = corev1.ResourceList{}
+		}
+		r.DefaultRequest[name] = quantity
+	})
+}
+
+// AddDefaultRequestString parses the quantity setting a single value on the DefaultRequest resource list. Panics if the string is not parsable.
+//
+// DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+func (d *LimitRangeItemDie) AddDefaultRequestString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
+	q := resource.MustParse(quantity)
+	return d.AddDefaultRequest(name, q)
+}
+
 // MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
 func (d *LimitRangeItemDie) MaxLimitRequestRatio(v corev1.ResourceList) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
 		r.MaxLimitRequestRatio = v
 	})
+}
+
+// AddMaxLimitRequestRatio sets a single quantity on the MaxLimitRequestRatio resource list.
+//
+// MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+func (d *LimitRangeItemDie) AddMaxLimitRequestRatio(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
+	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.MaxLimitRequestRatio == nil {
+			r.MaxLimitRequestRatio = corev1.ResourceList{}
+		}
+		r.MaxLimitRequestRatio[name] = quantity
+	})
+}
+
+// AddMaxLimitRequestRatioString parses the quantity setting a single value on the MaxLimitRequestRatio resource list. Panics if the string is not parsable.
+//
+// MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+func (d *LimitRangeItemDie) AddMaxLimitRequestRatioString(name corev1.ResourceName, quantity string) *LimitRangeItemDie {
+	q := resource.MustParse(quantity)
+	return d.AddMaxLimitRequestRatio(name, q)
 }
 
 var NamespaceBlank = (&NamespaceDie{}).DieFeed(corev1.Namespace{})
@@ -15454,6 +15674,30 @@ func (d *NodeStatusDie) Capacity(v corev1.ResourceList) *NodeStatusDie {
 	})
 }
 
+// AddCapacity sets a single quantity on the Capacity resource list.
+//
+// Capacity represents the total resources of a node.
+//
+// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+func (d *NodeStatusDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		if r.Capacity == nil {
+			r.Capacity = corev1.ResourceList{}
+		}
+		r.Capacity[name] = quantity
+	})
+}
+
+// AddCapacityString parses the quantity setting a single value on the Capacity resource list. Panics if the string is not parsable.
+//
+// Capacity represents the total resources of a node.
+//
+// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+func (d *NodeStatusDie) AddCapacityString(name corev1.ResourceName, quantity string) *NodeStatusDie {
+	q := resource.MustParse(quantity)
+	return d.AddCapacity(name, q)
+}
+
 // Allocatable represents the resources of a node that are available for scheduling.
 //
 // Defaults to Capacity.
@@ -15461,6 +15705,30 @@ func (d *NodeStatusDie) Allocatable(v corev1.ResourceList) *NodeStatusDie {
 	return d.DieStamp(func(r *corev1.NodeStatus) {
 		r.Allocatable = v
 	})
+}
+
+// AddAllocatable sets a single quantity on the Allocatable resource list.
+//
+// Allocatable represents the resources of a node that are available for scheduling.
+//
+// Defaults to Capacity.
+func (d *NodeStatusDie) AddAllocatable(name corev1.ResourceName, quantity resource.Quantity) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		if r.Allocatable == nil {
+			r.Allocatable = corev1.ResourceList{}
+		}
+		r.Allocatable[name] = quantity
+	})
+}
+
+// AddAllocatableString parses the quantity setting a single value on the Allocatable resource list. Panics if the string is not parsable.
+//
+// Allocatable represents the resources of a node that are available for scheduling.
+//
+// Defaults to Capacity.
+func (d *NodeStatusDie) AddAllocatableString(name corev1.ResourceName, quantity string) *NodeStatusDie {
+	q := resource.MustParse(quantity)
+	return d.AddAllocatable(name, q)
 }
 
 // NodePhase is the recently observed lifecycle phase of the node.
@@ -17954,6 +18222,30 @@ func (d *PersistentVolumeSpecDie) Capacity(v corev1.ResourceList) *PersistentVol
 	return d.DieStamp(func(r *corev1.PersistentVolumeSpec) {
 		r.Capacity = v
 	})
+}
+
+// AddCapacity sets a single quantity on the Capacity resource list.
+//
+// capacity is the description of the persistent volume's resources and capacity.
+//
+// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+func (d *PersistentVolumeSpecDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeSpecDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeSpec) {
+		if r.Capacity == nil {
+			r.Capacity = corev1.ResourceList{}
+		}
+		r.Capacity[name] = quantity
+	})
+}
+
+// AddCapacityString parses the quantity setting a single value on the Capacity resource list. Panics if the string is not parsable.
+//
+// capacity is the description of the persistent volume's resources and capacity.
+//
+// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+func (d *PersistentVolumeSpecDie) AddCapacityString(name corev1.ResourceName, quantity string) *PersistentVolumeSpecDie {
+	q := resource.MustParse(quantity)
+	return d.AddCapacity(name, q)
 }
 
 // persistentVolumeSource is the actual volume backing the persistent volume.
@@ -22594,6 +22886,30 @@ func (d *VolumeResourceRequirementsDie) Limits(v corev1.ResourceList) *VolumeRes
 	})
 }
 
+// AddLimit sets a single quantity on the Limits resource list.
+//
+// Limits describes the maximum amount of compute resources allowed.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *VolumeResourceRequirementsDie) AddLimit(name corev1.ResourceName, quantity resource.Quantity) *VolumeResourceRequirementsDie {
+	return d.DieStamp(func(r *corev1.VolumeResourceRequirements) {
+		if r.Limits == nil {
+			r.Limits = corev1.ResourceList{}
+		}
+		r.Limits[name] = quantity
+	})
+}
+
+// AddLimitString parses the quantity setting a single value on the Limits resource list. Panics if the string is not parsable.
+//
+// Limits describes the maximum amount of compute resources allowed.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *VolumeResourceRequirementsDie) AddLimitString(name corev1.ResourceName, quantity string) *VolumeResourceRequirementsDie {
+	q := resource.MustParse(quantity)
+	return d.AddLimit(name, q)
+}
+
 // Requests describes the minimum amount of compute resources required.
 //
 // If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
@@ -22605,6 +22921,38 @@ func (d *VolumeResourceRequirementsDie) Requests(v corev1.ResourceList) *VolumeR
 	return d.DieStamp(func(r *corev1.VolumeResourceRequirements) {
 		r.Requests = v
 	})
+}
+
+// AddRequest sets a single quantity on the Requests resource list.
+//
+// Requests describes the minimum amount of compute resources required.
+//
+// If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+//
+// otherwise to an implementation-defined value. Requests cannot exceed Limits.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *VolumeResourceRequirementsDie) AddRequest(name corev1.ResourceName, quantity resource.Quantity) *VolumeResourceRequirementsDie {
+	return d.DieStamp(func(r *corev1.VolumeResourceRequirements) {
+		if r.Requests == nil {
+			r.Requests = corev1.ResourceList{}
+		}
+		r.Requests[name] = quantity
+	})
+}
+
+// AddRequestString parses the quantity setting a single value on the Requests resource list. Panics if the string is not parsable.
+//
+// Requests describes the minimum amount of compute resources required.
+//
+// If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+//
+// otherwise to an implementation-defined value. Requests cannot exceed Limits.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *VolumeResourceRequirementsDie) AddRequestString(name corev1.ResourceName, quantity string) *VolumeResourceRequirementsDie {
+	q := resource.MustParse(quantity)
+	return d.AddRequest(name, q)
 }
 
 var PersistentVolumeClaimStatusBlank = (&PersistentVolumeClaimStatusDie{}).DieFeed(corev1.PersistentVolumeClaimStatus{})
@@ -22812,6 +23160,26 @@ func (d *PersistentVolumeClaimStatusDie) Capacity(v corev1.ResourceList) *Persis
 	})
 }
 
+// AddCapacity sets a single quantity on the Capacity resource list.
+//
+// capacity represents the actual resources of the underlying volume.
+func (d *PersistentVolumeClaimStatusDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeClaimStatusDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
+		if r.Capacity == nil {
+			r.Capacity = corev1.ResourceList{}
+		}
+		r.Capacity[name] = quantity
+	})
+}
+
+// AddCapacityString parses the quantity setting a single value on the Capacity resource list. Panics if the string is not parsable.
+//
+// capacity represents the actual resources of the underlying volume.
+func (d *PersistentVolumeClaimStatusDie) AddCapacityString(name corev1.ResourceName, quantity string) *PersistentVolumeClaimStatusDie {
+	q := resource.MustParse(quantity)
+	return d.AddCapacity(name, q)
+}
+
 // conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
 //
 // resized then the Condition will be set to 'Resizing'.
@@ -22862,6 +23230,98 @@ func (d *PersistentVolumeClaimStatusDie) AllocatedResources(v corev1.ResourceLis
 	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
 		r.AllocatedResources = v
 	})
+}
+
+// AddAllocatedResource sets a single quantity on the AllocatedResources resource list.
+//
+// allocatedResources tracks the resources allocated to a PVC including its capacity.
+//
+// Key names follow standard Kubernetes label syntax. Valid values are either:
+//
+// * Un-prefixed keys:
+//
+// - storage - the capacity of the volume.
+//
+// * Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+//
+// # Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered
+//
+// reserved and hence may not be used.
+//
+// # Capacity reported here may be larger than the actual capacity when a volume expansion operation
+//
+// is requested.
+//
+// For storage quota, the larger value from allocatedResources and PVC.spec.resources is used.
+//
+// If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.
+//
+// # If a volume expansion capacity request is lowered, allocatedResources is only
+//
+// lowered if there are no expansion operations in progress and if the actual volume capacity
+//
+// is equal or lower than the requested capacity.
+//
+// # A controller that receives PVC update with previously unknown resourceName
+//
+// should ignore the update for the purpose it was designed. For example - a controller that
+//
+// only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid
+//
+// resources associated with PVC.
+//
+// This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+func (d *PersistentVolumeClaimStatusDie) AddAllocatedResource(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeClaimStatusDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
+		if r.AllocatedResources == nil {
+			r.AllocatedResources = corev1.ResourceList{}
+		}
+		r.AllocatedResources[name] = quantity
+	})
+}
+
+// AddAllocatedResourceString parses the quantity setting a single value on the AllocatedResources resource list. Panics if the string is not parsable.
+//
+// allocatedResources tracks the resources allocated to a PVC including its capacity.
+//
+// Key names follow standard Kubernetes label syntax. Valid values are either:
+//
+// * Un-prefixed keys:
+//
+// - storage - the capacity of the volume.
+//
+// * Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+//
+// # Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered
+//
+// reserved and hence may not be used.
+//
+// # Capacity reported here may be larger than the actual capacity when a volume expansion operation
+//
+// is requested.
+//
+// For storage quota, the larger value from allocatedResources and PVC.spec.resources is used.
+//
+// If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.
+//
+// # If a volume expansion capacity request is lowered, allocatedResources is only
+//
+// lowered if there are no expansion operations in progress and if the actual volume capacity
+//
+// is equal or lower than the requested capacity.
+//
+// # A controller that receives PVC update with previously unknown resourceName
+//
+// should ignore the update for the purpose it was designed. For example - a controller that
+//
+// only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid
+//
+// resources associated with PVC.
+//
+// This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+func (d *PersistentVolumeClaimStatusDie) AddAllocatedResourceString(name corev1.ResourceName, quantity string) *PersistentVolumeClaimStatusDie {
+	q := resource.MustParse(quantity)
+	return d.AddAllocatedResource(name, q)
 }
 
 // currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
@@ -24206,6 +24666,50 @@ func (d *PodSpecDie) Overhead(v corev1.ResourceList) *PodSpecDie {
 	return d.DieStamp(func(r *corev1.PodSpec) {
 		r.Overhead = v
 	})
+}
+
+// AddOverhead sets a single quantity on the Overhead resource list.
+//
+// Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+//
+// This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+//
+// the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+//
+// # The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+//
+// set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+//
+// defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+//
+// More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+func (d *PodSpecDie) AddOverhead(name corev1.ResourceName, quantity resource.Quantity) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		if r.Overhead == nil {
+			r.Overhead = corev1.ResourceList{}
+		}
+		r.Overhead[name] = quantity
+	})
+}
+
+// AddOverheadString parses the quantity setting a single value on the Overhead resource list. Panics if the string is not parsable.
+//
+// Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+//
+// This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+//
+// the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+//
+// # The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+//
+// set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+//
+// defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+//
+// More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+func (d *PodSpecDie) AddOverheadString(name corev1.ResourceName, quantity string) *PodSpecDie {
+	q := resource.MustParse(quantity)
+	return d.AddOverhead(name, q)
 }
 
 // TopologySpreadConstraints describes how a group of pods ought to spread across topology
@@ -29262,6 +29766,30 @@ func (d *ResourceQuotaSpecDie) Hard(v corev1.ResourceList) *ResourceQuotaSpecDie
 	})
 }
 
+// AddHard sets a single quantity on the Hard resource list.
+//
+// hard is the set of desired hard limits for each named resource.
+//
+// More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+func (d *ResourceQuotaSpecDie) AddHard(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaSpecDie {
+	return d.DieStamp(func(r *corev1.ResourceQuotaSpec) {
+		if r.Hard == nil {
+			r.Hard = corev1.ResourceList{}
+		}
+		r.Hard[name] = quantity
+	})
+}
+
+// AddHardString parses the quantity setting a single value on the Hard resource list. Panics if the string is not parsable.
+//
+// hard is the set of desired hard limits for each named resource.
+//
+// More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+func (d *ResourceQuotaSpecDie) AddHardString(name corev1.ResourceName, quantity string) *ResourceQuotaSpecDie {
+	q := resource.MustParse(quantity)
+	return d.AddHard(name, q)
+}
+
 // A collection of filters that must match each object tracked by a quota.
 //
 // If not specified, the quota matches all objects.
@@ -29873,11 +30401,55 @@ func (d *ResourceQuotaStatusDie) Hard(v corev1.ResourceList) *ResourceQuotaStatu
 	})
 }
 
+// AddHard sets a single quantity on the Hard resource list.
+//
+// Hard is the set of enforced hard limits for each named resource.
+//
+// More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+func (d *ResourceQuotaStatusDie) AddHard(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaStatusDie {
+	return d.DieStamp(func(r *corev1.ResourceQuotaStatus) {
+		if r.Hard == nil {
+			r.Hard = corev1.ResourceList{}
+		}
+		r.Hard[name] = quantity
+	})
+}
+
+// AddHardString parses the quantity setting a single value on the Hard resource list. Panics if the string is not parsable.
+//
+// Hard is the set of enforced hard limits for each named resource.
+//
+// More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+func (d *ResourceQuotaStatusDie) AddHardString(name corev1.ResourceName, quantity string) *ResourceQuotaStatusDie {
+	q := resource.MustParse(quantity)
+	return d.AddHard(name, q)
+}
+
 // Used is the current observed total usage of the resource in the namespace.
 func (d *ResourceQuotaStatusDie) Used(v corev1.ResourceList) *ResourceQuotaStatusDie {
 	return d.DieStamp(func(r *corev1.ResourceQuotaStatus) {
 		r.Used = v
 	})
+}
+
+// AddUsed sets a single quantity on the Used resource list.
+//
+// Used is the current observed total usage of the resource in the namespace.
+func (d *ResourceQuotaStatusDie) AddUsed(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaStatusDie {
+	return d.DieStamp(func(r *corev1.ResourceQuotaStatus) {
+		if r.Used == nil {
+			r.Used = corev1.ResourceList{}
+		}
+		r.Used[name] = quantity
+	})
+}
+
+// AddUsedString parses the quantity setting a single value on the Used resource list. Panics if the string is not parsable.
+//
+// Used is the current observed total usage of the resource in the namespace.
+func (d *ResourceQuotaStatusDie) AddUsedString(name corev1.ResourceName, quantity string) *ResourceQuotaStatusDie {
+	q := resource.MustParse(quantity)
+	return d.AddUsed(name, q)
 }
 
 var SecretBlank = (&SecretDie{}).DieFeed(corev1.Secret{})
@@ -31381,6 +31953,23 @@ func (d *ServicePortDie) TargetPort(v intstr.IntOrString) *ServicePortDie {
 	})
 }
 
+// TargetPortInt sets TargetPort with the int value.
+//
+// Number or name of the port to access on the pods targeted by the service.
+//
+// Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+//
+// # If this is a string, it will be looked up as a named port in the
+//
+// target Pod's container ports. If this is not specified, the value
+//
+// of the 'port' field is used (an identity map).
+//
+// This field is ignored for services with clusterIP=None, and should be
+//
+// omitted or set equal to the 'port' field.
+//
+// More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
 func (d *ServicePortDie) TargetPortInt(i int) *ServicePortDie {
 	return d.DieStamp(func(r *corev1.ServicePort) {
 		v := intstr.FromInt(i)
@@ -31388,6 +31977,23 @@ func (d *ServicePortDie) TargetPortInt(i int) *ServicePortDie {
 	})
 }
 
+// TargetPortString sets TargetPort with the string value.
+//
+// Number or name of the port to access on the pods targeted by the service.
+//
+// Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+//
+// # If this is a string, it will be looked up as a named port in the
+//
+// target Pod's container ports. If this is not specified, the value
+//
+// of the 'port' field is used (an identity map).
+//
+// This field is ignored for services with clusterIP=None, and should be
+//
+// omitted or set equal to the 'port' field.
+//
+// More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
 func (d *ServicePortDie) TargetPortString(s string) *ServicePortDie {
 	return d.DieStamp(func(r *corev1.ServicePort) {
 		v := intstr.FromString(s)
@@ -33566,6 +34172,24 @@ func (d *EmptyDirVolumeSourceDie) SizeLimit(v *resource.Quantity) *EmptyDirVolum
 	return d.DieStamp(func(r *corev1.EmptyDirVolumeSource) {
 		r.SizeLimit = v
 	})
+}
+
+// SizeLimitString sets SizeLimit by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// sizeLimit is the total amount of local storage required for this EmptyDir volume.
+//
+// The size limit is also applicable for memory medium.
+//
+// # The maximum usage on memory medium EmptyDir would be the minimum value between
+//
+// the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+//
+// The default is nil which means that the limit is undefined.
+//
+// More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+func (d *EmptyDirVolumeSourceDie) SizeLimitString(s string) *EmptyDirVolumeSourceDie {
+	q := resource.MustParse(s)
+	return d.SizeLimit(&q)
 }
 
 var GCEPersistentDiskVolumeSourceBlank = (&GCEPersistentDiskVolumeSourceDie{}).DieFeed(corev1.GCEPersistentDiskVolumeSource{})

--- a/apis/networking/v1/zz_generated.die.go
+++ b/apis/networking/v1/zz_generated.die.go
@@ -4794,6 +4794,15 @@ func (d *NetworkPolicyPortDie) Port(v *intstr.IntOrString) *NetworkPolicyPortDie
 	})
 }
 
+// PortInt sets Port with the int value.
+//
+// port represents the port on the given protocol. This can either be a numerical or named
+//
+// port on a pod. If this field is not provided, this matches all port names and
+//
+// numbers.
+//
+// If present, only traffic on the specified protocol AND port will be matched.
 func (d *NetworkPolicyPortDie) PortInt(i int) *NetworkPolicyPortDie {
 	return d.DieStamp(func(r *networkingv1.NetworkPolicyPort) {
 		v := intstr.FromInt(i)
@@ -4801,6 +4810,15 @@ func (d *NetworkPolicyPortDie) PortInt(i int) *NetworkPolicyPortDie {
 	})
 }
 
+// PortString sets Port with the string value.
+//
+// port represents the port on the given protocol. This can either be a numerical or named
+//
+// port on a pod. If this field is not provided, this matches all port names and
+//
+// numbers.
+//
+// If present, only traffic on the specified protocol AND port will be matched.
 func (d *NetworkPolicyPortDie) PortString(s string) *NetworkPolicyPortDie {
 	return d.DieStamp(func(r *networkingv1.NetworkPolicyPort) {
 		v := intstr.FromString(s)

--- a/apis/node/v1/runtimeclass.go
+++ b/apis/node/v1/runtimeclass.go
@@ -19,7 +19,6 @@ package v1
 import (
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
@@ -28,19 +27,6 @@ type _ = nodev1.RuntimeClass
 
 // +die
 type _ = nodev1.Overhead
-
-func (d *OverheadDie) AddPodFixed(name corev1.ResourceName, quantity resource.Quantity) *OverheadDie {
-	return d.DieStamp(func(r *nodev1.Overhead) {
-		if r.PodFixed == nil {
-			r.PodFixed = corev1.ResourceList{}
-		}
-		r.PodFixed[name] = quantity
-	})
-}
-
-func (d *OverheadDie) AddPodFixedString(name corev1.ResourceName, quantity string) *OverheadDie {
-	return d.AddPodFixed(name, resource.MustParse(quantity))
-}
 
 // +die
 type _ = nodev1.Scheduling

--- a/apis/node/v1/zz_generated.die.go
+++ b/apis/node/v1/zz_generated.die.go
@@ -26,6 +26,7 @@ import (
 	fmtx "fmt"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -550,6 +551,26 @@ func (d *OverheadDie) PodFixed(v corev1.ResourceList) *OverheadDie {
 	return d.DieStamp(func(r *nodev1.Overhead) {
 		r.PodFixed = v
 	})
+}
+
+// AddPodFixed sets a single quantity on the PodFixed resource list.
+//
+// podFixed represents the fixed resource overhead associated with running a pod.
+func (d *OverheadDie) AddPodFixed(name corev1.ResourceName, quantity resource.Quantity) *OverheadDie {
+	return d.DieStamp(func(r *nodev1.Overhead) {
+		if r.PodFixed == nil {
+			r.PodFixed = corev1.ResourceList{}
+		}
+		r.PodFixed[name] = quantity
+	})
+}
+
+// AddPodFixedString parses the quantity setting a single value on the PodFixed resource list. Panics if the string is not parsable.
+//
+// podFixed represents the fixed resource overhead associated with running a pod.
+func (d *OverheadDie) AddPodFixedString(name corev1.ResourceName, quantity string) *OverheadDie {
+	q := resource.MustParse(quantity)
+	return d.AddPodFixed(name, q)
 }
 
 var SchedulingBlank = (&SchedulingDie{}).DieFeed(nodev1.Scheduling{})

--- a/apis/policy/v1/zz_generated.die.go
+++ b/apis/policy/v1/zz_generated.die.go
@@ -541,6 +541,15 @@ func (d *PodDisruptionBudgetSpecDie) MinAvailable(v *intstr.IntOrString) *PodDis
 	})
 }
 
+// MinAvailableInt sets MinAvailable with the int value.
+//
+// An eviction is allowed if at least "minAvailable" pods selected by
+//
+// "selector" will still be available after the eviction, i.e. even in the
+//
+// absence of the evicted pod.  So for example you can prevent all voluntary
+//
+// evictions by specifying "100%".
 func (d *PodDisruptionBudgetSpecDie) MinAvailableInt(i int) *PodDisruptionBudgetSpecDie {
 	return d.DieStamp(func(r *policyv1.PodDisruptionBudgetSpec) {
 		v := intstr.FromInt(i)
@@ -548,6 +557,15 @@ func (d *PodDisruptionBudgetSpecDie) MinAvailableInt(i int) *PodDisruptionBudget
 	})
 }
 
+// MinAvailableString sets MinAvailable with the string value.
+//
+// An eviction is allowed if at least "minAvailable" pods selected by
+//
+// "selector" will still be available after the eviction, i.e. even in the
+//
+// absence of the evicted pod.  So for example you can prevent all voluntary
+//
+// evictions by specifying "100%".
 func (d *PodDisruptionBudgetSpecDie) MinAvailableString(s string) *PodDisruptionBudgetSpecDie {
 	return d.DieStamp(func(r *policyv1.PodDisruptionBudgetSpec) {
 		v := intstr.FromString(s)
@@ -581,6 +599,15 @@ func (d *PodDisruptionBudgetSpecDie) MaxUnavailable(v *intstr.IntOrString) *PodD
 	})
 }
 
+// MaxUnavailableInt sets MaxUnavailable with the int value.
+//
+// An eviction is allowed if at most "maxUnavailable" pods selected by
+//
+// "selector" are unavailable after the eviction, i.e. even in absence of
+//
+// the evicted pod. For example, one can prevent all voluntary evictions
+//
+// by specifying 0. This is a mutually exclusive setting with "minAvailable".
 func (d *PodDisruptionBudgetSpecDie) MaxUnavailableInt(i int) *PodDisruptionBudgetSpecDie {
 	return d.DieStamp(func(r *policyv1.PodDisruptionBudgetSpec) {
 		v := intstr.FromInt(i)
@@ -588,6 +615,15 @@ func (d *PodDisruptionBudgetSpecDie) MaxUnavailableInt(i int) *PodDisruptionBudg
 	})
 }
 
+// MaxUnavailableString sets MaxUnavailable with the string value.
+//
+// An eviction is allowed if at most "maxUnavailable" pods selected by
+//
+// "selector" are unavailable after the eviction, i.e. even in absence of
+//
+// the evicted pod. For example, one can prevent all voluntary evictions
+//
+// by specifying 0. This is a mutually exclusive setting with "minAvailable".
 func (d *PodDisruptionBudgetSpecDie) MaxUnavailableString(s string) *PodDisruptionBudgetSpecDie {
 	return d.DieStamp(func(r *policyv1.PodDisruptionBudgetSpec) {
 		v := intstr.FromString(s)

--- a/apis/storage/v1/csistoragecapacities.go
+++ b/apis/storage/v1/csistoragecapacities.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	storagev1 "k8s.io/api/storage/v1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -31,14 +30,4 @@ func (d *CSIStorageCapacityDie) NodeTopologyDie(fn func(d *diemetav1.LabelSelect
 		fn(d)
 		r.NodeTopology = d.DieReleasePtr()
 	})
-}
-
-func (d *CSIStorageCapacityDie) CapacityString(quantity string) *CSIStorageCapacityDie {
-	q := resource.MustParse(quantity)
-	return d.Capacity(&q)
-}
-
-func (d *CSIStorageCapacityDie) MaximumVolumeSizeString(quantity string) *CSIStorageCapacityDie {
-	q := resource.MustParse(quantity)
-	return d.MaximumVolumeSize(&q)
 }

--- a/apis/storage/v1/zz_generated.die.go
+++ b/apis/storage/v1/zz_generated.die.go
@@ -26,7 +26,7 @@ import (
 	fmtx "fmt"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -2202,6 +2202,26 @@ func (d *CSIStorageCapacityDie) Capacity(v *resource.Quantity) *CSIStorageCapaci
 	})
 }
 
+// CapacityString sets Capacity by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// capacity is the value reported by the CSI driver in its GetCapacityResponse
+//
+// for a GetCapacityRequest with topology and parameters that match the
+//
+// previous fields.
+//
+// The semantic is currently (CSI spec 1.2) defined as:
+//
+// # The available capacity, in bytes, of the storage that can be used
+//
+// to provision volumes. If not set, that information is currently
+//
+// unavailable.
+func (d *CSIStorageCapacityDie) CapacityString(s string) *CSIStorageCapacityDie {
+	q := resource.MustParse(s)
+	return d.Capacity(&q)
+}
+
 // maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse
 //
 // for a GetCapacityRequest with topology and parameters that match the
@@ -2223,6 +2243,30 @@ func (d *CSIStorageCapacityDie) MaximumVolumeSize(v *resource.Quantity) *CSIStor
 	return d.DieStamp(func(r *storagev1.CSIStorageCapacity) {
 		r.MaximumVolumeSize = v
 	})
+}
+
+// MaximumVolumeSizeString sets MaximumVolumeSize by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse
+//
+// for a GetCapacityRequest with topology and parameters that match the
+//
+// previous fields.
+//
+// # This is defined since CSI spec 1.4.0 as the largest size
+//
+// that may be used in a
+//
+// CreateVolumeRequest.capacity_range.required_bytes field to
+//
+// create a volume with the same parameters as those in
+//
+// GetCapacityRequest. The corresponding value in the Kubernetes
+//
+// API is ResourceRequirements.Requests in a volume claim.
+func (d *CSIStorageCapacityDie) MaximumVolumeSizeString(s string) *CSIStorageCapacityDie {
+	q := resource.MustParse(s)
+	return d.MaximumVolumeSize(&q)
 }
 
 var StorageClassBlank = (&StorageClassDie{}).DieFeed(storagev1.StorageClass{})

--- a/apis/storage/v1beta1/csistoragecapacity.go
+++ b/apis/storage/v1beta1/csistoragecapacity.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -31,14 +30,4 @@ func (d *CSIStorageCapacityDie) NodeTopologyDie(fn func(d *diemetav1.LabelSelect
 		fn(d)
 		r.NodeTopology = d.DieReleasePtr()
 	})
-}
-
-func (d *CSIStorageCapacityDie) CapacityString(quantity string) *CSIStorageCapacityDie {
-	q := resource.MustParse(quantity)
-	return d.Capacity(&q)
-}
-
-func (d *CSIStorageCapacityDie) MaximumVolumeSizeString(quantity string) *CSIStorageCapacityDie {
-	q := resource.MustParse(quantity)
-	return d.MaximumVolumeSize(&q)
 }

--- a/apis/storage/v1beta1/zz_generated.die.go
+++ b/apis/storage/v1beta1/zz_generated.die.go
@@ -25,7 +25,7 @@ import (
 	json "encoding/json"
 	fmtx "fmt"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -365,6 +365,26 @@ func (d *CSIStorageCapacityDie) Capacity(v *resource.Quantity) *CSIStorageCapaci
 	})
 }
 
+// CapacityString sets Capacity by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// capacity is the value reported by the CSI driver in its GetCapacityResponse
+//
+// for a GetCapacityRequest with topology and parameters that match the
+//
+// previous fields.
+//
+// The semantic is currently (CSI spec 1.2) defined as:
+//
+// # The available capacity, in bytes, of the storage that can be used
+//
+// to provision volumes. If not set, that information is currently
+//
+// unavailable.
+func (d *CSIStorageCapacityDie) CapacityString(s string) *CSIStorageCapacityDie {
+	q := resource.MustParse(s)
+	return d.Capacity(&q)
+}
+
 // maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse
 //
 // for a GetCapacityRequest with topology and parameters that match the
@@ -386,4 +406,28 @@ func (d *CSIStorageCapacityDie) MaximumVolumeSize(v *resource.Quantity) *CSIStor
 	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
 		r.MaximumVolumeSize = v
 	})
+}
+
+// MaximumVolumeSizeString sets MaximumVolumeSize by parsing the string as a Quantity. Panics if the string is not parsable.
+//
+// maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse
+//
+// for a GetCapacityRequest with topology and parameters that match the
+//
+// previous fields.
+//
+// # This is defined since CSI spec 1.4.0 as the largest size
+//
+// that may be used in a
+//
+// CreateVolumeRequest.capacity_range.required_bytes field to
+//
+// create a volume with the same parameters as those in
+//
+// GetCapacityRequest. The corresponding value in the Kubernetes
+//
+// API is ResourceRequirements.Requests in a volume claim.
+func (d *CSIStorageCapacityDie) MaximumVolumeSizeString(s string) *CSIStorageCapacityDie {
+	q := resource.MustParse(s)
+	return d.MaximumVolumeSize(&q)
 }


### PR DESCRIPTION
Dies that have fields of resource.Quantity or corev1.ResourceList often have setter methods to parse a string formatted quantity into the structured value. Rather than the user defining these values, we can generate them when we see a field of the type.

for resource.Quantity:
```
func (d *MyResourceDie) CapacityString(quantity string) *MyResourceDie {
	q := resource.MustParse(quantity)
	return d.Capacity(q)
}
```

for corev1.ResourceList:
```
func (d *MyResourceDie) AddLimit(name corev1.ResourceName, quantity resource.Quantity) *MyResourceDie {
	return d.DieStamp(func(r *corev1.ResourceQuotaSpec) {
		if r.Limits == nil {
			r.Limits = corev1.ResourceList{}
		}
		r.Limits[name] = quantity
	})
}

func (d *MyResourceDie) AddLimitString(name corev1.ResourceName, quantity string) *MyResourceDie {
    q := resource.MustParse(quantity)
	return d.AddLimit(name, q)
}
```