### PR TITLE
Generate mutation die helpers for fields

### DIFF
--- a/apis/admission/v1/admissionrequest.go
+++ b/apis/admission/v1/admissionrequest.go
@@ -18,49 +18,12 @@ package v1
 
 import (
 	admissionv1 "k8s.io/api/admission/v1"
-	dieauthenticationv1 "reconciler.io/dies/apis/authentication/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die
+// +die:field:name=Kind,package=_/meta/v1,die=GroupVersionKindDie
+// +die:field:name=Resource,package=_/meta/v1,die=GroupVersionResourceDie
+// +die:field:name=RequestKind,package=_/meta/v1,die=GroupVersionKindDie,pointer=true
+// +die:field:name=RequestResource,package=_/meta/v1,die=GroupVersionResourceDie,pointer=true
+// +die:field:name=UserInfo,package=_/authentication/v1,die=UserInfoDie
 type _ = admissionv1.AdmissionRequest
-
-func (d *AdmissionRequestDie) KindDie(fn func(d *diemetav1.GroupVersionKindDie)) *AdmissionRequestDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionRequest) {
-		d := diemetav1.GroupVersionKindBlank.DieImmutable(false).DieFeed(r.Kind)
-		fn(d)
-		r.Kind = d.DieRelease()
-	})
-}
-
-func (d *AdmissionRequestDie) ResourceDie(fn func(d *diemetav1.GroupVersionResourceDie)) *AdmissionRequestDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionRequest) {
-		d := diemetav1.GroupVersionResourceBlank.DieImmutable(false).DieFeed(r.Resource)
-		fn(d)
-		r.Resource = d.DieRelease()
-	})
-}
-
-func (d *AdmissionRequestDie) RequestKindDie(fn func(d *diemetav1.GroupVersionKindDie)) *AdmissionRequestDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionRequest) {
-		d := diemetav1.GroupVersionKindBlank.DieImmutable(false).DieFeedPtr(r.RequestKind)
-		fn(d)
-		r.RequestKind = d.DieReleasePtr()
-	})
-}
-
-func (d *AdmissionRequestDie) RequestResourceDie(fn func(d *diemetav1.GroupVersionResourceDie)) *AdmissionRequestDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionRequest) {
-		d := diemetav1.GroupVersionResourceBlank.DieImmutable(false).DieFeedPtr(r.RequestResource)
-		fn(d)
-		r.RequestResource = d.DieReleasePtr()
-	})
-}
-
-func (d *AdmissionRequestDie) UserInfoDie(fn func(d *dieauthenticationv1.UserInfoDie)) *AdmissionRequestDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionRequest) {
-		d := dieauthenticationv1.UserInfoBlank.DieImmutable(false).DieFeed(r.UserInfo)
-		fn(d)
-		r.UserInfo = d.DieRelease()
-	})
-}

--- a/apis/admission/v1/admissionresponse.go
+++ b/apis/admission/v1/admissionresponse.go
@@ -18,19 +18,11 @@ package v1
 
 import (
 	admissionv1 "k8s.io/api/admission/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die
+// +die:field:name=Result,package=_/meta/v1,die=StatusDie,pointer=true
 type _ = admissionv1.AdmissionResponse
-
-func (d *AdmissionResponseDie) ResultDie(fn func(d *diemetav1.StatusDie)) *AdmissionResponseDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionResponse) {
-		d := diemetav1.StatusBlank.DieImmutable(false).DieFeedPtr(r.Result)
-		fn(d)
-		r.Result = d.DieReleasePtr()
-	})
-}
 
 func (d *AdmissionResponseDie) AddAuditAnnotation(key, value string) *AdmissionResponseDie {
 	return d.DieStamp(func(r *admissionv1.AdmissionResponse) {

--- a/apis/admission/v1/admissionreview.go
+++ b/apis/admission/v1/admissionreview.go
@@ -21,20 +21,6 @@ import (
 )
 
 // +die
+// +die:field:name=Request,die=AdmissionRequestDie,pointer=true
+// +die:field:name=Response,die=AdmissionResponseDie,pointer=true
 type _ = admissionv1.AdmissionReview
-
-func (d *AdmissionReviewDie) RequestDie(fn func(d *AdmissionRequestDie)) *AdmissionReviewDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionReview) {
-		d := AdmissionRequestBlank.DieImmutable(false).DieFeedPtr(r.Request)
-		fn(d)
-		r.Request = d.DieReleasePtr()
-	})
-}
-
-func (d *AdmissionReviewDie) ResponseDie(fn func(d *AdmissionResponseDie)) *AdmissionReviewDie {
-	return d.DieStamp(func(r *admissionv1.AdmissionReview) {
-		d := AdmissionResponseBlank.DieImmutable(false).DieFeedPtr(r.Response)
-		fn(d)
-		r.Response = d.DieReleasePtr()
-	})
-}

--- a/apis/admissionregistration/v1/common.go
+++ b/apis/admissionregistration/v1/common.go
@@ -21,15 +21,8 @@ import (
 )
 
 // +die
+// +die:field:name=Service,die=ServiceReferenceDie,pointer=true
 type _ = admissionregistrationv1.WebhookClientConfig
-
-func (d *WebhookClientConfigDie) ServiceDie(fn func(d *ServiceReferenceDie)) *WebhookClientConfigDie {
-	return d.DieStamp(func(r *admissionregistrationv1.WebhookClientConfig) {
-		d := ServiceReferenceBlank.DieImmutable(false).DieFeedPtr(r.Service)
-		fn(d)
-		r.Service = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ admissionregistrationv1.ServiceReference

--- a/apis/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/apis/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -18,78 +18,16 @@ package v1
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=admissionregistration.k8s.io/v1,kind=MutatingWebhookConfiguration
+// +die:field:name=Webhooks,die=MutatingWebhookDie,listType=map
 type _ = admissionregistrationv1.MutatingWebhookConfiguration
 
-func (d *MutatingWebhookConfigurationDie) WebhookDie(name string, fn func(d *MutatingWebhookDie)) *MutatingWebhookConfigurationDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhookConfiguration) {
-		for i := range r.Webhooks {
-			if name == r.Webhooks[i].Name {
-				d := MutatingWebhookBlank.DieImmutable(false).DieFeed(r.Webhooks[i])
-				fn(d)
-				r.Webhooks[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := MutatingWebhookBlank.DieImmutable(false).DieFeed(admissionregistrationv1.MutatingWebhook{Name: name})
-		fn(d)
-		r.Webhooks = append(r.Webhooks, d.DieRelease())
-	})
-}
-
 // +die
+// +die:field:name=ClientConfig,die=WebhookClientConfigDie
+// +die:field:name=NamespaceSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=ObjectSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Rules,die=RuleWithOperationsDie,listType=atomic
+// +die:field:name=MatchConditions,die=MatchConditionDie,listType=map
 type _ = admissionregistrationv1.MutatingWebhook
-
-func (d *MutatingWebhookDie) ClientConfigDie(fn func(d *WebhookClientConfigDie)) *MutatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhook) {
-		d := WebhookClientConfigBlank.DieImmutable(false).DieFeed(r.ClientConfig)
-		fn(d)
-		r.ClientConfig = d.DieRelease()
-	})
-}
-
-func (d *MutatingWebhookDie) RulesDie(rules ...*RuleWithOperationsDie) *MutatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhook) {
-		r.Rules = make([]admissionregistrationv1.RuleWithOperations, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
-
-func (d *MutatingWebhookDie) NamespaceSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *MutatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhook) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.NamespaceSelector)
-		fn(d)
-		r.NamespaceSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *MutatingWebhookDie) ObjectSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *MutatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhook) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.ObjectSelector)
-		fn(d)
-		r.ObjectSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *MutatingWebhookDie) MatchConditionDie(name string, fn func(d *MatchConditionDie)) *MutatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MutatingWebhook) {
-		for i := range r.MatchConditions {
-			if name == r.MatchConditions[i].Name {
-				d := MatchConditionBlank.DieImmutable(false).DieFeed(r.MatchConditions[i])
-				fn(d)
-				r.MatchConditions[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := MatchConditionBlank.DieImmutable(false).DieFeed(admissionregistrationv1.MatchCondition{Name: name})
-		fn(d)
-		r.MatchConditions = append(r.MatchConditions, d.DieRelease())
-	})
-}

--- a/apis/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/apis/admissionregistration/v1/validatingadmissionpolicy.go
@@ -18,123 +18,34 @@ package v1
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=admissionregistration.k8s.io/v1,kind=ValidatingAdmissionPolicy
 type _ = admissionregistrationv1.ValidatingAdmissionPolicy
 
 // +die
+// +die:field:name=ParamKind,die=ParamKindDie,pointer=true
+// +die:field:name=MatchConstraints,die=MatchResourcesDie,pointer=true
+// +die:field:name=Validations,die=ValidationDie,listType=atomic
+// +die:field:name=AuditAnnotations,die=AuditAnnotationDie,listType=atomic
+// +die:field:name=MatchConditions,die=MatchConditionDie,listType=map
+// +die:field:name=Variables,die=VariableDie,listType=map
 type _ = admissionregistrationv1.ValidatingAdmissionPolicySpec
 
-func (d *ValidatingAdmissionPolicySpecDie) ParamKindDie(fn func(d *ParamKindDie)) *ValidatingAdmissionPolicySpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicySpec) {
-		d := ParamKindBlank.DieImmutable(false).DieFeedPtr(r.ParamKind)
-		fn(d)
-		r.ParamKind = d.DieReleasePtr()
-	})
-}
-
-func (d *ValidatingAdmissionPolicySpecDie) MatchConstraintsDie(fn func(d *MatchResourcesDie)) *ValidatingAdmissionPolicySpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicySpec) {
-		d := MatchResourcesBlank.DieImmutable(false).DieFeedPtr(r.MatchConstraints)
-		fn(d)
-		r.MatchConstraints = d.DieReleasePtr()
-	})
-}
-
-func (d *ValidatingAdmissionPolicySpecDie) ValidationsDie(validations ...*ValidationDie) *ValidatingAdmissionPolicySpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicySpec) {
-		r.Validations = make([]admissionregistrationv1.Validation, len(validations))
-		for i := range validations {
-			r.Validations[i] = validations[i].DieRelease()
-		}
-	})
-}
-
-func (d *ValidatingAdmissionPolicySpecDie) AuditAnnotationsDie(annotations ...*AuditAnnotationDie) *ValidatingAdmissionPolicySpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicySpec) {
-		r.AuditAnnotations = make([]admissionregistrationv1.AuditAnnotation, len(annotations))
-		for i := range annotations {
-			r.AuditAnnotations[i] = annotations[i].DieRelease()
-		}
-	})
-}
-
-func (d *ValidatingAdmissionPolicySpecDie) MatchConditionDie(name string, fn func(d *MatchConditionDie)) *ValidatingAdmissionPolicySpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicySpec) {
-		for i := range r.MatchConditions {
-			if name == r.MatchConditions[i].Name {
-				d := MatchConditionBlank.DieImmutable(false).DieFeed(r.MatchConditions[i])
-				fn(d)
-				r.MatchConditions[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := MatchConditionBlank.DieImmutable(false).DieFeed(admissionregistrationv1.MatchCondition{Name: name})
-		fn(d)
-		r.MatchConditions = append(r.MatchConditions, d.DieRelease())
-	})
-}
-
+// deprecated: use VariableDie instead
 func (d *ValidatingAdmissionPolicySpecDie) VariablesDie(name string, fn func(d *VariableDie)) *ValidatingAdmissionPolicySpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicySpec) {
-		for i := range r.Variables {
-			if name == r.Variables[i].Name {
-				d := VariableBlank.DieImmutable(false).DieFeed(r.Variables[i])
-				fn(d)
-				r.Variables[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := VariableBlank.DieImmutable(false).DieFeed(admissionregistrationv1.Variable{Name: name})
-		fn(d)
-		r.Variables = append(r.Variables, d.DieRelease())
-	})
+	return d.VariableDie(name, fn)
 }
 
 // +die
 type _ = admissionregistrationv1.ParamKind
 
 // +die
+// +die:field:name=NamespaceSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=ObjectSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=ResourceRules,die=NamedRuleWithOperationsDie,listType=atomic
+// +die:field:name=ExcludeResourceRules,die=NamedRuleWithOperationsDie,listType=atomic
 type _ = admissionregistrationv1.MatchResources
-
-func (d *MatchResourcesDie) NamespaceSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *MatchResourcesDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MatchResources) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.NamespaceSelector)
-		fn(d)
-		r.NamespaceSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *MatchResourcesDie) ObjectSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *MatchResourcesDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MatchResources) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.ObjectSelector)
-		fn(d)
-		r.ObjectSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *MatchResourcesDie) ResourceRulesDie(rules ...*NamedRuleWithOperationsDie) *MatchResourcesDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MatchResources) {
-		r.ResourceRules = make([]admissionregistrationv1.NamedRuleWithOperations, len(rules))
-		for i := range rules {
-			r.ResourceRules[i] = rules[i].DieRelease()
-		}
-	})
-}
-
-func (d *MatchResourcesDie) ExcludeResourceRulesDie(rules ...*NamedRuleWithOperationsDie) *MatchResourcesDie {
-	return d.DieStamp(func(r *admissionregistrationv1.MatchResources) {
-		r.ExcludeResourceRules = make([]admissionregistrationv1.NamedRuleWithOperations, len(rules))
-		for i := range rules {
-			r.ExcludeResourceRules[i] = rules[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = admissionregistrationv1.NamedRuleWithOperations
@@ -185,36 +96,13 @@ type _ = admissionregistrationv1.AuditAnnotation
 type _ = admissionregistrationv1.Variable
 
 // +die
+// +die:field:name=TypeChecking,die=TypeCheckingDie,pointer=true
+// +die:field:name=Conditions,package=_/meta/v1,die=ConditionDie,listType=atomic
 type _ = admissionregistrationv1.ValidatingAdmissionPolicyStatus
 
-func (d *ValidatingAdmissionPolicyStatusDie) TypeCheckingDie(fn func(d *TypeCheckingDie)) *ValidatingAdmissionPolicyStatusDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicyStatus) {
-		d := TypeCheckingBlank.DieImmutable(false).DieFeedPtr(r.TypeChecking)
-		fn(d)
-		r.TypeChecking = d.DieReleasePtr()
-	})
-}
-
-func (d *ValidatingAdmissionPolicyStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *ValidatingAdmissionPolicyStatusDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicyStatus) {
-		r.Conditions = make([]metav1.Condition, len(conditions))
-		for i := range conditions {
-			r.Conditions[i] = conditions[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=ExpressionWarnings,die=ExpressionWarningDie,listType=atomic
 type _ = admissionregistrationv1.TypeChecking
-
-func (d *TypeCheckingDie) ExpressionWarningsDie(warnings ...*ExpressionWarningDie) *TypeCheckingDie {
-	return d.DieStamp(func(r *admissionregistrationv1.TypeChecking) {
-		r.ExpressionWarnings = make([]admissionregistrationv1.ExpressionWarning, len(warnings))
-		for i := range warnings {
-			r.ExpressionWarnings[i] = warnings[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = admissionregistrationv1.ExpressionWarning

--- a/apis/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/apis/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -18,38 +18,16 @@ package v1
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=admissionregistration.k8s.io/v1,kind=ValidatingAdmissionPolicyBinding
 type _ = admissionregistrationv1.ValidatingAdmissionPolicyBinding
 
 // +die
+// +die:field:name=ParamRef,die=ParamRefDie,pointer=true
+// +die:field:name=MatchResources,die=MatchResourcesDie,pointer=true
 type _ = admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec
 
-func (d *ValidatingAdmissionPolicyBindingSpecDie) ParamRefDie(fn func(d *ParamRefDie)) *ValidatingAdmissionPolicyBindingSpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec) {
-		d := ParamRefBlank.DieImmutable(false).DieFeedPtr(r.ParamRef)
-		fn(d)
-		r.ParamRef = d.DieReleasePtr()
-	})
-}
-
-func (d *ValidatingAdmissionPolicyBindingSpecDie) MatchResourcesDie(fn func(d *MatchResourcesDie)) *ValidatingAdmissionPolicyBindingSpecDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec) {
-		d := MatchResourcesBlank.DieImmutable(false).DieFeedPtr(r.MatchResources)
-		fn(d)
-		r.MatchResources = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
 type _ = admissionregistrationv1.ParamRef
-
-func (d *ParamRefDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *ParamRefDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ParamRef) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}

--- a/apis/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/apis/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -18,78 +18,16 @@ package v1
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=admissionregistration.k8s.io/v1,kind=ValidatingWebhookConfiguration
+// +die:field:name=Webhooks,die=ValidatingWebhookDie,listType=map
 type _ = admissionregistrationv1.ValidatingWebhookConfiguration
 
-func (d *ValidatingWebhookConfigurationDie) WebhookDie(name string, fn func(d *ValidatingWebhookDie)) *ValidatingWebhookConfigurationDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhookConfiguration) {
-		for i := range r.Webhooks {
-			if name == r.Webhooks[i].Name {
-				d := ValidatingWebhookBlank.DieImmutable(false).DieFeed(r.Webhooks[i])
-				fn(d)
-				r.Webhooks[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ValidatingWebhookBlank.DieImmutable(false).DieFeed(admissionregistrationv1.ValidatingWebhook{Name: name})
-		fn(d)
-		r.Webhooks = append(r.Webhooks, d.DieRelease())
-	})
-}
-
 // +die
+// +die:field:name=ClientConfig,die=WebhookClientConfigDie
+// +die:field:name=NamespaceSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=ObjectSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Rules,die=RuleWithOperationsDie,listType=atomic
+// +die:field:name=MatchConditions,die=MatchConditionDie,listType=map
 type _ = admissionregistrationv1.ValidatingWebhook
-
-func (d *ValidatingWebhookDie) ClientConfigDie(fn func(d *WebhookClientConfigDie)) *ValidatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhook) {
-		d := WebhookClientConfigBlank.DieImmutable(false).DieFeed(r.ClientConfig)
-		fn(d)
-		r.ClientConfig = d.DieRelease()
-	})
-}
-
-func (d *ValidatingWebhookDie) RulesDie(rules ...*RuleWithOperationsDie) *ValidatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhook) {
-		r.Rules = make([]admissionregistrationv1.RuleWithOperations, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
-
-func (d *ValidatingWebhookDie) NamespaceSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *ValidatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhook) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.NamespaceSelector)
-		fn(d)
-		r.NamespaceSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *ValidatingWebhookDie) ObjectSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *ValidatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhook) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.ObjectSelector)
-		fn(d)
-		r.ObjectSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *ValidatingWebhookDie) MatchConditionDie(name string, fn func(d *MatchConditionDie)) *ValidatingWebhookDie {
-	return d.DieStamp(func(r *admissionregistrationv1.ValidatingWebhook) {
-		for i := range r.MatchConditions {
-			if name == r.MatchConditions[i].Name {
-				d := MatchConditionBlank.DieImmutable(false).DieFeed(r.MatchConditions[i])
-				fn(d)
-				r.MatchConditions[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := MatchConditionBlank.DieImmutable(false).DieFeed(admissionregistrationv1.MatchCondition{Name: name})
-		fn(d)
-		r.MatchConditions = append(r.MatchConditions, d.DieRelease())
-	})
-}

--- a/apis/apiextensions/v1/customresourcedefinition.go
+++ b/apis/apiextensions/v1/customresourcedefinition.go
@@ -25,99 +25,24 @@ import (
 type _ = apiextensionsv1.CustomResourceDefinition
 
 // +die
+// +die:field:name=Names,die=CustomResourceDefinitionNamesDie
+// +die:field:name=Conversion,die=CustomResourceConversionDie,pointer=true
+// +die:field:name=Versions,die=CustomResourceDefinitionVersionDie,listType=map
 type _ = apiextensionsv1.CustomResourceDefinitionSpec
 
-func (d *CustomResourceDefinitionSpecDie) NamesDie(fn func(d *CustomResourceDefinitionNamesDie)) *CustomResourceDefinitionSpecDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionSpec) {
-		d := CustomResourceDefinitionNamesBlank.DieImmutable(false).DieFeed(r.Names)
-		fn(d)
-		r.Names = d.DieRelease()
-	})
-}
-
-func (d *CustomResourceDefinitionSpecDie) VersionDie(name string, fn func(d *CustomResourceDefinitionVersionDie)) *CustomResourceDefinitionSpecDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionSpec) {
-		for i := range r.Versions {
-			if name == r.Versions[i].Name {
-				d := CustomResourceDefinitionVersionBlank.DieImmutable(false).DieFeed(r.Versions[i])
-				fn(d)
-				r.Versions[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := CustomResourceDefinitionVersionBlank.DieImmutable(false).DieFeed(apiextensionsv1.CustomResourceDefinitionVersion{Name: name})
-		fn(d)
-		r.Versions = append(r.Versions, d.DieRelease())
-	})
-}
-
-func (d *CustomResourceDefinitionSpecDie) ConversionDie(fn func(d *CustomResourceConversionDie)) *CustomResourceDefinitionSpecDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionSpec) {
-		d := CustomResourceConversionBlank.DieImmutable(false).DieFeedPtr(r.Conversion)
-		fn(d)
-		r.Conversion = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Schema,die=CustomResourceValidationDie,pointer=true
+// +die:field:name=Subresources,die=CustomResourceSubresourcesDie,pointer=true
+// +die:field:name=AdditionalPrinterColumns,die=CustomResourceColumnDefinitionDie,listType=map
+// +die:field:name=SelectableFields,die=SelectableFieldDie,listType=atomic
 type _ apiextensionsv1.CustomResourceDefinitionVersion
-
-func (d *CustomResourceDefinitionVersionDie) SchemaDie(fn func(d *CustomResourceValidationDie)) *CustomResourceDefinitionVersionDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionVersion) {
-		d := CustomResourceValidationBlank.DieImmutable(false).DieFeedPtr(r.Schema)
-		fn(d)
-		r.Schema = d.DieReleasePtr()
-	})
-}
-
-func (d *CustomResourceDefinitionVersionDie) SubresourcesDie(fn func(d *CustomResourceSubresourcesDie)) *CustomResourceDefinitionVersionDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionVersion) {
-		d := CustomResourceSubresourcesBlank.DieImmutable(false).DieFeedPtr(r.Subresources)
-		fn(d)
-		r.Subresources = d.DieReleasePtr()
-	})
-}
-
-func (d *CustomResourceDefinitionVersionDie) AdditionalPrinterColumnDie(name string, fn func(d *CustomResourceColumnDefinitionDie)) *CustomResourceDefinitionVersionDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionVersion) {
-		for i := range r.AdditionalPrinterColumns {
-			if name == r.AdditionalPrinterColumns[i].Name {
-				d := CustomResourceColumnDefinitionBlank.DieImmutable(false).DieFeed(r.AdditionalPrinterColumns[i])
-				fn(d)
-				r.AdditionalPrinterColumns[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := CustomResourceColumnDefinitionBlank.DieImmutable(false).DieFeed(apiextensionsv1.CustomResourceColumnDefinition{Name: name})
-		fn(d)
-		r.AdditionalPrinterColumns = append(r.AdditionalPrinterColumns, d.DieRelease())
-	})
-}
-
-func (d *CustomResourceDefinitionVersionDie) SelectableFieldsDie(fields ...*SelectableFieldDie) *CustomResourceDefinitionVersionDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionVersion) {
-		r.SelectableFields = make([]apiextensionsv1.SelectableField, len(fields))
-		for i := range fields {
-			r.SelectableFields[i] = fields[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ apiextensionsv1.CustomResourceValidation
 
 // +die
+// +die:field:name=Scale,die=CustomResourceSubresourceScaleDie,pointer=true
 type _ apiextensionsv1.CustomResourceSubresources
-
-func (d *CustomResourceSubresourcesDie) ScaleDie(fn func(d *CustomResourceSubresourceScaleDie)) *CustomResourceSubresourcesDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceSubresources) {
-		d := CustomResourceSubresourceScaleBlank.DieImmutable(false).DieFeedPtr(r.Scale)
-		fn(d)
-		r.Scale = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ apiextensionsv1.CustomResourceSubresourceScale
@@ -126,37 +51,16 @@ type _ apiextensionsv1.CustomResourceSubresourceScale
 type _ apiextensionsv1.CustomResourceColumnDefinition
 
 // +die
+// +die:field:name=Webhook,die=WebhookConversionDie,pointer=true
 type _ apiextensionsv1.CustomResourceConversion
 
-func (d *CustomResourceConversionDie) WebhookDie(fn func(d *WebhookConversionDie)) *CustomResourceConversionDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceConversion) {
-		d := WebhookConversionBlank.DieImmutable(false).DieFeedPtr(r.Webhook)
-		fn(d)
-		r.Webhook = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=ClientConfig,die=WebhookClientConfigDie,pointer=true
 type _ apiextensionsv1.WebhookConversion
 
-func (d *WebhookConversionDie) ClientConfigDie(fn func(d *WebhookClientConfigDie)) *WebhookConversionDie {
-	return d.DieStamp(func(r *apiextensionsv1.WebhookConversion) {
-		d := WebhookClientConfigBlank.DieImmutable(false).DieFeedPtr(r.ClientConfig)
-		fn(d)
-		r.ClientConfig = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Service,die=ServiceReferenceDie,pointer=true
 type _ apiextensionsv1.WebhookClientConfig
-
-func (d *WebhookClientConfigDie) ServiceDie(fn func(d *ServiceReferenceDie)) *WebhookClientConfigDie {
-	return d.DieStamp(func(r *apiextensionsv1.WebhookClientConfig) {
-		d := ServiceReferenceBlank.DieImmutable(false).DieFeedPtr(r.Service)
-		fn(d)
-		r.Service = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ apiextensionsv1.ServiceReference
@@ -165,6 +69,7 @@ type _ apiextensionsv1.ServiceReference
 type _ apiextensionsv1.SelectableField
 
 // +die
+// +die:field:name=AcceptedNames,die=CustomResourceDefinitionNamesDie
 type _ = apiextensionsv1.CustomResourceDefinitionStatus
 
 func (d *CustomResourceDefinitionStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *CustomResourceDefinitionStatusDie {
@@ -180,14 +85,6 @@ func (d *CustomResourceDefinitionStatusDie) ConditionsDie(conditions ...*diemeta
 				LastTransitionTime: c.LastTransitionTime,
 			}
 		}
-	})
-}
-
-func (d *CustomResourceDefinitionStatusDie) AcceptedNamesDie(fn func(d *CustomResourceDefinitionNamesDie)) *CustomResourceDefinitionStatusDie {
-	return d.DieStamp(func(r *apiextensionsv1.CustomResourceDefinitionStatus) {
-		d := CustomResourceDefinitionNamesBlank.DieImmutable(false).DieFeed(r.AcceptedNames)
-		fn(d)
-		r.AcceptedNames = d.DieRelease()
 	})
 }
 

--- a/apis/apiregistration/v1/apiservice.go
+++ b/apis/apiregistration/v1/apiservice.go
@@ -25,15 +25,8 @@ import (
 type _ = apiregistrationv1.APIService
 
 // +die
+// +die:field:name=Service,die=ServiceReferenceDie,pointer=true
 type _ = apiregistrationv1.APIServiceSpec
-
-func (d *APIServiceSpecDie) TargetDie(fn func(d *ServiceReferenceDie)) *APIServiceSpecDie {
-	return d.DieStamp(func(r *apiregistrationv1.APIServiceSpec) {
-		d := ServiceReferenceBlank.DieImmutable(false).DieFeedPtr(r.Service)
-		fn(d)
-		r.Service = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = apiregistrationv1.ServiceReference

--- a/apis/apiregistration/v1/zz_generated.die.go
+++ b/apis/apiregistration/v1/zz_generated.die.go
@@ -622,6 +622,23 @@ func (d *APIServiceSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) 
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ServiceDie mutates Service as a die.
+//
+// Service is a reference to the service for this API server.  It must communicate
+//
+// on port 443.
+//
+// If the Service is nil, that means the handling for the API groupversion is handled locally on this server.
+//
+// The call will simply delegate to the normal handler chain to be fulfilled.
+func (d *APIServiceSpecDie) ServiceDie(fn func(d *ServiceReferenceDie)) *APIServiceSpecDie {
+	return d.DieStamp(func(r *apiregistration.APIServiceSpec) {
+		d := ServiceReferenceBlank.DieImmutable(false).DieFeedPtr(r.Service)
+		fn(d)
+		r.Service = d.DieReleasePtr()
+	})
+}
+
 // Service is a reference to the service for this API server.  It must communicate
 //
 // on port 443.

--- a/apis/apiserver/flowcontrol/v1beta1/flowschema.go
+++ b/apis/apiserver/flowcontrol/v1beta1/flowschema.go
@@ -25,32 +25,10 @@ import (
 type _ = flowcontrolv1beta1.FlowSchema
 
 // +die
+// +die:field:name=PriorityLevelConfiguration,die=PriorityLevelConfigurationReferenceDie
+// +die:field:name=DistinguisherMethod,die=FlowDistinguisherMethodDie,pointer=true
+// +die:field:name=Rules,die=PolicyRulesWithSubjectsDie,listType=atomic
 type _ = flowcontrolv1beta1.FlowSchemaSpec
-
-func (d *FlowSchemaSpecDie) PriorityLevelConfigurationDie(fn func(d *PriorityLevelConfigurationReferenceDie)) *FlowSchemaSpecDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchemaSpec) {
-		d := PriorityLevelConfigurationReferenceBlank.DieImmutable(false).DieFeed(r.PriorityLevelConfiguration)
-		fn(d)
-		r.PriorityLevelConfiguration = d.DieRelease()
-	})
-}
-
-func (d *FlowSchemaSpecDie) DistinguisherMethodDie(fn func(d *FlowDistinguisherMethodDie)) *FlowSchemaSpecDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchemaSpec) {
-		d := FlowDistinguisherMethodBlank.DieImmutable(false).DieFeedPtr(r.DistinguisherMethod)
-		fn(d)
-		r.DistinguisherMethod = d.DieReleasePtr()
-	})
-}
-
-func (d *FlowSchemaSpecDie) RulesDie(rules ...*PolicyRulesWithSubjectsDie) *FlowSchemaSpecDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.FlowSchemaSpec) {
-		r.Rules = make([]flowcontrolv1beta1.PolicyRulesWithSubjects, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = flowcontrolv1beta1.FlowSchemaStatus
@@ -78,33 +56,14 @@ type _ = flowcontrolv1beta1.PriorityLevelConfigurationReference
 type _ = flowcontrolv1beta1.FlowDistinguisherMethod
 
 // +die
+// +die:field:name=Subjects,die=SubjectDie,listType=atomic
+// +die:field:name=ResourceRules,die=ResourcePolicyRuleDie,listType=atomic
+// +die:field:name=NonResourceRules,die=NonResourcePolicyRuleDie,listType=atomic
 type _ = flowcontrolv1beta1.PolicyRulesWithSubjects
 
-func (d *PolicyRulesWithSubjectsDie) SubjectsDie(subjects ...*SubjectDie) *PolicyRulesWithSubjectsDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.PolicyRulesWithSubjects) {
-		r.Subjects = make([]flowcontrolv1beta1.Subject, len(subjects))
-		for i := range subjects {
-			r.Subjects[i] = subjects[i].DieRelease()
-		}
-	})
-}
-
-func (d *PolicyRulesWithSubjectsDie) ResourceRulesDie(rules ...*ResourcePolicyRuleDie) *PolicyRulesWithSubjectsDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.PolicyRulesWithSubjects) {
-		r.ResourceRules = make([]flowcontrolv1beta1.ResourcePolicyRule, len(rules))
-		for i := range rules {
-			r.ResourceRules[i] = rules[i].DieRelease()
-		}
-	})
-}
-
+// deprecated: use NonResourceRulesDie
 func (d *PolicyRulesWithSubjectsDie) NonResourcePolicyRuleDie(rules ...*NonResourcePolicyRuleDie) *PolicyRulesWithSubjectsDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.PolicyRulesWithSubjects) {
-		r.NonResourceRules = make([]flowcontrolv1beta1.NonResourcePolicyRule, len(rules))
-		for i := range rules {
-			r.NonResourceRules[i] = rules[i].DieRelease()
-		}
-	})
+	return d.NonResourceRulesDie(rules...)
 }
 
 // +die

--- a/apis/apiserver/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/apis/apiserver/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -25,45 +25,17 @@ import (
 type _ = flowcontrolv1beta1.PriorityLevelConfiguration
 
 // +die
+// +die:field:name=Limited,die=LimitedPriorityLevelConfigurationDie,pointer=true
+// +die:field:name=Exempt,die=ExemptPriorityLevelConfigurationDie,pointer=true
 type _ = flowcontrolv1beta1.PriorityLevelConfigurationSpec
 
-func (d *PriorityLevelConfigurationSpecDie) LimitedDie(fn func(d *LimitedPriorityLevelConfigurationDie)) *PriorityLevelConfigurationSpecDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.PriorityLevelConfigurationSpec) {
-		d := LimitedPriorityLevelConfigurationBlank.DieImmutable(false).DieFeedPtr(r.Limited)
-		fn(d)
-		r.Limited = d.DieReleasePtr()
-	})
-}
-
-func (d *PriorityLevelConfigurationSpecDie) ExemptDie(fn func(d *ExemptPriorityLevelConfigurationDie)) *PriorityLevelConfigurationSpecDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.PriorityLevelConfigurationSpec) {
-		d := ExemptPriorityLevelConfigurationBlank.DieImmutable(false).DieFeedPtr(r.Exempt)
-		fn(d)
-		r.Exempt = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=LimitResponse,die=LimitResponseDie
 type _ = flowcontrolv1beta1.LimitedPriorityLevelConfiguration
 
-func (d *LimitedPriorityLevelConfigurationDie) LimitResponseDie(fn func(d *LimitResponseDie)) *LimitedPriorityLevelConfigurationDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.LimitedPriorityLevelConfiguration) {
-		d := LimitResponseBlank.DieImmutable(false).DieFeed(r.LimitResponse)
-		fn(d)
-		r.LimitResponse = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Queuing,die=QueuingConfigurationDie,pointer=true
 type _ = flowcontrolv1beta1.LimitResponse
-
-func (d *LimitResponseDie) QueuingDie(fn func(d *QueuingConfigurationDie)) *LimitResponseDie {
-	return d.DieStamp(func(r *flowcontrolv1beta1.LimitResponse) {
-		d := QueuingConfigurationBlank.DieImmutable(false).DieFeedPtr(r.Queuing)
-		fn(d)
-		r.Queuing = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = flowcontrolv1beta1.ExemptPriorityLevelConfiguration

--- a/apis/apps/v1/daemonset.go
+++ b/apis/apps/v1/daemonset.go
@@ -19,7 +19,6 @@ package v1
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -27,31 +26,10 @@ import (
 type _ = appsv1.DaemonSet
 
 // +die
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Template,package=_/core/v1,die=PodTemplateSpecDie
+// +die:field:name=UpdateStrategy,die=DaemonSetUpdateStrategyDie
 type _ = appsv1.DaemonSetSpec
-
-func (d *DaemonSetSpecDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *DaemonSetSpecDie {
-	return d.DieStamp(func(r *appsv1.DaemonSetSpec) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}
-
-func (d *DaemonSetSpecDie) TemplateDie(fn func(d *diecorev1.PodTemplateSpecDie)) *DaemonSetSpecDie {
-	return d.DieStamp(func(r *appsv1.DaemonSetSpec) {
-		d := diecorev1.PodTemplateSpecBlank.DieImmutable(false).DieFeed(r.Template)
-		fn(d)
-		r.Template = d.DieRelease()
-	})
-}
-
-func (d *DaemonSetSpecDie) UpdateStrategyDie(fn func(d *DaemonSetUpdateStrategyDie)) *DaemonSetSpecDie {
-	return d.DieStamp(func(r *appsv1.DaemonSetSpec) {
-		d := DaemonSetUpdateStrategyBlank.DieImmutable(false).DieFeed(r.UpdateStrategy)
-		fn(d)
-		r.UpdateStrategy = d.DieRelease()
-	})
-}
 
 // +die
 type _ = appsv1.DaemonSetUpdateStrategy

--- a/apis/apps/v1/deployment.go
+++ b/apis/apps/v1/deployment.go
@@ -19,7 +19,6 @@ package v1
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -27,31 +26,10 @@ import (
 type _ = appsv1.Deployment
 
 // +die
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Template,package=_/core/v1,die=PodTemplateSpecDie
+// +die:field:name=Strategy,die=DeploymentStrategyDie
 type _ = appsv1.DeploymentSpec
-
-func (d *DeploymentSpecDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *DeploymentSpecDie {
-	return d.DieStamp(func(r *appsv1.DeploymentSpec) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}
-
-func (d *DeploymentSpecDie) TemplateDie(fn func(d *diecorev1.PodTemplateSpecDie)) *DeploymentSpecDie {
-	return d.DieStamp(func(r *appsv1.DeploymentSpec) {
-		d := diecorev1.PodTemplateSpecBlank.DieImmutable(false).DieFeed(r.Template)
-		fn(d)
-		r.Template = d.DieRelease()
-	})
-}
-
-func (d *DeploymentSpecDie) StrategyDie(fn func(d *DeploymentStrategyDie)) *DeploymentSpecDie {
-	return d.DieStamp(func(r *appsv1.DeploymentSpec) {
-		d := DeploymentStrategyBlank.DieImmutable(false).DieFeed(r.Strategy)
-		fn(d)
-		r.Strategy = d.DieRelease()
-	})
-}
 
 // +die
 type _ = appsv1.DeploymentStrategy

--- a/apis/apps/v1/replicaset.go
+++ b/apis/apps/v1/replicaset.go
@@ -19,7 +19,6 @@ package v1
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -27,23 +26,9 @@ import (
 type _ = appsv1.ReplicaSet
 
 // +die
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Template,package=_/core/v1,die=PodTemplateSpecDie
 type _ = appsv1.ReplicaSetSpec
-
-func (d *ReplicaSetSpecDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *ReplicaSetSpecDie {
-	return d.DieStamp(func(r *appsv1.ReplicaSetSpec) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}
-
-func (d *ReplicaSetSpecDie) TemplateDie(fn func(d *diecorev1.PodTemplateSpecDie)) *ReplicaSetSpecDie {
-	return d.DieStamp(func(r *appsv1.ReplicaSetSpec) {
-		d := diecorev1.PodTemplateSpecBlank.DieImmutable(false).DieFeed(r.Template)
-		fn(d)
-		r.Template = d.DieRelease()
-	})
-}
 
 // +die
 type _ = appsv1.ReplicaSetStatus

--- a/apis/apps/v1/statefulset.go
+++ b/apis/apps/v1/statefulset.go
@@ -19,7 +19,6 @@ package v1
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -27,56 +26,13 @@ import (
 type _ = appsv1.StatefulSet
 
 // +die
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Template,package=_/core/v1,die=PodTemplateSpecDie
+// +die:field:name=UpdateStrategy,die=StatefulSetUpdateStrategyDie
+// +die:field:name=PersistentVolumeClaimRetentionPolicy,die=StatefulSetPersistentVolumeClaimRetentionPolicyDie,pointer=true
+// +die:field:name=Ordinals,die=StatefulSetOrdinalsDie,pointer=true
+// +die:field:name=VolumeClaimTemplates,package=_/core/v1,die=PersistentVolumeClaimDie,listType=atomic
 type _ = appsv1.StatefulSetSpec
-
-func (d *StatefulSetSpecDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *StatefulSetSpecDie {
-	return d.DieStamp(func(r *appsv1.StatefulSetSpec) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}
-
-func (d *StatefulSetSpecDie) TemplateDie(fn func(d *diecorev1.PodTemplateSpecDie)) *StatefulSetSpecDie {
-	return d.DieStamp(func(r *appsv1.StatefulSetSpec) {
-		d := diecorev1.PodTemplateSpecBlank.DieImmutable(false).DieFeed(r.Template)
-		fn(d)
-		r.Template = d.DieRelease()
-	})
-}
-
-func (d *StatefulSetSpecDie) VolumeClaimTemplatesDie(volumeClaimTemplates ...*diecorev1.PersistentVolumeClaimDie) *StatefulSetSpecDie {
-	return d.DieStamp(func(r *appsv1.StatefulSetSpec) {
-		r.VolumeClaimTemplates = make([]corev1.PersistentVolumeClaim, len(volumeClaimTemplates))
-		for i, v := range volumeClaimTemplates {
-			r.VolumeClaimTemplates[i] = v.DieRelease()
-		}
-	})
-}
-
-func (d *StatefulSetSpecDie) UpdateStrategyDie(fn func(d *StatefulSetUpdateStrategyDie)) *StatefulSetSpecDie {
-	return d.DieStamp(func(r *appsv1.StatefulSetSpec) {
-		d := StatefulSetUpdateStrategyBlank.DieImmutable(false).DieFeed(r.UpdateStrategy)
-		fn(d)
-		r.UpdateStrategy = d.DieRelease()
-	})
-}
-
-func (d *StatefulSetSpecDie) PersistentVolumeClaimRetentionPolicyDie(fn func(d *StatefulSetPersistentVolumeClaimRetentionPolicyDie)) *StatefulSetSpecDie {
-	return d.DieStamp(func(r *appsv1.StatefulSetSpec) {
-		d := StatefulSetPersistentVolumeClaimRetentionPolicyBlank.DieImmutable(false).DieFeedPtr(r.PersistentVolumeClaimRetentionPolicy)
-		fn(d)
-		r.PersistentVolumeClaimRetentionPolicy = d.DieReleasePtr()
-	})
-}
-
-func (d *StatefulSetSpecDie) OrdinalsDie(fn func(d *StatefulSetOrdinalsDie)) *StatefulSetSpecDie {
-	return d.DieStamp(func(r *appsv1.StatefulSetSpec) {
-		d := StatefulSetOrdinalsBlank.DieImmutable(false).DieFeedPtr(r.Ordinals)
-		fn(d)
-		r.Ordinals = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = appsv1.StatefulSetUpdateStrategy

--- a/apis/authentication/v1/selfsubjectreview.go
+++ b/apis/authentication/v1/selfsubjectreview.go
@@ -24,15 +24,8 @@ import (
 type _ = authenticationv1.SelfSubjectReview
 
 // +die
+// +die:field:name=UserInfo,die=UserInfoDie
 type _ = authenticationv1.SelfSubjectReviewStatus
-
-func (d *SelfSubjectReviewStatusDie) UserInfoDie(fn func(d *UserInfoDie)) *SelfSubjectReviewStatusDie {
-	return d.DieStamp(func(r *authenticationv1.SelfSubjectReviewStatus) {
-		d := UserInfoBlank.DieImmutable(false).DieFeed(r.UserInfo)
-		fn(d)
-		r.UserInfo = d.DieRelease()
-	})
-}
 
 // +die:ignore={Extra}
 type _ = authenticationv1.UserInfo

--- a/apis/authentication/v1/tokenreview.go
+++ b/apis/authentication/v1/tokenreview.go
@@ -24,15 +24,8 @@ import (
 type _ = authenticationv1.TokenReview
 
 // +die
+// +die:field:name=BoundObjectRef,die=BoundObjectReferenceDie,pointer=true
 type _ = authenticationv1.TokenRequestSpec
-
-func (d *TokenRequestSpecDie) BoundObjectRefDie(fn func(d *BoundObjectReferenceDie)) *TokenRequestSpecDie {
-	return d.DieStamp(func(r *authenticationv1.TokenRequestSpec) {
-		d := BoundObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.BoundObjectRef)
-		fn(d)
-		r.BoundObjectRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = authenticationv1.BoundObjectReference

--- a/apis/authentication/v1/zz_generated.die.go
+++ b/apis/authentication/v1/zz_generated.die.go
@@ -606,6 +606,17 @@ func (d *SelfSubjectReviewStatusDie) DiePatch(patchType types.PatchType) ([]byte
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// UserInfoDie mutates UserInfo as a die.
+//
+// User attributes of the user making this request.
+func (d *SelfSubjectReviewStatusDie) UserInfoDie(fn func(d *UserInfoDie)) *SelfSubjectReviewStatusDie {
+	return d.DieStamp(func(r *authenticationv1.SelfSubjectReviewStatus) {
+		d := UserInfoBlank.DieImmutable(false).DieFeed(r.UserInfo)
+		fn(d)
+		r.UserInfo = d.DieRelease()
+	})
+}
+
 // User attributes of the user making this request.
 func (d *SelfSubjectReviewStatusDie) UserInfo(v authenticationv1.UserInfo) *SelfSubjectReviewStatusDie {
 	return d.DieStamp(func(r *authenticationv1.SelfSubjectReviewStatus) {
@@ -1429,6 +1440,25 @@ func (d *TokenRequestSpecDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *TokenRequestSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// BoundObjectRefDie mutates BoundObjectRef as a die.
+//
+// BoundObjectRef is a reference to an object that the token will be bound to.
+//
+// The token will only be valid for as long as the bound object exists.
+//
+// NOTE: The API server's TokenReview endpoint will validate the
+//
+// BoundObjectRef, but other audiences may not. Keep ExpirationSeconds
+//
+// small if you want prompt revocation.
+func (d *TokenRequestSpecDie) BoundObjectRefDie(fn func(d *BoundObjectReferenceDie)) *TokenRequestSpecDie {
+	return d.DieStamp(func(r *authenticationv1.TokenRequestSpec) {
+		d := BoundObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.BoundObjectRef)
+		fn(d)
+		r.BoundObjectRef = d.DieReleasePtr()
+	})
 }
 
 // Audiences are the intendend audiences of the token. A recipient of a

--- a/apis/authorization/rbac/v1/clusterrole.go
+++ b/apis/authorization/rbac/v1/clusterrole.go
@@ -18,21 +18,12 @@ package v1
 
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=ClusterRole
+// +die:field:name=AggregationRule,die=AggregationRuleDie,pointer=true
+// +die:field:name=Rules,die=PolicyRuleDie,listType=atomic
 type _ = rbacv1.ClusterRole
-
-func (d *ClusterRoleDie) RulesDie(rules ...*PolicyRuleDie) *ClusterRoleDie {
-	return d.DieStamp(func(r *rbacv1.ClusterRole) {
-		r.Rules = make([]rbacv1.PolicyRule, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
 
 func (d *ClusterRoleDie) AddRuleDie(rule *PolicyRuleDie) *ClusterRoleDie {
 	return d.DieStamp(func(r *rbacv1.ClusterRole) {
@@ -40,22 +31,6 @@ func (d *ClusterRoleDie) AddRuleDie(rule *PolicyRuleDie) *ClusterRoleDie {
 	})
 }
 
-func (d *ClusterRoleDie) AggregationRuleDie(fn func(d *AggregationRuleDie)) *ClusterRoleDie {
-	return d.DieStamp(func(r *rbacv1.ClusterRole) {
-		d := AggregationRuleBlank.DieImmutable(false).DieFeedPtr(r.AggregationRule)
-		fn(d)
-		r.AggregationRule = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=ClusterRoleSelectors,package=_/meta/v1,die=LabelSelectorDie,listType=atomic
 type _ = rbacv1.AggregationRule
-
-func (d *AggregationRuleDie) ClusterRoleSelectorsDie(selectors ...*diemetav1.LabelSelectorDie) *AggregationRuleDie {
-	return d.DieStamp(func(r *rbacv1.AggregationRule) {
-		r.ClusterRoleSelectors = make([]metav1.LabelSelector, len(selectors))
-		for i := range selectors {
-			r.ClusterRoleSelectors[i] = selectors[i].DieRelease()
-		}
-	})
-}

--- a/apis/authorization/rbac/v1/clusterrolebinding.go
+++ b/apis/authorization/rbac/v1/clusterrolebinding.go
@@ -21,21 +21,6 @@ import (
 )
 
 // +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=ClusterRoleBinding
+// +die:field:name=RoleRef,die=RoleRefDie
+// +die:field:name=Subjects,die=SubjectDie,listType=atomic
 type _ = rbacv1.ClusterRoleBinding
-
-func (d *ClusterRoleBindingDie) SubjectsDie(subjects ...*SubjectDie) *ClusterRoleBindingDie {
-	return d.DieStamp(func(r *rbacv1.ClusterRoleBinding) {
-		r.Subjects = make([]rbacv1.Subject, len(subjects))
-		for i := range subjects {
-			r.Subjects[i] = subjects[i].DieRelease()
-		}
-	})
-}
-
-func (d *ClusterRoleBindingDie) RoleRefDie(fn func(d *RoleRefDie)) *ClusterRoleBindingDie {
-	return d.DieStamp(func(r *rbacv1.ClusterRoleBinding) {
-		d := RoleRefBlank.DieImmutable(false).DieFeed(r.RoleRef)
-		fn(d)
-		r.RoleRef = d.DieRelease()
-	})
-}

--- a/apis/authorization/rbac/v1/role.go
+++ b/apis/authorization/rbac/v1/role.go
@@ -21,16 +21,8 @@ import (
 )
 
 // +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=Role
+// +die:field:name=Rules,die=PolicyRuleDie,listType=atomic
 type _ = rbacv1.Role
-
-func (d *RoleDie) RulesDie(rules ...*PolicyRuleDie) *RoleDie {
-	return d.DieStamp(func(r *rbacv1.Role) {
-		r.Rules = make([]rbacv1.PolicyRule, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
 
 func (d *RoleDie) AddRuleDie(rule *PolicyRuleDie) *RoleDie {
 	return d.DieStamp(func(r *rbacv1.Role) {

--- a/apis/authorization/rbac/v1/rolebinding.go
+++ b/apis/authorization/rbac/v1/rolebinding.go
@@ -21,24 +21,9 @@ import (
 )
 
 // +die:object=true,apiVersion=rbac.authorization.k8s.io/v1,kind=RoleBinding
+// +die:field:name=RoleRef,die=RoleRefDie
+// +die:field:name=Subjects,die=SubjectDie,listType=atomic
 type _ = rbacv1.RoleBinding
-
-func (d *RoleBindingDie) SubjectsDie(subjects ...*SubjectDie) *RoleBindingDie {
-	return d.DieStamp(func(r *rbacv1.RoleBinding) {
-		r.Subjects = make([]rbacv1.Subject, len(subjects))
-		for i := range subjects {
-			r.Subjects[i] = subjects[i].DieRelease()
-		}
-	})
-}
-
-func (d *RoleBindingDie) RoleRefDie(fn func(d *RoleRefDie)) *RoleBindingDie {
-	return d.DieStamp(func(r *rbacv1.RoleBinding) {
-		d := RoleRefBlank.DieImmutable(false).DieFeed(r.RoleRef)
-		fn(d)
-		r.RoleRef = d.DieRelease()
-	})
-}
 
 // +die
 type _ = rbacv1.Subject

--- a/apis/authorization/v1/selfsubjectaccessreview.go
+++ b/apis/authorization/v1/selfsubjectaccessreview.go
@@ -24,20 +24,6 @@ import (
 type _ = authorizationv1.SelfSubjectAccessReview
 
 // +die
+// +die:field:name=ResourceAttributes,die=ResourceAttributesDie,pointer=true
+// +die:field:name=NonResourceAttributes,die=NonResourceAttributesDie,pointer=true
 type _ = authorizationv1.SelfSubjectAccessReviewSpec
-
-func (d *SelfSubjectAccessReviewSpecDie) ResourceAttributesDie(fn func(d *ResourceAttributesDie)) *SelfSubjectAccessReviewSpecDie {
-	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReviewSpec) {
-		d := ResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.ResourceAttributes)
-		fn(d)
-		r.ResourceAttributes = d.DieReleasePtr()
-	})
-}
-
-func (d *SelfSubjectAccessReviewSpecDie) NonResourceAttributesDie(fn func(d *NonResourceAttributesDie)) *SelfSubjectAccessReviewSpecDie {
-	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReviewSpec) {
-		d := NonResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.NonResourceAttributes)
-		fn(d)
-		r.NonResourceAttributes = d.DieReleasePtr()
-	})
-}

--- a/apis/authorization/v1/selfsubjectrulesreview.go
+++ b/apis/authorization/v1/selfsubjectrulesreview.go
@@ -27,25 +27,9 @@ type _ = authorizationv1.SelfSubjectRulesReview
 type _ = authorizationv1.SelfSubjectRulesReviewSpec
 
 // +die
+// +die:field:name=ResourceRules,die=ResourceRuleDie,listType=atomic
+// +die:field:name=NonResourceRules,die=NonResourceRuleDie,listType=atomic
 type _ = authorizationv1.SubjectRulesReviewStatus
-
-func (d *SubjectRulesReviewStatusDie) ResourceRulesDie(rules ...*ResourceRuleDie) *SubjectRulesReviewStatusDie {
-	return d.DieStamp(func(r *authorizationv1.SubjectRulesReviewStatus) {
-		r.ResourceRules = make([]authorizationv1.ResourceRule, len(rules))
-		for i := range rules {
-			r.ResourceRules[i] = rules[i].DieRelease()
-		}
-	})
-}
-
-func (d *SubjectRulesReviewStatusDie) NonResourceRulesDie(rules ...*NonResourceRuleDie) *SubjectRulesReviewStatusDie {
-	return d.DieStamp(func(r *authorizationv1.SubjectRulesReviewStatus) {
-		r.NonResourceRules = make([]authorizationv1.NonResourceRule, len(rules))
-		for i := range rules {
-			r.NonResourceRules[i] = rules[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = authorizationv1.ResourceRule

--- a/apis/authorization/v1/subjectaccessreview.go
+++ b/apis/authorization/v1/subjectaccessreview.go
@@ -26,23 +26,9 @@ type _ = authorizationv1.SubjectAccessReview
 // TODO(scothis) fix import for maps with struct values, ignore the 'Extra' field until then
 
 // +die:ignore={Extra}
+// +die:field:name=ResourceAttributes,die=ResourceAttributesDie,pointer=true
+// +die:field:name=NonResourceAttributes,die=NonResourceAttributesDie,pointer=true
 type _ = authorizationv1.SubjectAccessReviewSpec
-
-func (d *SubjectAccessReviewSpecDie) ResourceAttributesDie(fn func(d *ResourceAttributesDie)) *SubjectAccessReviewSpecDie {
-	return d.DieStamp(func(r *authorizationv1.SubjectAccessReviewSpec) {
-		d := ResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.ResourceAttributes)
-		fn(d)
-		r.ResourceAttributes = d.DieReleasePtr()
-	})
-}
-
-func (d *SubjectAccessReviewSpecDie) NonResourceAttributesDie(fn func(d *NonResourceAttributesDie)) *SubjectAccessReviewSpecDie {
-	return d.DieStamp(func(r *authorizationv1.SubjectAccessReviewSpec) {
-		d := NonResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.NonResourceAttributes)
-		fn(d)
-		r.NonResourceAttributes = d.DieReleasePtr()
-	})
-}
 
 // Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.
 func (d *SubjectAccessReviewSpecDie) Extra(v map[string]authorizationv1.ExtraValue) *SubjectAccessReviewSpecDie {

--- a/apis/authorization/v1/zz_generated.die.go
+++ b/apis/authorization/v1/zz_generated.die.go
@@ -961,6 +961,28 @@ func (d *SelfSubjectAccessReviewSpecDie) DiePatch(patchType types.PatchType) ([]
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ResourceAttributesDie mutates ResourceAttributes as a die.
+//
+// ResourceAuthorizationAttributes describes information for a resource access request
+func (d *SelfSubjectAccessReviewSpecDie) ResourceAttributesDie(fn func(d *ResourceAttributesDie)) *SelfSubjectAccessReviewSpecDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReviewSpec) {
+		d := ResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.ResourceAttributes)
+		fn(d)
+		r.ResourceAttributes = d.DieReleasePtr()
+	})
+}
+
+// NonResourceAttributesDie mutates NonResourceAttributes as a die.
+//
+// NonResourceAttributes describes information for a non-resource access request
+func (d *SelfSubjectAccessReviewSpecDie) NonResourceAttributesDie(fn func(d *NonResourceAttributesDie)) *SelfSubjectAccessReviewSpecDie {
+	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReviewSpec) {
+		d := NonResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.NonResourceAttributes)
+		fn(d)
+		r.NonResourceAttributes = d.DieReleasePtr()
+	})
+}
+
 // ResourceAuthorizationAttributes describes information for a resource access request
 func (d *SelfSubjectAccessReviewSpecDie) ResourceAttributes(v *authorizationv1.ResourceAttributes) *SelfSubjectAccessReviewSpecDie {
 	return d.DieStamp(func(r *authorizationv1.SelfSubjectAccessReviewSpec) {
@@ -1791,6 +1813,34 @@ func (d *SubjectRulesReviewStatusDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *SubjectRulesReviewStatusDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ResourceRulesDie replaces ResourceRules by collecting the released value from each die passed.
+//
+// ResourceRules is the list of actions the subject is allowed to perform on resources.
+//
+// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+func (d *SubjectRulesReviewStatusDie) ResourceRulesDie(v ...*ResourceRuleDie) *SubjectRulesReviewStatusDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectRulesReviewStatus) {
+		r.ResourceRules = make([]authorizationv1.ResourceRule, len(v))
+		for i := range v {
+			r.ResourceRules[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// NonResourceRulesDie replaces NonResourceRules by collecting the released value from each die passed.
+//
+// NonResourceRules is the list of actions the subject is allowed to perform on non-resources.
+//
+// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+func (d *SubjectRulesReviewStatusDie) NonResourceRulesDie(v ...*NonResourceRuleDie) *SubjectRulesReviewStatusDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectRulesReviewStatus) {
+		r.NonResourceRules = make([]authorizationv1.NonResourceRule, len(v))
+		for i := range v {
+			r.NonResourceRules[i] = v[i].DieRelease()
+		}
+	})
 }
 
 // ResourceRules is the list of actions the subject is allowed to perform on resources.
@@ -2916,6 +2966,28 @@ func (d *SubjectAccessReviewSpecDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *SubjectAccessReviewSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ResourceAttributesDie mutates ResourceAttributes as a die.
+//
+// ResourceAuthorizationAttributes describes information for a resource access request
+func (d *SubjectAccessReviewSpecDie) ResourceAttributesDie(fn func(d *ResourceAttributesDie)) *SubjectAccessReviewSpecDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectAccessReviewSpec) {
+		d := ResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.ResourceAttributes)
+		fn(d)
+		r.ResourceAttributes = d.DieReleasePtr()
+	})
+}
+
+// NonResourceAttributesDie mutates NonResourceAttributes as a die.
+//
+// NonResourceAttributes describes information for a non-resource access request
+func (d *SubjectAccessReviewSpecDie) NonResourceAttributesDie(fn func(d *NonResourceAttributesDie)) *SubjectAccessReviewSpecDie {
+	return d.DieStamp(func(r *authorizationv1.SubjectAccessReviewSpec) {
+		d := NonResourceAttributesBlank.DieImmutable(false).DieFeedPtr(r.NonResourceAttributes)
+		fn(d)
+		r.NonResourceAttributes = d.DieReleasePtr()
+	})
 }
 
 // ResourceAuthorizationAttributes describes information for a resource access request

--- a/apis/autoscaling/v1/horizontalpodautoscaler.go
+++ b/apis/autoscaling/v1/horizontalpodautoscaler.go
@@ -24,15 +24,8 @@ import (
 type _ = autoscalingv1.HorizontalPodAutoscaler
 
 // +die
+// +die:field:name=ScaleTargetRef,die=CrossVersionObjectReferenceDie
 type _ = autoscalingv1.HorizontalPodAutoscalerSpec
-
-func (d *HorizontalPodAutoscalerSpecDie) ScaleTargetRefDie(fn func(d *CrossVersionObjectReferenceDie)) *HorizontalPodAutoscalerSpecDie {
-	return d.DieStamp(func(r *autoscalingv1.HorizontalPodAutoscalerSpec) {
-		d := CrossVersionObjectReferenceBlank.DieImmutable(false).DieFeed(r.ScaleTargetRef)
-		fn(d)
-		r.ScaleTargetRef = d.DieRelease()
-	})
-}
 
 // +die
 type _ = autoscalingv1.CrossVersionObjectReference

--- a/apis/autoscaling/v1/zz_generated.die.go
+++ b/apis/autoscaling/v1/zz_generated.die.go
@@ -622,6 +622,19 @@ func (d *HorizontalPodAutoscalerSpecDie) DiePatch(patchType types.PatchType) ([]
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ScaleTargetRefDie mutates ScaleTargetRef as a die.
+//
+// reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption
+//
+// and will set the desired number of pods by using its Scale subresource.
+func (d *HorizontalPodAutoscalerSpecDie) ScaleTargetRefDie(fn func(d *CrossVersionObjectReferenceDie)) *HorizontalPodAutoscalerSpecDie {
+	return d.DieStamp(func(r *autoscalingv1.HorizontalPodAutoscalerSpec) {
+		d := CrossVersionObjectReferenceBlank.DieImmutable(false).DieFeed(r.ScaleTargetRef)
+		fn(d)
+		r.ScaleTargetRef = d.DieRelease()
+	})
+}
+
 // reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption
 //
 // and will set the desired number of pods by using its Scale subresource.

--- a/apis/autoscaling/v2/horizontalpodautoscaler.go
+++ b/apis/autoscaling/v2/horizontalpodautoscaler.go
@@ -26,225 +26,68 @@ import (
 type _ = autoscalingv2.HorizontalPodAutoscaler
 
 // +die
+// +die:field:name=ScaleTargetRef,die=CrossVersionObjectReferenceDie
+// +die:field:name=Behavior,die=HorizontalPodAutoscalerBehaviorDie,pointer=true
+// +die:field:name=Metrics,die=MetricSpecDie,listType=atomic
 type _ = autoscalingv2.HorizontalPodAutoscalerSpec
-
-func (d *HorizontalPodAutoscalerSpecDie) ScaleTargetRefDie(fn func(d *CrossVersionObjectReferenceDie)) *HorizontalPodAutoscalerSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.HorizontalPodAutoscalerSpec) {
-		d := CrossVersionObjectReferenceBlank.DieImmutable(false).DieFeed(r.ScaleTargetRef)
-		fn(d)
-		r.ScaleTargetRef = d.DieRelease()
-	})
-}
-
-func (d *HorizontalPodAutoscalerSpecDie) ConditionsDie(metrics ...*MetricSpecDie) *HorizontalPodAutoscalerSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.HorizontalPodAutoscalerSpec) {
-		r.Metrics = make([]autoscalingv2.MetricSpec, len(metrics))
-		for i := range metrics {
-			r.Metrics[i] = metrics[i].DieRelease()
-		}
-	})
-}
-
-func (d *HorizontalPodAutoscalerSpecDie) BehaviorDie(fn func(d *HorizontalPodAutoscalerBehaviorDie)) *HorizontalPodAutoscalerSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.HorizontalPodAutoscalerSpec) {
-		d := HorizontalPodAutoscalerBehaviorBlank.DieImmutable(false).DieFeedPtr(r.Behavior)
-		fn(d)
-		r.Behavior = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = autoscalingv2.CrossVersionObjectReference
 
 // +die
+// +die:field:name=Object,die=ObjectMetricSourceDie,pointer=true
+// +die:field:name=Pods,die=PodsMetricSourceDie,pointer=true
+// +die:field:name=Resource,die=ResourceMetricSourceDie,pointer=true
+// +die:field:name=ContainerResource,die=ContainerResourceMetricSourceDie,pointer=true
+// +die:field:name=External,die=ExternalMetricSourceDie,pointer=true
 type _ = autoscalingv2.MetricSpec
 
-func (d *MetricSpecDie) BehaviorDie(fn func(d *ObjectMetricSourceDie)) *MetricSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricSpec) {
-		d := ObjectMetricSourceBlank.DieImmutable(false).DieFeedPtr(r.Object)
-		fn(d)
-		r.Object = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricSpecDie) PodsDie(fn func(d *PodsMetricSourceDie)) *MetricSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricSpec) {
-		d := PodsMetricSourceBlank.DieImmutable(false).DieFeedPtr(r.Pods)
-		fn(d)
-		r.Pods = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricSpecDie) ResourceDie(fn func(d *ResourceMetricSourceDie)) *MetricSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricSpec) {
-		d := ResourceMetricSourceBlank.DieImmutable(false).DieFeedPtr(r.Resource)
-		fn(d)
-		r.Resource = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricSpecDie) ContainerResourceDie(fn func(d *ContainerResourceMetricSourceDie)) *MetricSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricSpec) {
-		d := ContainerResourceMetricSourceBlank.DieImmutable(false).DieFeedPtr(r.ContainerResource)
-		fn(d)
-		r.ContainerResource = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricSpecDie) ExternalDie(fn func(d *ExternalMetricSourceDie)) *MetricSpecDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricSpec) {
-		d := ExternalMetricSourceBlank.DieImmutable(false).DieFeedPtr(r.External)
-		fn(d)
-		r.External = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=DescribedObject,die=CrossVersionObjectReferenceDie
+// +die:field:name=Target,die=MetricTargetDie
+// +die:field:name=Metric,die=MetricIdentifierDie
 type _ = autoscalingv2.ObjectMetricSource
-
-func (d *ObjectMetricSourceDie) DescribedObjectDie(fn func(d *CrossVersionObjectReferenceDie)) *ObjectMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.ObjectMetricSource) {
-		d := CrossVersionObjectReferenceBlank.DieImmutable(false).DieFeed(r.DescribedObject)
-		fn(d)
-		r.DescribedObject = d.DieRelease()
-	})
-}
-
-func (d *ObjectMetricSourceDie) TargetDie(fn func(d *MetricTargetDie)) *ObjectMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.ObjectMetricSource) {
-		d := MetricTargetBlank.DieImmutable(false).DieFeed(r.Target)
-		fn(d)
-		r.Target = d.DieRelease()
-	})
-}
-
-func (d *ObjectMetricSourceDie) MetricDie(fn func(d *MetricIdentifierDie)) *ObjectMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.ObjectMetricSource) {
-		d := MetricIdentifierBlank.DieImmutable(false).DieFeed(r.Metric)
-		fn(d)
-		r.Metric = d.DieRelease()
-	})
-}
 
 // +die
 type _ = autoscalingv2.MetricTarget
 
 // +die
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
 type _ = autoscalingv2.MetricIdentifier
 
-func (d *MetricIdentifierDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *MetricIdentifierDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricIdentifier) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Metric,die=MetricIdentifierDie
+// +die:field:name=Target,die=MetricTargetDie
 type _ = autoscalingv2.PodsMetricSource
 
-func (d *PodsMetricSourceDie) MetricDie(fn func(d *MetricIdentifierDie)) *PodsMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.PodsMetricSource) {
-		d := MetricIdentifierBlank.DieImmutable(false).DieFeed(r.Metric)
-		fn(d)
-		r.Metric = d.DieRelease()
-	})
-}
-
-func (d *PodsMetricSourceDie) TargetDie(fn func(d *MetricTargetDie)) *PodsMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.PodsMetricSource) {
-		d := MetricTargetBlank.DieImmutable(false).DieFeed(r.Target)
-		fn(d)
-		r.Target = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Target,die=MetricTargetDie
 type _ = autoscalingv2.ResourceMetricSource
 
-func (d *ResourceMetricSourceDie) TargetDie(fn func(d *MetricTargetDie)) *ResourceMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.ResourceMetricSource) {
-		d := MetricTargetBlank.DieImmutable(false).DieFeed(r.Target)
-		fn(d)
-		r.Target = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Target,die=MetricTargetDie
 type _ = autoscalingv2.ContainerResourceMetricSource
 
-func (d *ContainerResourceMetricSourceDie) TargetDie(fn func(d *MetricTargetDie)) *ContainerResourceMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.ContainerResourceMetricSource) {
-		d := MetricTargetBlank.DieImmutable(false).DieFeed(r.Target)
-		fn(d)
-		r.Target = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Metric,die=MetricIdentifierDie
+// +die:field:name=Target,die=MetricTargetDie
 type _ = autoscalingv2.ExternalMetricSource
 
-func (d *ExternalMetricSourceDie) MetricDie(fn func(d *MetricIdentifierDie)) *ExternalMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.ExternalMetricSource) {
-		d := MetricIdentifierBlank.DieImmutable(false).DieFeed(r.Metric)
-		fn(d)
-		r.Metric = d.DieRelease()
-	})
-}
-
-func (d *ExternalMetricSourceDie) TargetDie(fn func(d *MetricTargetDie)) *ExternalMetricSourceDie {
-	return d.DieStamp(func(r *autoscalingv2.ExternalMetricSource) {
-		d := MetricTargetBlank.DieImmutable(false).DieFeed(r.Target)
-		fn(d)
-		r.Target = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=ScaleUp,die=HPAScalingRulesDie,pointer=true
+// +die:field:name=ScaleDown,die=HPAScalingRulesDie,pointer=true
 type _ = autoscalingv2.HorizontalPodAutoscalerBehavior
 
-func (d *HorizontalPodAutoscalerBehaviorDie) ScaleUpDie(fn func(d *HPAScalingRulesDie)) *HorizontalPodAutoscalerBehaviorDie {
-	return d.DieStamp(func(r *autoscalingv2.HorizontalPodAutoscalerBehavior) {
-		d := HPAScalingRulesBlank.DieImmutable(false).DieFeedPtr(r.ScaleUp)
-		fn(d)
-		r.ScaleUp = d.DieReleasePtr()
-	})
-}
-
-func (d *HorizontalPodAutoscalerBehaviorDie) ScaleDownDie(fn func(d *HPAScalingRulesDie)) *HorizontalPodAutoscalerBehaviorDie {
-	return d.DieStamp(func(r *autoscalingv2.HorizontalPodAutoscalerBehavior) {
-		d := HPAScalingRulesBlank.DieImmutable(false).DieFeedPtr(r.ScaleDown)
-		fn(d)
-		r.ScaleDown = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Policies,die=HPAScalingPolicyDie,listType=atomic
 type _ = autoscalingv2.HPAScalingRules
-
-func (d *HPAScalingRulesDie) PoliciesDie(policies ...*HPAScalingPolicyDie) *HPAScalingRulesDie {
-	return d.DieStamp(func(r *autoscalingv2.HPAScalingRules) {
-		r.Policies = make([]autoscalingv2.HPAScalingPolicy, len(policies))
-		for i := range policies {
-			r.Policies[i] = policies[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = autoscalingv2.HPAScalingPolicy
 
 // +die
+// +die:field:name=CurrentMetrics,die=MetricStatusDie,listType=atomic
 type _ = autoscalingv2.HorizontalPodAutoscalerStatus
-
-func (d *HorizontalPodAutoscalerStatusDie) CurrentMetricsDie(metrics ...*MetricStatusDie) *HorizontalPodAutoscalerStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.HorizontalPodAutoscalerStatus) {
-		r.CurrentMetrics = make([]autoscalingv2.MetricStatus, len(metrics))
-		for i := range metrics {
-			r.CurrentMetrics[i] = metrics[i].DieRelease()
-		}
-	})
-}
 
 func (d *HorizontalPodAutoscalerStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *HorizontalPodAutoscalerStatusDie {
 	return d.DieStamp(func(r *autoscalingv2.HorizontalPodAutoscalerStatus) {
@@ -263,134 +106,36 @@ func (d *HorizontalPodAutoscalerStatusDie) ConditionsDie(conditions ...*diemetav
 }
 
 // +die
+// +die:field:name=Object,die=ObjectMetricStatusDie,pointer=true
+// +die:field:name=Pods,die=PodsMetricStatusDie,pointer=true
+// +die:field:name=Resource,die=ResourceMetricStatusDie,pointer=true
+// +die:field:name=ContainerResource,die=ContainerResourceMetricStatusDie,pointer=true
+// +die:field:name=External,die=ExternalMetricStatusDie,pointer=true
 type _ = autoscalingv2.MetricStatus
 
-func (d *MetricStatusDie) ObjectDie(fn func(d *ObjectMetricStatusDie)) *MetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricStatus) {
-		d := ObjectMetricStatusBlank.DieImmutable(false).DieFeedPtr(r.Object)
-		fn(d)
-		r.Object = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricStatusDie) PodDie(fn func(d *PodsMetricStatusDie)) *MetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricStatus) {
-		d := PodsMetricStatusBlank.DieImmutable(false).DieFeedPtr(r.Pods)
-		fn(d)
-		r.Pods = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricStatusDie) ResourceDie(fn func(d *ResourceMetricStatusDie)) *MetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricStatus) {
-		d := ResourceMetricStatusBlank.DieImmutable(false).DieFeedPtr(r.Resource)
-		fn(d)
-		r.Resource = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricStatusDie) ContainerResourceDie(fn func(d *ContainerResourceMetricStatusDie)) *MetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricStatus) {
-		d := ContainerResourceMetricStatusBlank.DieImmutable(false).DieFeedPtr(r.ContainerResource)
-		fn(d)
-		r.ContainerResource = d.DieReleasePtr()
-	})
-}
-
-func (d *MetricStatusDie) ExternalDie(fn func(d *ExternalMetricStatusDie)) *MetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.MetricStatus) {
-		d := ExternalMetricStatusBlank.DieImmutable(false).DieFeedPtr(r.External)
-		fn(d)
-		r.External = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Metric,die=MetricIdentifierDie
+// +die:field:name=Current,die=MetricValueStatusDie
+// +die:field:name=DescribedObject,die=CrossVersionObjectReferenceDie
 type _ = autoscalingv2.ObjectMetricStatus
-
-func (d *ObjectMetricStatusDie) MetricDie(fn func(d *MetricIdentifierDie)) *ObjectMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.ObjectMetricStatus) {
-		d := MetricIdentifierBlank.DieImmutable(false).DieFeed(r.Metric)
-		fn(d)
-		r.Metric = d.DieRelease()
-	})
-}
-
-func (d *ObjectMetricStatusDie) CurrentDie(fn func(d *MetricValueStatusDie)) *ObjectMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.ObjectMetricStatus) {
-		d := MetricValueStatusBlank.DieImmutable(false).DieFeed(r.Current)
-		fn(d)
-		r.Current = d.DieRelease()
-	})
-}
-
-func (d *ObjectMetricStatusDie) DescribedObjectDie(fn func(d *CrossVersionObjectReferenceDie)) *ObjectMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.ObjectMetricStatus) {
-		d := CrossVersionObjectReferenceBlank.DieImmutable(false).DieFeed(r.DescribedObject)
-		fn(d)
-		r.DescribedObject = d.DieRelease()
-	})
-}
 
 // +die
 type _ = autoscalingv2.MetricValueStatus
 
 // +die
+// +die:field:name=Metric,die=MetricIdentifierDie
+// +die:field:name=Current,die=MetricValueStatusDie
 type _ = autoscalingv2.PodsMetricStatus
 
-func (d *PodsMetricStatusDie) MetricDie(fn func(d *MetricIdentifierDie)) *PodsMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.PodsMetricStatus) {
-		d := MetricIdentifierBlank.DieImmutable(false).DieFeed(r.Metric)
-		fn(d)
-		r.Metric = d.DieRelease()
-	})
-}
-
-func (d *PodsMetricStatusDie) CurrentDie(fn func(d *MetricValueStatusDie)) *PodsMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.PodsMetricStatus) {
-		d := MetricValueStatusBlank.DieImmutable(false).DieFeed(r.Current)
-		fn(d)
-		r.Current = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Current,die=MetricValueStatusDie
 type _ = autoscalingv2.ResourceMetricStatus
 
-func (d *ResourceMetricStatusDie) CurrentDie(fn func(d *MetricValueStatusDie)) *ResourceMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.ResourceMetricStatus) {
-		d := MetricValueStatusBlank.DieImmutable(false).DieFeed(r.Current)
-		fn(d)
-		r.Current = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Current,die=MetricValueStatusDie
 type _ = autoscalingv2.ContainerResourceMetricStatus
 
-func (d *ContainerResourceMetricStatusDie) CurrentDie(fn func(d *MetricValueStatusDie)) *ContainerResourceMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.ContainerResourceMetricStatus) {
-		d := MetricValueStatusBlank.DieImmutable(false).DieFeed(r.Current)
-		fn(d)
-		r.Current = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Metric,die=MetricIdentifierDie
+// +die:field:name=Current,die=MetricValueStatusDie
 type _ = autoscalingv2.ExternalMetricStatus
-
-func (d *ExternalMetricStatusDie) MetricDie(fn func(d *MetricIdentifierDie)) *ExternalMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.ExternalMetricStatus) {
-		d := MetricIdentifierBlank.DieImmutable(false).DieFeed(r.Metric)
-		fn(d)
-		r.Metric = d.DieRelease()
-	})
-}
-
-func (d *ExternalMetricStatusDie) CurrentDie(fn func(d *MetricValueStatusDie)) *ExternalMetricStatusDie {
-	return d.DieStamp(func(r *autoscalingv2.ExternalMetricStatus) {
-		d := MetricValueStatusBlank.DieImmutable(false).DieFeed(r.Current)
-		fn(d)
-		r.Current = d.DieRelease()
-	})
-}

--- a/apis/batch/v1/job.go
+++ b/apis/batch/v1/job.go
@@ -19,7 +19,6 @@ package v1
 import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
@@ -27,71 +26,20 @@ import (
 type _ = batchv1.Job
 
 // +die
+// +die:field:name=PodFailurePolicy,die=PodFailurePolicyDie,pointer=true
+// +die:field:name=SuccessPolicy,die=SuccessPolicyDie,pointer=true
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Template,package=_/core/v1,die=PodTemplateSpecDie
 type _ = batchv1.JobSpec
 
-func (d *JobSpecDie) PodFailurePolicyDie(fn func(d *PodFailurePolicyDie)) *JobSpecDie {
-	return d.DieStamp(func(r *batchv1.JobSpec) {
-		d := PodFailurePolicyBlank.DieImmutable(false).DieFeedPtr(r.PodFailurePolicy)
-		fn(d)
-		r.PodFailurePolicy = d.DieReleasePtr()
-	})
-}
-
-func (d *JobSpecDie) SuccessPolicyDie(fn func(d *SuccessPolicyDie)) *JobSpecDie {
-	return d.DieStamp(func(r *batchv1.JobSpec) {
-		d := SuccessPolicyBlank.DieImmutable(false).DieFeedPtr(r.SuccessPolicy)
-		fn(d)
-		r.SuccessPolicy = d.DieReleasePtr()
-	})
-}
-
-func (d *JobSpecDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *JobSpecDie {
-	return d.DieStamp(func(r *batchv1.JobSpec) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}
-
-func (d *JobSpecDie) TemplateDie(fn func(d *diecorev1.PodTemplateSpecDie)) *JobSpecDie {
-	return d.DieStamp(func(r *batchv1.JobSpec) {
-		d := diecorev1.PodTemplateSpecBlank.DieImmutable(false).DieFeed(r.Template)
-		fn(d)
-		r.Template = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Rules,die=PodFailurePolicyRuleDie,listType=atomic
 type _ = batchv1.PodFailurePolicy
 
-func (d *PodFailurePolicyDie) RulesDie(rules ...*PodFailurePolicyRuleDie) *PodFailurePolicyDie {
-	return d.DieStamp(func(r *batchv1.PodFailurePolicy) {
-		r.Rules = make([]batchv1.PodFailurePolicyRule, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=OnExitCodes,die=PodFailurePolicyOnExitCodesRequirementDie,pointer=true
+// +die:field:name=OnPodConditions,die=PodFailurePolicyOnPodConditionsPatternDie,listType=atomic
 type _ = batchv1.PodFailurePolicyRule
-
-func (d *PodFailurePolicyRuleDie) OnExitCodesDie(fn func(d *PodFailurePolicyOnExitCodesRequirementDie)) *PodFailurePolicyRuleDie {
-	return d.DieStamp(func(r *batchv1.PodFailurePolicyRule) {
-		d := PodFailurePolicyOnExitCodesRequirementBlank.DieImmutable(false).DieFeedPtr(r.OnExitCodes)
-		fn(d)
-		r.OnExitCodes = d.DieReleasePtr()
-	})
-}
-
-func (d *PodFailurePolicyRuleDie) OnPodConditionsDie(patterns ...*PodFailurePolicyOnPodConditionsPatternDie) *PodFailurePolicyRuleDie {
-	return d.DieStamp(func(r *batchv1.PodFailurePolicyRule) {
-		r.OnPodConditions = make([]batchv1.PodFailurePolicyOnPodConditionsPattern, len(patterns))
-		for i := range patterns {
-			r.OnPodConditions[i] = patterns[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = batchv1.PodFailurePolicyOnExitCodesRequirement
@@ -100,21 +48,14 @@ type _ = batchv1.PodFailurePolicyOnExitCodesRequirement
 type _ = batchv1.PodFailurePolicyOnPodConditionsPattern
 
 // +die
+// +die:field:name=Rules,die=SuccessPolicyRuleDie,listType=atomic
 type _ = batchv1.SuccessPolicy
-
-func (d *SuccessPolicyDie) RulesDie(rules ...*SuccessPolicyRuleDie) *SuccessPolicyDie {
-	return d.DieStamp(func(r *batchv1.SuccessPolicy) {
-		r.Rules = make([]batchv1.SuccessPolicyRule, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = batchv1.SuccessPolicyRule
 
 // +die
+// +die:field:name=UncountedTerminatedPods,die=UncountedTerminatedPodsDie,pointer=true
 type _ = batchv1.JobStatus
 
 func (d *JobStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *JobStatusDie {
@@ -130,14 +71,6 @@ func (d *JobStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *Job
 				LastTransitionTime: c.LastTransitionTime,
 			}
 		}
-	})
-}
-
-func (d *JobStatusDie) UncountedTerminatedPodsDie(fn func(d *UncountedTerminatedPodsDie)) *JobStatusDie {
-	return d.DieStamp(func(r *batchv1.JobStatus) {
-		d := UncountedTerminatedPodsBlank.DieImmutable(false).DieFeedPtr(r.UncountedTerminatedPods)
-		fn(d)
-		r.UncountedTerminatedPods = d.DieReleasePtr()
 	})
 }
 

--- a/apis/core/v1/binding.go
+++ b/apis/core/v1/binding.go
@@ -21,12 +21,5 @@ import (
 )
 
 // +die:object=true,apiVersion=v1,kind=Binding
+// +die:field:name=Target,die=ObjectReferenceDie
 type _ = corev1.Binding
-
-func (d *BindingDie) TargetDie(fn func(d *ObjectReferenceDie)) *BindingDie {
-	return d.DieStamp(func(r *corev1.Binding) {
-		d := ObjectReferenceBlank.DieImmutable(false).DieFeed(r.Target)
-		fn(d)
-		r.Target = d.DieRelease()
-	})
-}

--- a/apis/core/v1/common.go
+++ b/apis/core/v1/common.go
@@ -36,16 +36,8 @@ type _ = corev1.TypedObjectReference
 type _ = corev1.SecretReference
 
 // +die
+// +die:field:name=MatchLabelExpressions,die=TopologySelectorLabelRequirementDie,listType=atomic
 type _ = corev1.TopologySelectorTerm
-
-func (d *TopologySelectorTermDie) MatchLabelExpressionsDie(requirements ...*TopologySelectorLabelRequirementDie) *TopologySelectorTermDie {
-	return d.DieStamp(func(r *corev1.TopologySelectorTerm) {
-		r.MatchLabelExpressions = make([]corev1.TopologySelectorLabelRequirement, len(requirements))
-		for i := range requirements {
-			r.MatchLabelExpressions[i] = requirements[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = corev1.TopologySelectorLabelRequirement

--- a/apis/core/v1/container.go
+++ b/apis/core/v1/container.go
@@ -21,171 +21,27 @@ import (
 )
 
 // +die
+// +die:field:name=Resources,die=ResourceRequirementsDie
+// +die:field:name=LivenessProbe,die=ProbeDie,pointer=true
+// +die:field:name=ReadinessProbe,die=ProbeDie,pointer=true
+// +die:field:name=StartupProbe,die=ProbeDie,pointer=true
+// +die:field:name=Lifecycle,die=LifecycleDie,pointer=true
+// +die:field:name=SecurityContext,die=SecurityContextDie,pointer=true
+// +die:field:name=Ports,die=ContainerPortDie,listType=atomic
+// +die:field:name=EnvFrom,die=EnvFromSourceDie,listType=map,listMapKey=Prefix
+// +die:field:name=Env,die=EnvVarDie,listType=map
+// +die:field:name=ResizePolicy,die=ContainerResizePolicyDie,listType=map,listMapKey=ResourceName,listMapKeyPackage=k8s.io/api/core/v1,listMapKeyType=ResourceName
+// +die:field:name=VolumeMounts,die=VolumeMountDie,listType=map
+// +die:field:name=VolumeDevices,die=VolumeDeviceDie,listType=map
 type _ = corev1.Container
-
-func (d *ContainerDie) PortsDie(ports ...*ContainerPortDie) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		r.Ports = make([]corev1.ContainerPort, len(ports))
-		for i := range ports {
-			r.Ports[i] = ports[i].DieRelease()
-		}
-	})
-}
-
-func (d *ContainerDie) EnvFromDie(prefix string, fn func(d *EnvFromSourceDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		for i := range r.EnvFrom {
-			if prefix == r.EnvFrom[i].Prefix {
-				d := EnvFromSourceBlank.DieImmutable(false).DieFeed(r.EnvFrom[i])
-				fn(d)
-				r.EnvFrom[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := EnvFromSourceBlank.DieImmutable(false).DieFeed(corev1.EnvFromSource{Prefix: prefix})
-		fn(d)
-		r.EnvFrom = append(r.EnvFrom, d.DieRelease())
-	})
-}
-
-func (d *ContainerDie) EnvDie(name string, fn func(d *EnvVarDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		for i := range r.Env {
-			if name == r.Env[i].Name {
-				d := EnvVarBlank.DieImmutable(false).DieFeed(r.Env[i])
-				fn(d)
-				r.Env[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := EnvVarBlank.DieImmutable(false).DieFeed(corev1.EnvVar{Name: name})
-		fn(d)
-		r.Env = append(r.Env, d.DieRelease())
-	})
-}
-
-func (d *ContainerDie) ResourcesDie(fn func(d *ResourceRequirementsDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		d := ResourceRequirementsBlank.DieImmutable(false).DieFeed(r.Resources)
-		fn(d)
-		r.Resources = d.DieRelease()
-	})
-}
-
-func (d *ContainerDie) ResizePolicyDie(name corev1.ResourceName, fn func(d *ContainerResizePolicyDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		for i := range r.ResizePolicy {
-			if name == r.ResizePolicy[i].ResourceName {
-				d := ContainerResizePolicyBlank.DieImmutable(false).DieFeed(r.ResizePolicy[i])
-				fn(d)
-				r.ResizePolicy[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ContainerResizePolicyBlank.DieImmutable(false).DieFeed(corev1.ContainerResizePolicy{ResourceName: name})
-		fn(d)
-		r.ResizePolicy = append(r.ResizePolicy, d.DieRelease())
-	})
-}
-
-func (d *ContainerDie) VolumeMountDie(name string, fn func(d *VolumeMountDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		for i := range r.VolumeMounts {
-			if name == r.VolumeMounts[i].Name {
-				d := VolumeMountBlank.DieImmutable(false).DieFeed(r.VolumeMounts[i])
-				fn(d)
-				r.VolumeMounts[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := VolumeMountBlank.DieImmutable(false).DieFeed(corev1.VolumeMount{Name: name})
-		fn(d)
-		r.VolumeMounts = append(r.VolumeMounts, d.DieRelease())
-	})
-}
-
-func (d *ContainerDie) VolumeDeviceDie(name string, fn func(d *VolumeDeviceDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		for i := range r.VolumeDevices {
-			if name == r.VolumeDevices[i].Name {
-				d := VolumeDeviceBlank.DieImmutable(false).DieFeed(r.VolumeDevices[i])
-				fn(d)
-				r.VolumeDevices[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := VolumeDeviceBlank.DieImmutable(false).DieFeed(corev1.VolumeDevice{Name: name})
-		fn(d)
-		r.VolumeDevices = append(r.VolumeDevices, d.DieRelease())
-	})
-}
-
-func (d *ContainerDie) LivenessProbeDie(fn func(d *ProbeDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		d := ProbeBlank.DieImmutable(false).DieFeedPtr(r.LivenessProbe)
-		fn(d)
-		r.LivenessProbe = d.DieReleasePtr()
-	})
-}
-
-func (d *ContainerDie) ReadinessProbeDie(fn func(d *ProbeDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		d := ProbeBlank.DieImmutable(false).DieFeedPtr(r.ReadinessProbe)
-		fn(d)
-		r.ReadinessProbe = d.DieReleasePtr()
-	})
-}
-
-func (d *ContainerDie) StartupProbeDie(fn func(d *ProbeDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		d := ProbeBlank.DieImmutable(false).DieFeedPtr(r.StartupProbe)
-		fn(d)
-		r.StartupProbe = d.DieReleasePtr()
-	})
-}
-
-func (d *ContainerDie) LifecycleDie(fn func(d *LifecycleDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		d := LifecycleBlank.DieImmutable(false).DieFeedPtr(r.Lifecycle)
-		fn(d)
-		r.Lifecycle = d.DieReleasePtr()
-	})
-}
-
-func (d *ContainerDie) SecurityContextDie(fn func(d *SecurityContextDie)) *ContainerDie {
-	return d.DieStamp(func(r *corev1.Container) {
-		d := SecurityContextBlank.DieImmutable(false).DieFeedPtr(r.SecurityContext)
-		fn(d)
-		r.SecurityContext = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ContainerPort
 
 // +die
+// +die:field:name=ConfigMapRef,die=ConfigMapEnvSourceDie,pointer=true
+// +die:field:name=SecretRef,die=SecretEnvSourceDie,pointer=true
 type _ = corev1.EnvFromSource
-
-func (d *EnvFromSourceDie) ConfigMapRefDie(fn func(d *ConfigMapEnvSourceDie)) *EnvFromSourceDie {
-	return d.DieStamp(func(r *corev1.EnvFromSource) {
-		d := ConfigMapEnvSourceBlank.DieImmutable(false).DieFeedPtr(r.ConfigMapRef)
-		fn(d)
-		r.ConfigMapRef = d.DieReleasePtr()
-	})
-}
-
-func (d *EnvFromSourceDie) SecretRefDie(fn func(d *SecretEnvSourceDie)) *EnvFromSourceDie {
-	return d.DieStamp(func(r *corev1.EnvFromSource) {
-		d := SecretEnvSourceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ConfigMapEnvSource
@@ -206,50 +62,15 @@ func (d *SecretEnvSourceDie) Name(v string) *SecretEnvSourceDie {
 }
 
 // +die
+// +die:field:name=ValueFrom,die=EnvVarSourceDie,pointer=true
 type _ = corev1.EnvVar
 
-func (d *EnvVarDie) ValueFromDie(fn func(d *EnvVarSourceDie)) *EnvVarDie {
-	return d.DieStamp(func(r *corev1.EnvVar) {
-		d := EnvVarSourceBlank.DieImmutable(false).DieFeedPtr(r.ValueFrom)
-		fn(d)
-		r.ValueFrom = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=FieldRef,die=ObjectFieldSelectorDie,pointer=true
+// +die:field:name=ResourceFieldRef,die=ResourceFieldSelectorDie,pointer=true
+// +die:field:name=ConfigMapKeyRef,die=ConfigMapKeySelectorDie,pointer=true
+// +die:field:name=SecretKeyRef,die=SecretKeySelectorDie,pointer=true
 type _ = corev1.EnvVarSource
-
-func (d *EnvVarSourceDie) FieldRefDie(fn func(d *ObjectFieldSelectorDie)) *EnvVarSourceDie {
-	return d.DieStamp(func(r *corev1.EnvVarSource) {
-		d := ObjectFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.FieldRef)
-		fn(d)
-		r.FieldRef = d.DieReleasePtr()
-	})
-}
-
-func (d *EnvVarSourceDie) ResourceFieldRefDie(fn func(d *ResourceFieldSelectorDie)) *EnvVarSourceDie {
-	return d.DieStamp(func(r *corev1.EnvVarSource) {
-		d := ResourceFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.ResourceFieldRef)
-		fn(d)
-		r.ResourceFieldRef = d.DieReleasePtr()
-	})
-}
-
-func (d *EnvVarSourceDie) ConfigMapKeyRefDie(fn func(d *ConfigMapKeySelectorDie)) *EnvVarSourceDie {
-	return d.DieStamp(func(r *corev1.EnvVarSource) {
-		d := ConfigMapKeySelectorBlank.DieImmutable(false).DieFeedPtr(r.ConfigMapKeyRef)
-		fn(d)
-		r.ConfigMapKeyRef = d.DieReleasePtr()
-	})
-}
-
-func (d *EnvVarSourceDie) SecretKeyRefDie(fn func(d *SecretKeySelectorDie)) *EnvVarSourceDie {
-	return d.DieStamp(func(r *corev1.EnvVarSource) {
-		d := SecretKeySelectorBlank.DieImmutable(false).DieFeedPtr(r.SecretKeyRef)
-		fn(d)
-		r.SecretKeyRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ObjectFieldSelector
@@ -276,16 +97,9 @@ func (d *SecretKeySelectorDie) Name(v string) *SecretKeySelectorDie {
 }
 
 // +die
+// +die:field:name=Claims,die=ResourceClaimDie,listType=atomic
+// +die:field:name=Claims,die=ResourceClaimDie,listType=map
 type _ = corev1.ResourceRequirements
-
-func (d *ResourceRequirementsDie) ClaimsDie(claims ...*ResourceClaimDie) *ResourceRequirementsDie {
-	return d.DieStamp(func(r *corev1.ResourceRequirements) {
-		r.Claims = make([]corev1.ResourceClaim, len(claims))
-		for i := range claims {
-			r.Claims[i] = claims[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = corev1.ResourceClaim
@@ -300,15 +114,8 @@ type _ = corev1.VolumeMount
 type _ = corev1.VolumeDevice
 
 // +die
+// +die:field:name=ProbeHandler,die=ProbeHandlerDie
 type _ = corev1.Probe
-
-func (d *ProbeDie) ProbeHandlerDie(fn func(d *ProbeHandlerDie)) *ProbeDie {
-	return d.DieStamp(func(r *corev1.Probe) {
-		d := ProbeHandlerBlank.DieImmutable(false).DieFeed(r.ProbeHandler)
-		fn(d)
-		r.ProbeHandler = d.DieRelease()
-	})
-}
 
 func (d *ProbeDie) ExecDie(fn func(d *ExecActionDie)) *ProbeDie {
 	return d.DieStamp(func(r *corev1.Probe) {
@@ -341,108 +148,30 @@ func (d *ProbeDie) TCPSocketDie(fn func(d *TCPSocketActionDie)) *ProbeDie {
 }
 
 // +die
+// +die:field:name=PostStart,die=LifecycleHandlerDie,pointer=true
+// +die:field:name=PreStop,die=LifecycleHandlerDie,pointer=true
 type _ = corev1.Lifecycle
 
-func (d *LifecycleDie) PostStartDie(fn func(d *LifecycleHandlerDie)) *LifecycleDie {
-	return d.DieStamp(func(r *corev1.Lifecycle) {
-		d := LifecycleHandlerBlank.DieImmutable(false).DieFeedPtr(r.PostStart)
-		fn(d)
-		r.PostStart = d.DieReleasePtr()
-	})
-}
-
-func (d *LifecycleDie) PreStopDie(fn func(d *LifecycleHandlerDie)) *LifecycleDie {
-	return d.DieStamp(func(r *corev1.Lifecycle) {
-		d := LifecycleHandlerBlank.DieImmutable(false).DieFeedPtr(r.PreStop)
-		fn(d)
-		r.PreStop = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Exec,die=ExecActionDie,pointer=true
+// +die:field:name=HTTPGet,die=HTTPGetActionDie,pointer=true
+// +die:field:name=TCPSocket,die=TCPSocketActionDie,pointer=true
+// +die:field:name=Sleep,die=SleepActionDie,pointer=true
 type _ = corev1.LifecycleHandler
 
-func (d *LifecycleHandlerDie) ExecDie(fn func(d *ExecActionDie)) *LifecycleHandlerDie {
-	return d.DieStamp(func(r *corev1.LifecycleHandler) {
-		d := ExecActionBlank.DieImmutable(false).DieFeedPtr(r.Exec)
-		fn(d)
-		r.Exec = d.DieReleasePtr()
-	})
-}
-
-func (d *LifecycleHandlerDie) HTTPGetDie(fn func(d *HTTPGetActionDie)) *LifecycleHandlerDie {
-	return d.DieStamp(func(r *corev1.LifecycleHandler) {
-		d := HTTPGetActionBlank.DieImmutable(false).DieFeedPtr(r.HTTPGet)
-		fn(d)
-		r.HTTPGet = d.DieReleasePtr()
-	})
-}
-
-func (d *LifecycleHandlerDie) TCPSocketDie(fn func(d *TCPSocketActionDie)) *LifecycleHandlerDie {
-	return d.DieStamp(func(r *corev1.LifecycleHandler) {
-		d := TCPSocketActionBlank.DieImmutable(false).DieFeedPtr(r.TCPSocket)
-		fn(d)
-		r.TCPSocket = d.DieReleasePtr()
-	})
-}
-
-func (d *LifecycleHandlerDie) SleepDie(fn func(d *SleepActionDie)) *LifecycleHandlerDie {
-	return d.DieStamp(func(r *corev1.LifecycleHandler) {
-		d := SleepActionBlank.DieImmutable(false).DieFeedPtr(r.Sleep)
-		fn(d)
-		r.Sleep = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Exec,die=ExecActionDie,pointer=true
+// +die:field:name=HTTPGet,die=HTTPGetActionDie,pointer=true
+// +die:field:name=TCPSocket,die=TCPSocketActionDie,pointer=true
+// +die:field:name=GRPC,die=GRPCActionDie,pointer=true
 type _ = corev1.ProbeHandler
-
-func (d *ProbeHandlerDie) ExecDie(fn func(d *ExecActionDie)) *ProbeHandlerDie {
-	return d.DieStamp(func(r *corev1.ProbeHandler) {
-		d := ExecActionBlank.DieImmutable(false).DieFeedPtr(r.Exec)
-		fn(d)
-		r.Exec = d.DieReleasePtr()
-	})
-}
-
-func (d *ProbeHandlerDie) HTTPGetDie(fn func(d *HTTPGetActionDie)) *ProbeHandlerDie {
-	return d.DieStamp(func(r *corev1.ProbeHandler) {
-		d := HTTPGetActionBlank.DieImmutable(false).DieFeedPtr(r.HTTPGet)
-		fn(d)
-		r.HTTPGet = d.DieReleasePtr()
-	})
-}
-
-func (d *ProbeHandlerDie) TCPSocketDie(fn func(d *TCPSocketActionDie)) *ProbeHandlerDie {
-	return d.DieStamp(func(r *corev1.ProbeHandler) {
-		d := TCPSocketActionBlank.DieImmutable(false).DieFeedPtr(r.TCPSocket)
-		fn(d)
-		r.TCPSocket = d.DieReleasePtr()
-	})
-}
-
-func (d *ProbeHandlerDie) GRPCDie(fn func(d *GRPCActionDie)) *ProbeHandlerDie {
-	return d.DieStamp(func(r *corev1.ProbeHandler) {
-		d := GRPCActionBlank.DieImmutable(false).DieFeedPtr(r.GRPC)
-		fn(d)
-		r.GRPC = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ExecAction
 
 // +die
+// +die:field:name=HTTPHeaders,die=HTTPHeaderDie,listType=atomic
 type _ = corev1.HTTPGetAction
-
-func (d *HTTPGetActionDie) HTTPHeadersDie(headers ...*HTTPHeaderDie) *HTTPGetActionDie {
-	return d.DieStamp(func(r *corev1.HTTPGetAction) {
-		r.HTTPHeaders = make([]corev1.HTTPHeader, len(headers))
-		for i := range headers {
-			r.HTTPHeaders[i] = headers[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = corev1.HTTPHeader
@@ -457,47 +186,12 @@ type _ = corev1.GRPCAction
 type _ = corev1.SleepAction
 
 // +die
+// +die:field:name=Capabilities,die=CapabilitiesDie,pointer=true
+// +die:field:name=SELinuxOptions,die=SELinuxOptionsDie,pointer=true
+// +die:field:name=WindowsOptions,die=WindowsSecurityContextOptionsDie,pointer=true
+// +die:field:name=SeccompProfile,die=SeccompProfileDie,pointer=true
+// +die:field:name=AppArmorProfile,die=AppArmorProfileDie,pointer=true
 type _ = corev1.SecurityContext
-
-func (d *SecurityContextDie) CapabilitiesDie(fn func(d *CapabilitiesDie)) *SecurityContextDie {
-	return d.DieStamp(func(r *corev1.SecurityContext) {
-		d := CapabilitiesBlank.DieImmutable(false).DieFeedPtr(r.Capabilities)
-		fn(d)
-		r.Capabilities = d.DieReleasePtr()
-	})
-}
-
-func (d *SecurityContextDie) SELinuxOptionsDie(fn func(d *SELinuxOptionsDie)) *SecurityContextDie {
-	return d.DieStamp(func(r *corev1.SecurityContext) {
-		d := SELinuxOptionsBlank.DieImmutable(false).DieFeedPtr(r.SELinuxOptions)
-		fn(d)
-		r.SELinuxOptions = d.DieReleasePtr()
-	})
-}
-
-func (d *SecurityContextDie) WindowsOptionsDie(fn func(d *WindowsSecurityContextOptionsDie)) *SecurityContextDie {
-	return d.DieStamp(func(r *corev1.SecurityContext) {
-		d := WindowsSecurityContextOptionsBlank.DieImmutable(false).DieFeedPtr(r.WindowsOptions)
-		fn(d)
-		r.WindowsOptions = d.DieReleasePtr()
-	})
-}
-
-func (d *SecurityContextDie) SeccompProfileDie(fn func(d *SeccompProfileDie)) *SecurityContextDie {
-	return d.DieStamp(func(r *corev1.SecurityContext) {
-		d := SeccompProfileBlank.DieImmutable(false).DieFeedPtr(r.SeccompProfile)
-		fn(d)
-		r.SeccompProfile = d.DieReleasePtr()
-	})
-}
-
-func (d *SecurityContextDie) AppArmorProfileDie(fn func(d *AppArmorProfileDie)) *SecurityContextDie {
-	return d.DieStamp(func(r *corev1.SecurityContext) {
-		d := AppArmorProfileBlank.DieImmutable(false).DieFeedPtr(r.AppArmorProfile)
-		fn(d)
-		r.AppArmorProfile = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.Capabilities
@@ -515,75 +209,17 @@ type _ = corev1.SeccompProfile
 type _ = corev1.AppArmorProfile
 
 // +die
+// +die:field:name=State,die=ContainerStateDie
+// +die:field:name=LastTerminationState,die=ContainerStateDie
+// +die:field:name=Resources,die=ResourceRequirementsDie,pointer=true
+// +die:field:name=VolumeMounts,die=VolumeMountStatusDie,listType=map
 type _ = corev1.ContainerStatus
 
-func (d *ContainerStatusDie) StateDie(fn func(d *ContainerStateDie)) *ContainerStatusDie {
-	return d.DieStamp(func(r *corev1.ContainerStatus) {
-		d := ContainerStateBlank.DieImmutable(false).DieFeed(r.State)
-		fn(d)
-		r.State = d.DieRelease()
-	})
-}
-
-func (d *ContainerStatusDie) LastTerminationStateDie(fn func(d *ContainerStateDie)) *ContainerStatusDie {
-	return d.DieStamp(func(r *corev1.ContainerStatus) {
-		d := ContainerStateBlank.DieImmutable(false).DieFeed(r.LastTerminationState)
-		fn(d)
-		r.LastTerminationState = d.DieRelease()
-	})
-}
-
-func (d *ContainerStatusDie) ResourcesDie(fn func(d *ResourceRequirementsDie)) *ContainerStatusDie {
-	return d.DieStamp(func(r *corev1.ContainerStatus) {
-		d := ResourceRequirementsBlank.DieImmutable(false).DieFeedPtr(r.Resources)
-		fn(d)
-		r.Resources = d.DieReleasePtr()
-	})
-}
-
-func (d *ContainerStatusDie) VolumeMountDie(name string, fn func(d *VolumeMountStatusDie)) *ContainerStatusDie {
-	return d.DieStamp(func(r *corev1.ContainerStatus) {
-		for i := range r.VolumeMounts {
-			if name == r.VolumeMounts[i].Name {
-				d := VolumeMountStatusBlank.DieImmutable(false).DieFeed(r.VolumeMounts[i])
-				fn(d)
-				r.VolumeMounts[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := VolumeMountStatusBlank.DieImmutable(false).DieFeed(corev1.VolumeMountStatus{Name: name})
-		fn(d)
-		r.VolumeMounts = append(r.VolumeMounts, d.DieRelease())
-	})
-}
-
 // +die
+// +die:field:name=Waiting,die=ContainerStateWaitingDie,pointer=true
+// +die:field:name=Running,die=ContainerStateRunningDie,pointer=true
+// +die:field:name=Terminated,die=ContainerStateTerminatedDie,pointer=true
 type _ = corev1.ContainerState
-
-func (d *ContainerStateDie) WaitingDie(fn func(d *ContainerStateWaitingDie)) *ContainerStateDie {
-	return d.DieStamp(func(r *corev1.ContainerState) {
-		d := ContainerStateWaitingBlank.DieImmutable(false).DieFeedPtr(r.Waiting)
-		fn(d)
-		r.Waiting = d.DieReleasePtr()
-	})
-}
-
-func (d *ContainerStateDie) RunningDie(fn func(d *ContainerStateRunningDie)) *ContainerStateDie {
-	return d.DieStamp(func(r *corev1.ContainerState) {
-		d := ContainerStateRunningBlank.DieImmutable(false).DieFeedPtr(r.Running)
-		fn(d)
-		r.Running = d.DieReleasePtr()
-	})
-}
-
-func (d *ContainerStateDie) TerminatedDie(fn func(d *ContainerStateTerminatedDie)) *ContainerStateDie {
-	return d.DieStamp(func(r *corev1.ContainerState) {
-		d := ContainerStateTerminatedBlank.DieImmutable(false).DieFeedPtr(r.Terminated)
-		fn(d)
-		r.Terminated = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ContainerStateWaiting

--- a/apis/core/v1/endpoints.go
+++ b/apis/core/v1/endpoints.go
@@ -21,57 +21,18 @@ import (
 )
 
 // +die:object=true,apiVersion=v1,kind=Endpoints
+// +die:field:name=Subsets,die=EndpointSubsetDie,listType=atomic
 type _ = corev1.Endpoints
 
-func (d *EndpointsDie) SubsetsDie(subsets ...*EndpointSubsetDie) *EndpointsDie {
-	return d.DieStamp(func(r *corev1.Endpoints) {
-		r.Subsets = make([]corev1.EndpointSubset, len(subsets))
-		for i := range subsets {
-			r.Subsets[i] = subsets[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Addresses,die=EndpointAddressDie,listType=atomic
+// +die:field:name=NotReadyAddresses,die=EndpointAddressDie,listType=atomic
+// +die:field:name=Ports,die=EndpointPortDie,listType=atomic
 type _ = corev1.EndpointSubset
 
-func (d *EndpointSubsetDie) AddressesDie(addresses ...*EndpointAddressDie) *EndpointSubsetDie {
-	return d.DieStamp(func(r *corev1.EndpointSubset) {
-		r.Addresses = make([]corev1.EndpointAddress, len(addresses))
-		for i := range addresses {
-			r.Addresses[i] = addresses[i].DieRelease()
-		}
-	})
-}
-
-func (d *EndpointSubsetDie) NotReadyAddressesDie(addresses ...*EndpointAddressDie) *EndpointSubsetDie {
-	return d.DieStamp(func(r *corev1.EndpointSubset) {
-		r.NotReadyAddresses = make([]corev1.EndpointAddress, len(addresses))
-		for i := range addresses {
-			r.NotReadyAddresses[i] = addresses[i].DieRelease()
-		}
-	})
-}
-
-func (d *EndpointSubsetDie) PortsDie(ports ...*EndpointPortDie) *EndpointSubsetDie {
-	return d.DieStamp(func(r *corev1.EndpointSubset) {
-		r.Ports = make([]corev1.EndpointPort, len(ports))
-		for i := range ports {
-			r.Ports[i] = ports[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=TargetRef,die=ObjectReferenceDie,pointer=true
 type _ = corev1.EndpointAddress
-
-func (d *EndpointAddressDie) TargetRefDie(fn func(d *ObjectReferenceDie)) *EndpointAddressDie {
-	return d.DieStamp(func(r *corev1.EndpointAddress) {
-		d := ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.TargetRef)
-		fn(d)
-		r.TargetRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.EndpointPort

--- a/apis/core/v1/event.go
+++ b/apis/core/v1/event.go
@@ -21,39 +21,11 @@ import (
 )
 
 // +die:object=true,apiVersion=v1,kind=Event
+// +die:field:name=InvolvedObject,die=ObjectReferenceDie
+// +die:field:name=Source,die=EventSourceDie
+// +die:field:name=Series,die=EventSeriesDie,pointer=true
+// +die:field:name=Related,die=ObjectReferenceDie,pointer=true
 type _ = corev1.Event
-
-func (d *EventDie) InvolvedObjectDie(fn func(d *ObjectReferenceDie)) *EventDie {
-	return d.DieStamp(func(r *corev1.Event) {
-		d := ObjectReferenceBlank.DieImmutable(false).DieFeed(r.InvolvedObject)
-		fn(d)
-		r.InvolvedObject = d.DieRelease()
-	})
-}
-
-func (d *EventDie) SourceDie(fn func(d *EventSourceDie)) *EventDie {
-	return d.DieStamp(func(r *corev1.Event) {
-		d := EventSourceBlank.DieImmutable(false).DieFeed(r.Source)
-		fn(d)
-		r.Source = d.DieRelease()
-	})
-}
-
-func (d *EventDie) SeriesDie(fn func(d *EventSeriesDie)) *EventDie {
-	return d.DieStamp(func(r *corev1.Event) {
-		d := EventSeriesBlank.DieImmutable(false).DieFeedPtr(r.Series)
-		fn(d)
-		r.Series = d.DieReleasePtr()
-	})
-}
-
-func (d *EventDie) RelatedDie(fn func(d *ObjectReferenceDie)) *EventDie {
-	return d.DieStamp(func(r *corev1.Event) {
-		d := ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.Related)
-		fn(d)
-		r.Related = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.EventSource

--- a/apis/core/v1/limitrange.go
+++ b/apis/core/v1/limitrange.go
@@ -24,16 +24,8 @@ import (
 type _ = corev1.LimitRange
 
 // +die
+// +die:field:name=Limits,die=LimitRangeItemDie,listType=atomic
 type _ = corev1.LimitRangeSpec
-
-func (d *LimitRangeSpecDie) LimitsDie(limits ...*LimitRangeItemDie) *LimitRangeSpecDie {
-	return d.DieStamp(func(r *corev1.LimitRangeSpec) {
-		r.Limits = make([]corev1.LimitRangeItem, len(limits))
-		for i := range r.Limits {
-			r.Limits[i] = limits[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = corev1.LimitRangeItem

--- a/apis/core/v1/node.go
+++ b/apis/core/v1/node.go
@@ -25,51 +25,28 @@ import (
 type _ = corev1.Node
 
 // +die
+// +die:field:name=ConfigSource,die=NodeConfigSourceDie,pointer=true
+// +die:field:name=Taints,die=TaintDie,listType=map,listMapKey=Key
 type _ = corev1.NodeSpec
-
-func (d *NodeSpecDie) TaintDie(key string, fn func(d *TaintDie)) *NodeSpecDie {
-	return d.DieStamp(func(r *corev1.NodeSpec) {
-		for i := range r.Taints {
-			if key == r.Taints[i].Key {
-				d := TaintBlank.DieImmutable(false).DieFeed(r.Taints[i])
-				fn(d)
-				r.Taints[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := TaintBlank.DieImmutable(false).DieFeed(corev1.Taint{Key: key})
-		fn(d)
-		r.Taints = append(r.Taints, d.DieRelease())
-	})
-}
-
-func (d *NodeSpecDie) ConfigSourceDie(fn func(d *NodeConfigSourceDie)) *NodeSpecDie {
-	return d.DieStamp(func(r *corev1.NodeSpec) {
-		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.ConfigSource)
-		fn(d)
-		r.ConfigSource = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.Taint
 
 // +die
+// +die:field:name=ConfigMap,die=ConfigMapNodeConfigSourceDie,pointer=true
 type _ = corev1.NodeConfigSource
-
-func (d *NodeConfigSourceDie) ConfigMapDie(fn func(d *ConfigMapNodeConfigSourceDie)) *NodeConfigSourceDie {
-	return d.DieStamp(func(r *corev1.NodeConfigSource) {
-		d := ConfigMapNodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.ConfigMap)
-		fn(d)
-		r.ConfigMap = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ConfigMapNodeConfigSource
 
 // +die
+// +die:field:name=DaemonEndpoints,die=NodeDaemonEndpointsDie
+// +die:field:name=NodeInfo,die=NodeSystemInfoDie
+// +die:field:name=Config,die=NodeConfigStatusDie,pointer=true
+// +die:field:name=Addresses,die=NodeAddressDie,listType=atomic
+// +die:field:name=Images,die=ContainerImageDie,listType=atomic
+// +die:field:name=VolumesAttached,method=VolumeAttachedDie,die=AttachedVolumeDie,listType=map,listMapKeyPackage=k8s.io/api/core/v1,listMapKeyType=UniqueVolumeName
+// +die:field:name=RuntimeHandlers,die=NodeRuntimeHandlerDie,listType=atomic
 type _ = corev1.NodeStatus
 
 func (d *NodeStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *NodeStatusDie {
@@ -88,87 +65,17 @@ func (d *NodeStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *No
 	})
 }
 
+// deprecated: use AddressesDie
 func (d *NodeStatusDie) AddresssDie(addresses ...*NodeAddressDie) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		r.Addresses = make([]corev1.NodeAddress, len(addresses))
-		for i := range addresses {
-			r.Addresses[i] = addresses[i].DieRelease()
-		}
-	})
-}
-
-func (d *NodeStatusDie) DaemonEndpointsDie(fn func(d *NodeDaemonEndpointsDie)) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		d := NodeDaemonEndpointsBlank.DieImmutable(false).DieFeed(r.DaemonEndpoints)
-		fn(d)
-		r.DaemonEndpoints = d.DieRelease()
-	})
-}
-
-func (d *NodeStatusDie) NodeInfoDie(fn func(d *NodeSystemInfoDie)) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		d := NodeSystemInfoBlank.DieImmutable(false).DieFeed(r.NodeInfo)
-		fn(d)
-		r.NodeInfo = d.DieRelease()
-	})
-}
-
-func (d *NodeStatusDie) ImagesDie(images ...*ContainerImageDie) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		r.Images = make([]corev1.ContainerImage, len(images))
-		for i := range images {
-			r.Images[i] = images[i].DieRelease()
-		}
-	})
-}
-
-func (d *NodeStatusDie) VolumeAttachedDie(name corev1.UniqueVolumeName, fn func(d *AttachedVolumeDie)) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		for i := range r.VolumesAttached {
-			if name == r.VolumesAttached[i].Name {
-				d := AttachedVolumeBlank.DieImmutable(false).DieFeed(r.VolumesAttached[i])
-				fn(d)
-				r.VolumesAttached[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := AttachedVolumeBlank.DieImmutable(false).DieFeed(corev1.AttachedVolume{Name: name})
-		fn(d)
-		r.VolumesAttached = append(r.VolumesAttached, d.DieRelease())
-	})
-}
-
-func (d *NodeStatusDie) ConfigDie(fn func(d *NodeConfigStatusDie)) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		d := NodeConfigStatusBlank.DieImmutable(false).DieFeedPtr(r.Config)
-		fn(d)
-		r.Config = d.DieReleasePtr()
-	})
-}
-
-func (d *NodeStatusDie) RuntimeHandlersDie(handlers ...*NodeRuntimeHandlerDie) *NodeStatusDie {
-	return d.DieStamp(func(r *corev1.NodeStatus) {
-		r.RuntimeHandlers = make([]corev1.NodeRuntimeHandler, len(handlers))
-		for i := range handlers {
-			r.RuntimeHandlers[i] = handlers[i].DieRelease()
-		}
-	})
+	return d.AddressesDie(addresses...)
 }
 
 // +die
 type _ = corev1.NodeAddress
 
 // +die
+// +die:field:name=KubeletEndpoint,die=DaemonEndpointDie
 type _ = corev1.NodeDaemonEndpoints
-
-func (d *NodeDaemonEndpointsDie) KubeletEndpointDie(fn func(d *DaemonEndpointDie)) *NodeDaemonEndpointsDie {
-	return d.DieStamp(func(r *corev1.NodeDaemonEndpoints) {
-		d := DaemonEndpointBlank.DieImmutable(false).DieFeed(r.KubeletEndpoint)
-		fn(d)
-		r.KubeletEndpoint = d.DieRelease()
-	})
-}
 
 // +die
 type _ = corev1.DaemonEndpoint
@@ -183,42 +90,14 @@ type _ = corev1.ContainerImage
 type _ = corev1.AttachedVolume
 
 // +die
+// +die:field:name=Assigned,die=NodeConfigSourceDie,pointer=true
+// +die:field:name=Active,die=NodeConfigSourceDie,pointer=true
+// +die:field:name=LastKnownGood,die=NodeConfigSourceDie,pointer=true
 type _ = corev1.NodeConfigStatus
 
-func (d *NodeConfigStatusDie) AssignedDie(fn func(d *NodeConfigSourceDie)) *NodeConfigStatusDie {
-	return d.DieStamp(func(r *corev1.NodeConfigStatus) {
-		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.Assigned)
-		fn(d)
-		r.Assigned = d.DieReleasePtr()
-	})
-}
-
-func (d *NodeConfigStatusDie) ActiveDie(fn func(d *NodeConfigSourceDie)) *NodeConfigStatusDie {
-	return d.DieStamp(func(r *corev1.NodeConfigStatus) {
-		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.Active)
-		fn(d)
-		r.Active = d.DieReleasePtr()
-	})
-}
-
-func (d *NodeConfigStatusDie) LastKnownGoodDie(fn func(d *NodeConfigSourceDie)) *NodeConfigStatusDie {
-	return d.DieStamp(func(r *corev1.NodeConfigStatus) {
-		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.LastKnownGood)
-		fn(d)
-		r.LastKnownGood = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Features,die=NodeRuntimeHandlerFeaturesDie,pointer=true
 type _ = corev1.NodeRuntimeHandler
-
-func (d *NodeRuntimeHandlerDie) FeaturesDie(fn func(d *NodeRuntimeHandlerFeaturesDie)) *NodeRuntimeHandlerDie {
-	return d.DieStamp(func(r *corev1.NodeRuntimeHandler) {
-		d := NodeRuntimeHandlerFeaturesBlank.DieImmutable(false).DieFeedPtr(r.Features)
-		fn(d)
-		r.Features = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.NodeRuntimeHandlerFeatures

--- a/apis/core/v1/persistantvolume.go
+++ b/apis/core/v1/persistantvolume.go
@@ -24,6 +24,7 @@ import (
 type _ = corev1.PersistentVolume
 
 // +die
+// +die:field:name=NodeAffinity,die=VolumeNodeAffinityDie,pointer=true
 type _ = corev1.PersistentVolumeSpec
 
 func (d *PersistentVolumeSpecDie) GCEPersistentDiskDie(fn func(d *GCEPersistentDiskVolumeSourceDie)) *PersistentVolumeSpecDie {
@@ -254,14 +255,6 @@ func (d *PersistentVolumeSpecDie) ClaimRefDie(fn func(d *ObjectReferenceDie)) *P
 	})
 }
 
-func (d *PersistentVolumeSpecDie) NodeAffinityDie(fn func(d *VolumeNodeAffinityDie)) *PersistentVolumeSpecDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeSpec) {
-		d := VolumeNodeAffinityBlank.DieImmutable(false).DieFeedPtr(r.NodeAffinity)
-		fn(d)
-		r.NodeAffinity = d.DieReleasePtr()
-	})
-}
-
 // +die
 type _ = corev1.PersistentVolumeStatus
 
@@ -269,89 +262,45 @@ type _ = corev1.PersistentVolumeStatus
 type _ = corev1.GlusterfsPersistentVolumeSource
 
 // +die
+// +die:field:name=SecretRef,die=SecretReferenceDie,pointer=true
 type _ = corev1.RBDPersistentVolumeSource
 
-func (d *RBDPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *RBDPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.RBDPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=SecretReferenceDie,pointer=true
 type _ = corev1.ISCSIPersistentVolumeSource
 
-func (d *ISCSIPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *ISCSIPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.ISCSIPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=SecretReferenceDie,pointer=true
 type _ = corev1.CinderPersistentVolumeSource
 
-func (d *CinderPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *CinderPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CinderPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=SecretReferenceDie,pointer=true
 type _ = corev1.CephFSPersistentVolumeSource
 
-func (d *CephFSPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *CephFSPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CephFSPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=SecretReferenceDie,pointer=true
 type _ = corev1.FlexPersistentVolumeSource
-
-func (d *FlexPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *FlexPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.FlexPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.AzureFilePersistentVolumeSource
 
 // +die
+// +die:field:name=SecretRef,die=SecretReferenceDie,pointer=true
 type _ = corev1.ScaleIOPersistentVolumeSource
-
-func (d *ScaleIOPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *ScaleIOPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.ScaleIOPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.LocalVolumeSource
 
 // +die
+// +die:field:name=SecretRef,die=ObjectReferenceDie,pointer=true
 type _ = corev1.StorageOSPersistentVolumeSource
 
-func (d *StorageOSPersistentVolumeSourceDie) SecretRefDie(fn func(d *ObjectReferenceDie)) *StorageOSPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.StorageOSPersistentVolumeSource) {
-		d := ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=ControllerPublishSecretRef,die=SecretReferenceDie,pointer=true
+// +die:field:name=NodeStageSecretRef,die=SecretReferenceDie,pointer=true
+// +die:field:name=NodePublishSecretRef,die=SecretReferenceDie,pointer=true
+// +die:field:name=ControllerExpandSecretRef,die=SecretReferenceDie,pointer=true
+// +die:field:name=NodeExpandSecretRef,die=SecretReferenceDie,pointer=true
 type _ = corev1.CSIPersistentVolumeSource
 
 func (d *CSIPersistentVolumeSourceDie) AddVolumeAttributes(key, value string) *CSIPersistentVolumeSourceDie {
@@ -363,104 +312,22 @@ func (d *CSIPersistentVolumeSourceDie) AddVolumeAttributes(key, value string) *C
 	})
 }
 
-func (d *CSIPersistentVolumeSourceDie) ControllerPublishSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.ControllerPublishSecretRef)
-		fn(d)
-		r.ControllerPublishSecretRef = d.DieReleasePtr()
-	})
-}
-
-func (d *CSIPersistentVolumeSourceDie) NodeStageSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodeStageSecretRef)
-		fn(d)
-		r.NodeStageSecretRef = d.DieReleasePtr()
-	})
-}
-
-func (d *CSIPersistentVolumeSourceDie) NodePublishSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodePublishSecretRef)
-		fn(d)
-		r.NodePublishSecretRef = d.DieReleasePtr()
-	})
-}
-
-func (d *CSIPersistentVolumeSourceDie) ControllerExpandSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.ControllerExpandSecretRef)
-		fn(d)
-		r.ControllerExpandSecretRef = d.DieReleasePtr()
-	})
-}
-
-func (d *CSIPersistentVolumeSourceDie) NodeExpandSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
-		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodeExpandSecretRef)
-		fn(d)
-		r.NodeExpandSecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Required,die=NodeSelectorDie,pointer=true
 type _ = corev1.VolumeNodeAffinity
 
-func (d *VolumeNodeAffinityDie) RequiredDie(fn func(d *NodeSelectorDie)) *VolumeNodeAffinityDie {
-	return d.DieStamp(func(r *corev1.VolumeNodeAffinity) {
-		d := NodeSelectorBlank.DieImmutable(false).DieFeedPtr(r.Required)
-		fn(d)
-		r.Required = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=NodeSelectorTerms,die=NodeSelectorTermDie,listType=atomic
 type _ = corev1.NodeSelector
 
-func (d *NodeSelectorDie) NodeSelectorTermsDie(terms ...*NodeSelectorTermDie) *NodeSelectorDie {
-	return d.DieStamp(func(r *corev1.NodeSelector) {
-		r.NodeSelectorTerms = make([]corev1.NodeSelectorTerm, len(terms))
-		for i := range terms {
-			r.NodeSelectorTerms[i] = terms[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=MatchExpressions,die=NodeSelectorRequirementDie,listMapKey=Key
+// +die:field:name=MatchFields,die=NodeSelectorRequirementDie,listMapKey=Key
 type _ = corev1.NodeSelectorTerm
 
-func (d *NodeSelectorTermDie) MatchExpressionDie(key string, fn func(d *NodeSelectorRequirementDie)) *NodeSelectorTermDie {
-	return d.DieStamp(func(r *corev1.NodeSelectorTerm) {
-		for i := range r.MatchExpressions {
-			if key == r.MatchExpressions[i].Key {
-				d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(r.MatchExpressions[i])
-				fn(d)
-				r.MatchExpressions[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(corev1.NodeSelectorRequirement{Key: key})
-		fn(d)
-		r.MatchExpressions = append(r.MatchExpressions, d.DieRelease())
-	})
-}
-
+// deprecated: use MatchFieldDie
 func (d *NodeSelectorTermDie) MatchFieldsDie(key string, fn func(d *NodeSelectorRequirementDie)) *NodeSelectorTermDie {
-	return d.DieStamp(func(r *corev1.NodeSelectorTerm) {
-		for i := range r.MatchFields {
-			if key == r.MatchFields[i].Key {
-				d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(r.MatchFields[i])
-				fn(d)
-				r.MatchFields[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(corev1.NodeSelectorRequirement{Key: key})
-		fn(d)
-		r.MatchFields = append(r.MatchFields, d.DieRelease())
-	})
+	return d.MatchFieldDie(key, fn)
 }
 
 // +die

--- a/apis/core/v1/persistantvolumeclaim.go
+++ b/apis/core/v1/persistantvolumeclaim.go
@@ -25,44 +25,17 @@ import (
 type _ = corev1.PersistentVolumeClaim
 
 // +die
+// +die:field:name=Selector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=Resources,die=VolumeResourceRequirementsDie
+// +die:field:name=DataSource,die=TypedLocalObjectReferenceDie,pointer=true
+// +die:field:name=DataSourceRef,die=TypedObjectReferenceDie,pointer=true
 type _ = corev1.PersistentVolumeClaimSpec
-
-func (d *PersistentVolumeClaimSpecDie) SelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *PersistentVolumeClaimSpecDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
-		fn(d)
-		r.Selector = d.DieReleasePtr()
-	})
-}
-
-func (d *PersistentVolumeClaimSpecDie) ResourcesDie(fn func(d *VolumeResourceRequirementsDie)) *PersistentVolumeClaimSpecDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
-		d := VolumeResourceRequirementsBlank.DieImmutable(false).DieFeed(r.Resources)
-		fn(d)
-		r.Resources = d.DieRelease()
-	})
-}
-
-func (d *PersistentVolumeClaimSpecDie) DataSourceDie(fn func(d *TypedLocalObjectReferenceDie)) *PersistentVolumeClaimSpecDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
-		d := TypedLocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.DataSource)
-		fn(d)
-		r.DataSource = d.DieReleasePtr()
-	})
-}
-
-func (d *PersistentVolumeClaimSpecDie) DataSourceRefDie(fn func(d *TypedObjectReferenceDie)) *PersistentVolumeClaimSpecDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
-		d := TypedObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.DataSourceRef)
-		fn(d)
-		r.DataSourceRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.VolumeResourceRequirements
 
 // +die:ignore={AllocatedResourceStatuses}
+// +die:field:name=ModifyVolumeStatus,die=ModifyVolumeStatusDie,pointer=true
 type _ = corev1.PersistentVolumeClaimStatus
 
 func (d *PersistentVolumeClaimStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *PersistentVolumeClaimStatusDie {
@@ -134,32 +107,10 @@ func (d *PersistentVolumeClaimStatusDie) AddAllocatedResourceStatus(name corev1.
 	})
 }
 
-func (d *PersistentVolumeClaimStatusDie) ModifyVolumeStatusDie(fn func(d *ModifyVolumeStatusDie)) *PersistentVolumeClaimStatusDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
-		d := ModifyVolumeStatusBlank.DieImmutable(false).DieFeedPtr(r.ModifyVolumeStatus)
-		fn(d)
-		r.ModifyVolumeStatus = d.DieReleasePtr()
-	})
-}
-
 // +die
 type _ corev1.ModifyVolumeStatus
 
 // +die
+// +die:field:name=ObjectMeta,package=_/meta/v1,die=ObjectMetaDie
+// +die:field:name=Spec,die=PersistentVolumeClaimSpecDie
 type _ corev1.PersistentVolumeClaimTemplate
-
-func (d *PersistentVolumeClaimTemplateDie) MetadataDie(fn func(d *diemetav1.ObjectMetaDie)) *PersistentVolumeClaimTemplateDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimTemplate) {
-		d := diemetav1.ObjectMetaBlank.DieImmutable(false).DieFeed(r.ObjectMeta)
-		fn(d)
-		r.ObjectMeta = d.DieRelease()
-	})
-}
-
-func (d *PersistentVolumeClaimTemplateDie) SpecDie(fn func(d *PersistentVolumeClaimSpecDie)) *PersistentVolumeClaimTemplateDie {
-	return d.DieStamp(func(r *corev1.PersistentVolumeClaimTemplate) {
-		d := PersistentVolumeClaimSpecBlank.DieImmutable(false).DieFeed(r.Spec)
-		fn(d)
-		r.Spec = d.DieRelease()
-	})
-}

--- a/apis/core/v1/pod.go
+++ b/apis/core/v1/pod.go
@@ -25,213 +25,38 @@ import (
 type _ = corev1.Pod
 
 // +die
+// +die:field:name=SecurityContext,die=PodSecurityContextDie,pointer=true
+// +die:field:name=DNSConfig,die=PodDNSConfigDie,pointer=true
+// +die:field:name=OS,die=PodOSDie,pointer=true
+// +die:field:name=Volumes,die=VolumeDie,listType=map
+// +die:field:name=InitContainers,die=ContainerDie,listType=map
+// +die:field:name=Containers,die=ContainerDie,listType=map
+// +die:field:name=Tolerations,die=TolerationDie,listMapKey=Key
+// +die:field:name=HostAliases,die=HostAliasDie,listType=atomic
+// +die:field:name=ReadinessGates,die=PodReadinessGateDie,listType=atomic
+// +die:field:name=TopologySpreadConstraints,die=TopologySpreadConstraintDie,listMapKey=TopologyKey
+// +die:field:name=SchedulingGates,die=PodSchedulingGateDie,listType=atomic
+// +die:field:name=ResourceClaims,die=PodResourceClaimDie,listType=atomic
 type _ = corev1.PodSpec
-
-func (d *PodSpecDie) VolumeDie(name string, fn func(d *VolumeDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		for i := range r.Volumes {
-			if name == r.Volumes[i].Name {
-				d := VolumeBlank.DieImmutable(false).DieFeed(r.Volumes[i])
-				fn(d)
-				r.Volumes[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := VolumeBlank.DieImmutable(false).DieFeed(corev1.Volume{Name: name})
-		fn(d)
-		r.Volumes = append(r.Volumes, d.DieRelease())
-	})
-}
-
-func (d *PodSpecDie) InitContainerDie(name string, fn func(d *ContainerDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		for i := range r.InitContainers {
-			if name == r.InitContainers[i].Name {
-				d := ContainerBlank.DieImmutable(false).DieFeed(r.InitContainers[i])
-				fn(d)
-				r.InitContainers[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ContainerBlank.DieImmutable(false).DieFeed(corev1.Container{Name: name})
-		fn(d)
-		r.InitContainers = append(r.InitContainers, d.DieRelease())
-	})
-}
-
-func (d *PodSpecDie) ContainerDie(name string, fn func(d *ContainerDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		for i := range r.Containers {
-			if name == r.Containers[i].Name {
-				d := ContainerBlank.DieImmutable(false).DieFeed(r.Containers[i])
-				fn(d)
-				r.Containers[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ContainerBlank.DieImmutable(false).DieFeed(corev1.Container{Name: name})
-		fn(d)
-		r.Containers = append(r.Containers, d.DieRelease())
-	})
-}
-
-func (d *PodSpecDie) SecurityContextDie(fn func(d *PodSecurityContextDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		d := PodSecurityContextBlank.DieImmutable(false).DieFeedPtr(r.SecurityContext)
-		fn(d)
-		r.SecurityContext = d.DieReleasePtr()
-	})
-}
-
-func (d *PodSpecDie) TolerationDie(key string, fn func(d *TolerationDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		for i := range r.Tolerations {
-			if key == r.Tolerations[i].Key {
-				d := TolerationBlank.DieImmutable(false).DieFeed(r.Tolerations[i])
-				fn(d)
-				r.Tolerations[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := TolerationBlank.DieImmutable(false).DieFeed(corev1.Toleration{Key: key})
-		fn(d)
-		r.Tolerations = append(r.Tolerations, d.DieRelease())
-	})
-}
-
-func (d *PodSpecDie) HostAliasesDie(hosts ...*HostAliasDie) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		r.HostAliases = make([]corev1.HostAlias, len(hosts))
-		for i := range hosts {
-			r.HostAliases[i] = hosts[i].DieRelease()
-		}
-	})
-}
-
-func (d *PodSpecDie) DNSConfigDie(fn func(d *PodDNSConfigDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		d := PodDNSConfigBlank.DieImmutable(false).DieFeedPtr(r.DNSConfig)
-		fn(d)
-		r.DNSConfig = d.DieReleasePtr()
-	})
-}
-
-func (d *PodSpecDie) ReadinessGatesDie(gates ...*PodReadinessGateDie) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		r.ReadinessGates = make([]corev1.PodReadinessGate, len(gates))
-		for i := range gates {
-			r.ReadinessGates[i] = gates[i].DieRelease()
-		}
-	})
-}
-
-func (d *PodSpecDie) TopologySpreadConstraintDie(topologyKey string, fn func(d *TopologySpreadConstraintDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		for i := range r.TopologySpreadConstraints {
-			if topologyKey == r.TopologySpreadConstraints[i].TopologyKey {
-				d := TopologySpreadConstraintBlank.DieImmutable(false).DieFeed(r.TopologySpreadConstraints[i])
-				fn(d)
-				r.TopologySpreadConstraints[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := TopologySpreadConstraintBlank.DieImmutable(false).DieFeed(corev1.TopologySpreadConstraint{TopologyKey: topologyKey})
-		fn(d)
-		r.TopologySpreadConstraints = append(r.TopologySpreadConstraints, d.DieRelease())
-	})
-}
-
-func (d *PodSpecDie) OSDie(fn func(d *PodOSDie)) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		d := PodOSBlank.DieImmutable(false).DieFeedPtr(r.OS)
-		fn(d)
-		r.OS = d.DieReleasePtr()
-	})
-}
-
-func (d *PodSpecDie) SchedulingGatesDie(gates ...*PodSchedulingGateDie) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		r.SchedulingGates = make([]corev1.PodSchedulingGate, len(gates))
-		for i := range gates {
-			r.SchedulingGates[i] = gates[i].DieRelease()
-		}
-	})
-}
-
-func (d *PodSpecDie) ResourceClaimsDie(gates ...*PodResourceClaimDie) *PodSpecDie {
-	return d.DieStamp(func(r *corev1.PodSpec) {
-		r.ResourceClaims = make([]corev1.PodResourceClaim, len(gates))
-		for i := range gates {
-			r.ResourceClaims[i] = gates[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = corev1.PodSchedulingGate
 
 // +die
+// +die:field:name=Source,die=ClaimSourceDie
 type _ = corev1.PodResourceClaim
-
-func (d *PodResourceClaimDie) SourceDie(fn func(d *ClaimSourceDie)) *PodResourceClaimDie {
-	return d.DieStamp(func(r *corev1.PodResourceClaim) {
-		d := ClaimSourceBlank.DieImmutable(false).DieFeed(r.Source)
-		fn(d)
-		r.Source = d.DieRelease()
-	})
-}
 
 // +die
 type _ = corev1.ClaimSource
 
 // +die
+// +die:field:name=SELinuxOptions,die=SELinuxOptionsDie,pointer=true
+// +die:field:name=WindowsOptions,die=WindowsSecurityContextOptionsDie,pointer=true
+// +die:field:name=AppArmorProfile,die=AppArmorProfileDie,pointer=true
+// +die:field:name=Sysctls,die=SysctlDie,listType=atomic
+// +die:field:name=SeccompProfile,die=SeccompProfileDie,pointer=true
+
 type _ = corev1.PodSecurityContext
-
-func (d *PodSecurityContextDie) SELinuxOptionsDie(fn func(d *SELinuxOptionsDie)) *PodSecurityContextDie {
-	return d.DieStamp(func(r *corev1.PodSecurityContext) {
-		d := SELinuxOptionsBlank.DieImmutable(false).DieFeedPtr(r.SELinuxOptions)
-		fn(d)
-		r.SELinuxOptions = d.DieReleasePtr()
-	})
-}
-
-func (d *PodSecurityContextDie) WindowsOptionsDie(fn func(d *WindowsSecurityContextOptionsDie)) *PodSecurityContextDie {
-	return d.DieStamp(func(r *corev1.PodSecurityContext) {
-		d := WindowsSecurityContextOptionsBlank.DieImmutable(false).DieFeedPtr(r.WindowsOptions)
-		fn(d)
-		r.WindowsOptions = d.DieReleasePtr()
-	})
-}
-
-func (d *PodSecurityContextDie) SysctlsDie(sysctls ...*SysctlDie) *PodSecurityContextDie {
-	return d.DieStamp(func(r *corev1.PodSecurityContext) {
-		r.Sysctls = make([]corev1.Sysctl, len(sysctls))
-		for i := range sysctls {
-			r.Sysctls[i] = sysctls[i].DieRelease()
-		}
-	})
-}
-
-func (d *PodSecurityContextDie) SeccompProfileDie(fn func(d *SeccompProfileDie)) *PodSecurityContextDie {
-	return d.DieStamp(func(r *corev1.PodSecurityContext) {
-		d := SeccompProfileBlank.DieImmutable(false).DieFeedPtr(r.SeccompProfile)
-		fn(d)
-		r.SeccompProfile = d.DieReleasePtr()
-	})
-}
-
-func (d *PodSecurityContextDie) AppArmorProfileDie(fn func(d *AppArmorProfileDie)) *PodSecurityContextDie {
-	return d.DieStamp(func(r *corev1.PodSecurityContext) {
-		d := AppArmorProfileBlank.DieImmutable(false).DieFeedPtr(r.AppArmorProfile)
-		fn(d)
-		r.AppArmorProfile = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.Sysctl
@@ -243,16 +68,8 @@ type _ = corev1.Toleration
 type _ = corev1.HostAlias
 
 // +die
+// +die:field:name=Options,die=PodDNSConfigOptionDie,listType=atomic
 type _ = corev1.PodDNSConfig
-
-func (d *PodDNSConfigDie) OptionsDie(options ...*PodDNSConfigOptionDie) *PodDNSConfigDie {
-	return d.DieStamp(func(r *corev1.PodDNSConfig) {
-		r.Options = make([]corev1.PodDNSConfigOption, len(options))
-		for i := range options {
-			r.Options[i] = options[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = corev1.PodDNSConfigOption
@@ -261,20 +78,16 @@ type _ = corev1.PodDNSConfigOption
 type _ = corev1.PodReadinessGate
 
 // +die
+// +die:field:name=LabelSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
 type _ = corev1.TopologySpreadConstraint
-
-func (d *TopologySpreadConstraintDie) LabelSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *TopologySpreadConstraintDie {
-	return d.DieStamp(func(r *corev1.TopologySpreadConstraint) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.LabelSelector)
-		fn(d)
-		r.LabelSelector = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.PodOS
 
 // +die
+// +die:field:name=InitContainerStatuses,method=InitContainerStatusDie,die=ContainerStatusDie,listType=map
+// +die:field:name=ContainerStatuses,method=ContainerStatusDie,die=ContainerStatusDie,listType=map
+// +die:field:name=EphemeralContainerStatuses,method=EphemeralContainerStatusDie,die=ContainerStatusDie,listType=map
 type _ = corev1.PodStatus
 
 func (d *PodStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *PodStatusDie {
@@ -290,56 +103,5 @@ func (d *PodStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *Pod
 				LastTransitionTime: c.LastTransitionTime,
 			}
 		}
-	})
-}
-
-func (d *PodStatusDie) InitContainerStatusDie(name string, fn func(d *ContainerStatusDie)) *PodStatusDie {
-	return d.DieStamp(func(r *corev1.PodStatus) {
-		for i := range r.InitContainerStatuses {
-			if name == r.InitContainerStatuses[i].Name {
-				d := ContainerStatusBlank.DieImmutable(false).DieFeed(r.InitContainerStatuses[i])
-				fn(d)
-				r.InitContainerStatuses[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ContainerStatusBlank.DieImmutable(false).DieFeed(corev1.ContainerStatus{Name: name})
-		fn(d)
-		r.InitContainerStatuses = append(r.InitContainerStatuses, d.DieRelease())
-	})
-}
-
-func (d *PodStatusDie) ContainerStatusDie(name string, fn func(d *ContainerStatusDie)) *PodStatusDie {
-	return d.DieStamp(func(r *corev1.PodStatus) {
-		for i := range r.ContainerStatuses {
-			if name == r.ContainerStatuses[i].Name {
-				d := ContainerStatusBlank.DieImmutable(false).DieFeed(r.ContainerStatuses[i])
-				fn(d)
-				r.ContainerStatuses[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ContainerStatusBlank.DieImmutable(false).DieFeed(corev1.ContainerStatus{Name: name})
-		fn(d)
-		r.ContainerStatuses = append(r.ContainerStatuses, d.DieRelease())
-	})
-}
-
-func (d *PodStatusDie) EphemeralContainerStatusDie(name string, fn func(d *ContainerStatusDie)) *PodStatusDie {
-	return d.DieStamp(func(r *corev1.PodStatus) {
-		for i := range r.EphemeralContainerStatuses {
-			if name == r.EphemeralContainerStatuses[i].Name {
-				d := ContainerStatusBlank.DieImmutable(false).DieFeed(r.EphemeralContainerStatuses[i])
-				fn(d)
-				r.EphemeralContainerStatuses[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ContainerStatusBlank.DieImmutable(false).DieFeed(corev1.ContainerStatus{Name: name})
-		fn(d)
-		r.EphemeralContainerStatuses = append(r.EphemeralContainerStatuses, d.DieRelease())
 	})
 }

--- a/apis/core/v1/podtemplate.go
+++ b/apis/core/v1/podtemplate.go
@@ -18,35 +18,13 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,spec=-
+// +die:field:name=Template,die=PodTemplateSpecDie
 type _ = corev1.PodTemplate
 
-func (d *PodTemplateDie) TemplateDie(fn func(d *PodTemplateSpecDie)) *PodTemplateDie {
-	return d.DieStamp(func(r *corev1.PodTemplate) {
-		d := PodTemplateSpecBlank.DieImmutable(false).DieFeed(r.Template)
-		fn(d)
-		r.Template = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=ObjectMeta,method=MetadataDie,package=_/meta/v1,die=ObjectMetaDie
+// +die:field:name=Spec,die=PodSpecDie
 type _ = corev1.PodTemplateSpec
-
-func (d *PodTemplateSpecDie) MetadataDie(fn func(d *diemetav1.ObjectMetaDie)) *PodTemplateSpecDie {
-	return d.DieStamp(func(r *corev1.PodTemplateSpec) {
-		d := diemetav1.ObjectMetaBlank.DieImmutable(false).DieFeed(r.ObjectMeta)
-		fn(d)
-		r.ObjectMeta = d.DieRelease()
-	})
-}
-
-func (d *PodTemplateSpecDie) SpecDie(fn func(d *PodSpecDie)) *PodTemplateSpecDie {
-	return d.DieStamp(func(r *corev1.PodTemplateSpec) {
-		d := PodSpecBlank.DieImmutable(false).DieFeed(r.Spec)
-		fn(d)
-		r.Spec = d.DieRelease()
-	})
-}

--- a/apis/core/v1/replicationcontroller.go
+++ b/apis/core/v1/replicationcontroller.go
@@ -25,15 +25,8 @@ import (
 type _ = corev1.ReplicationController
 
 // +die
+// +die:field:name=Template,die=PodTemplateSpecDie,pointer=true
 type _ = corev1.ReplicationControllerSpec
-
-func (d *ReplicationControllerSpecDie) TemplateDie(fn func(d *PodTemplateSpecDie)) *ReplicationControllerSpecDie {
-	return d.DieStamp(func(r *corev1.ReplicationControllerSpec) {
-		d := PodTemplateSpecBlank.DieImmutable(false).DieFeedPtr(r.Template)
-		fn(d)
-		r.Template = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ReplicationControllerStatus

--- a/apis/core/v1/resourcequota.go
+++ b/apis/core/v1/resourcequota.go
@@ -24,35 +24,12 @@ import (
 type _ = corev1.ResourceQuota
 
 // +die
+// +die:field:name=ScopeSelector,die=ScopeSelectorDie,pointer=true
 type _ = corev1.ResourceQuotaSpec
 
-func (d *ResourceQuotaSpecDie) ScopeSelectorDie(fn func(d *ScopeSelectorDie)) *ResourceQuotaSpecDie {
-	return d.DieStamp(func(r *corev1.ResourceQuotaSpec) {
-		d := ScopeSelectorBlank.DieImmutable(false).DieFeedPtr(r.ScopeSelector)
-		fn(d)
-		r.ScopeSelector = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=MatchExpressions,die=ScopedResourceSelectorRequirementDie,listType=map,listMapKey=ScopeName,listMapKeyPackage=k8s.io/api/core/v1,listMapKeyType=ResourceQuotaScope
 type _ = corev1.ScopeSelector
-
-func (d *ScopeSelectorDie) MatchExpressionDie(scope corev1.ResourceQuotaScope, fn func(d *ScopedResourceSelectorRequirementDie)) *ScopeSelectorDie {
-	return d.DieStamp(func(r *corev1.ScopeSelector) {
-		for i := range r.MatchExpressions {
-			if scope == r.MatchExpressions[i].ScopeName {
-				d := ScopedResourceSelectorRequirementBlank.DieImmutable(false).DieFeed(r.MatchExpressions[i])
-				fn(d)
-				r.MatchExpressions[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := ScopedResourceSelectorRequirementBlank.DieImmutable(false).DieFeed(corev1.ScopedResourceSelectorRequirement{ScopeName: scope})
-		fn(d)
-		r.MatchExpressions = append(r.MatchExpressions, d.DieRelease())
-	})
-}
 
 // +die
 type _ = corev1.ScopedResourceSelectorRequirement

--- a/apis/core/v1/service.go
+++ b/apis/core/v1/service.go
@@ -26,6 +26,7 @@ import (
 type _ = corev1.Service
 
 // +die
+// +die:field:name=SessionAffinityConfig,die=SessionAffinityConfigDie,pointer=true
 type _ = corev1.ServiceSpec
 
 func (d *ServiceSpecDie) PortDie(protocol corev1.Protocol, port int32, fn func(d *ServicePortDie)) *ServiceSpecDie {
@@ -54,41 +55,19 @@ func (d *ServiceSpecDie) AddSelector(key, value string) *ServiceSpecDie {
 	})
 }
 
-func (d *ServiceSpecDie) SessionAffinityConfigDie(fn func(d *SessionAffinityConfigDie)) *ServiceSpecDie {
-	return d.DieStamp(func(r *corev1.ServiceSpec) {
-		d := SessionAffinityConfigBlank.DieImmutable(false).DieFeedPtr(r.SessionAffinityConfig)
-		fn(d)
-		r.SessionAffinityConfig = d.DieReleasePtr()
-	})
-}
-
 // +die
 type _ = corev1.ServicePort
 
 // +die
+// +die:field:name=ClientIP,die=ClientIPConfigDie,pointer=true
 type _ = corev1.SessionAffinityConfig
-
-func (d *SessionAffinityConfigDie) ClientIPDie(fn func(d *ClientIPConfigDie)) *SessionAffinityConfigDie {
-	return d.DieStamp(func(r *corev1.SessionAffinityConfig) {
-		d := ClientIPConfigBlank.DieImmutable(false).DieFeedPtr(r.ClientIP)
-		fn(d)
-		r.ClientIP = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.ClientIPConfig
 
 // +die
+// +die:field:name=LoadBalancer,die=LoadBalancerStatusDie
 type _ = corev1.ServiceStatus
-
-func (d *ServiceStatusDie) LoadBalancerDie(fn func(d *LoadBalancerStatusDie)) *ServiceStatusDie {
-	return d.DieStamp(func(r *corev1.ServiceStatus) {
-		d := LoadBalancerStatusBlank.DieImmutable(false).DieFeed(r.LoadBalancer)
-		fn(d)
-		r.LoadBalancer = d.DieRelease()
-	})
-}
 
 func (d *ServiceStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *ServiceStatusDie {
 	return d.DieStamp(func(r *corev1.ServiceStatus) {
@@ -100,28 +79,17 @@ func (d *ServiceStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) 
 }
 
 // +die
+// +die:field:name=Ingress,die=LoadBalancerIngressDie,listType=atomic
 type _ = corev1.LoadBalancerStatus
 
+// deprecated: use IngressDie
 func (d *LoadBalancerStatusDie) LoadBalancerDie(ingress ...*LoadBalancerIngressDie) *LoadBalancerStatusDie {
-	return d.DieStamp(func(r *corev1.LoadBalancerStatus) {
-		r.Ingress = make([]corev1.LoadBalancerIngress, len(ingress))
-		for i := range ingress {
-			r.Ingress[i] = ingress[i].DieRelease()
-		}
-	})
+	return d.IngressDie(ingress...)
 }
 
 // +die
+// +die:field:name=Ports,die=PortStatusDie,listType=atomic
 type _ = corev1.LoadBalancerIngress
-
-func (d *LoadBalancerIngressDie) PortsDie(ports ...*PortStatusDie) *LoadBalancerIngressDie {
-	return d.DieStamp(func(r *corev1.LoadBalancerIngress) {
-		r.Ports = make([]corev1.PortStatus, len(ports))
-		for i := range ports {
-			r.Ports[i] = ports[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = corev1.PortStatus

--- a/apis/core/v1/serviceaccount.go
+++ b/apis/core/v1/serviceaccount.go
@@ -21,22 +21,6 @@ import (
 )
 
 // +die:object=true,apiVersion=v1,kind=ServiceAccount
+// +die:field:name=Secrets,die=ObjectReferenceDie,listType=atomic
+// +die:field:name=ImagePullSecrets,die=LocalObjectReferenceDie,listType=atomic
 type _ = corev1.ServiceAccount
-
-func (d *ServiceAccountDie) SecretsDie(secrets ...*ObjectReferenceDie) *ServiceAccountDie {
-	return d.DieStamp(func(r *corev1.ServiceAccount) {
-		r.Secrets = make([]corev1.ObjectReference, len(secrets))
-		for i := range secrets {
-			r.Secrets[i] = secrets[i].DieRelease()
-		}
-	})
-}
-
-func (d *ServiceAccountDie) ImagePullSecretsDie(secrets ...*LocalObjectReferenceDie) *ServiceAccountDie {
-	return d.DieStamp(func(r *corev1.ServiceAccount) {
-		r.ImagePullSecrets = make([]corev1.LocalObjectReference, len(secrets))
-		for i := range secrets {
-			r.ImagePullSecrets[i] = secrets[i].DieRelease()
-		}
-	})
-}

--- a/apis/core/v1/volume.go
+++ b/apis/core/v1/volume.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die
@@ -330,38 +329,15 @@ type _ = corev1.AWSElasticBlockStoreVolumeSource
 type _ = corev1.GitRepoVolumeSource
 
 // +die
+// +die:field:name=Items,die=KeyToPathDie,listMapKey=Key
 type _ = corev1.SecretVolumeSource
-
-func (d *SecretVolumeSourceDie) ItemDie(key string, fn func(d *KeyToPathDie)) *SecretVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.SecretVolumeSource) {
-		for i := range r.Items {
-			if key == r.Items[i].Key {
-				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
-				fn(d)
-				r.Items[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: key})
-		fn(d)
-		r.Items = append(r.Items, d.DieRelease())
-	})
-}
 
 // +die
 type _ = corev1.NFSVolumeSource
 
 // +die
+// +die:field:name=SecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.ISCSIVolumeSource
-
-func (d *ISCSIVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *ISCSIVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.ISCSIVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.GlusterfsVolumeSource
@@ -370,90 +346,32 @@ type _ = corev1.GlusterfsVolumeSource
 type _ = corev1.PersistentVolumeClaimVolumeSource
 
 // +die
+// +die:field:name=SecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.RBDVolumeSource
 
-func (d *RBDVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *RBDVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.RBDVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.FlexVolumeSource
 
-func (d *FlexVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *FlexVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.FlexVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.CinderVolumeSource
 
-func (d *CinderVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *CinderVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CinderVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.CephFSVolumeSource
-
-func (d *CephFSVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *CephFSVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CephFSVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.FlockerVolumeSource
 
 // +die
+// +die:field:name=Items,die=DownwardAPIVolumeFileDie,listMapKey=Path
 type _ = corev1.DownwardAPIVolumeSource
 
-func (d *DownwardAPIVolumeSourceDie) ItemDie(path string, fn func(d *DownwardAPIVolumeFileDie)) *DownwardAPIVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.DownwardAPIVolumeSource) {
-		for i := range r.Items {
-			if path == r.Items[i].Path {
-				d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(r.Items[i])
-				fn(d)
-				r.Items[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(corev1.DownwardAPIVolumeFile{Path: path})
-		fn(d)
-		r.Items = append(r.Items, d.DieRelease())
-	})
-}
-
 // +die
+// +die:field:name=FieldRef,die=ObjectFieldSelectorDie,pointer=true
+// +die:field:name=ResourceFieldRef,die=ResourceFieldSelectorDie,pointer=true
 type _ = corev1.DownwardAPIVolumeFile
-
-func (d *DownwardAPIVolumeFileDie) FieldRefDie(fn func(d *ObjectFieldSelectorDie)) *DownwardAPIVolumeFileDie {
-	return d.DieStamp(func(r *corev1.DownwardAPIVolumeFile) {
-		d := ObjectFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.FieldRef)
-		fn(d)
-		r.FieldRef = d.DieReleasePtr()
-	})
-}
-
-func (d *DownwardAPIVolumeFileDie) ResourceFieldRefDie(fn func(d *ResourceFieldSelectorDie)) *DownwardAPIVolumeFileDie {
-	return d.DieStamp(func(r *corev1.DownwardAPIVolumeFile) {
-		d := ResourceFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.ResourceFieldRef)
-		fn(d)
-		r.ResourceFieldRef = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.FCVolumeSource
@@ -462,28 +380,12 @@ type _ = corev1.FCVolumeSource
 type _ = corev1.AzureFileVolumeSource
 
 // +die
+// +die:field:name=Items,die=KeyToPathDie,listMapKey=Key
 type _ = corev1.ConfigMapVolumeSource
 
 func (d *ConfigMapVolumeSourceDie) Name(v string) *ConfigMapVolumeSourceDie {
 	return d.DieStamp(func(r *corev1.ConfigMapVolumeSource) {
 		r.Name = v
-	})
-}
-
-func (d *ConfigMapVolumeSourceDie) ItemDie(key string, fn func(d *KeyToPathDie)) *ConfigMapVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.ConfigMapVolumeSource) {
-		for i := range r.Items {
-			if key == r.Items[i].Key {
-				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
-				fn(d)
-				r.Items[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: key})
-		fn(d)
-		r.Items = append(r.Items, d.DieRelease())
 	})
 }
 
@@ -500,61 +402,19 @@ type _ = corev1.AzureDiskVolumeSource
 type _ = corev1.PhotonPersistentDiskVolumeSource
 
 // +die
+// +die:field:name=Sources,die=VolumeProjectionDie,listType=atomic
 type _ = corev1.ProjectedVolumeSource
 
-func (d *ProjectedVolumeSourceDie) SourcesDie(sources ...*VolumeProjectionDie) *ProjectedVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.ProjectedVolumeSource) {
-		r.Sources = make([]corev1.VolumeProjection, len(sources))
-		for i := range sources {
-			r.Sources[i] = sources[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Secret,die=SecretProjectionDie,pointer=true
+// +die:field:name=DownwardAPI,die=DownwardAPIProjectionDie,pointer=true
+// +die:field:name=ConfigMap,die=ConfigMapProjectionDie,pointer=true
+// +die:field:name=ServiceAccountToken,die=ServiceAccountTokenProjectionDie,pointer=true
+// +die:field:name=ClusterTrustBundle,die=ClusterTrustBundleProjectionDie,pointer=true
 type _ = corev1.VolumeProjection
 
-func (d *VolumeProjectionDie) SecretDie(fn func(d *SecretProjectionDie)) *VolumeProjectionDie {
-	return d.DieStamp(func(r *corev1.VolumeProjection) {
-		d := SecretProjectionBlank.DieImmutable(false).DieFeedPtr(r.Secret)
-		fn(d)
-		r.Secret = d.DieReleasePtr()
-	})
-}
-
-func (d *VolumeProjectionDie) DownwardAPIDie(fn func(d *DownwardAPIProjectionDie)) *VolumeProjectionDie {
-	return d.DieStamp(func(r *corev1.VolumeProjection) {
-		d := DownwardAPIProjectionBlank.DieImmutable(false).DieFeedPtr(r.DownwardAPI)
-		fn(d)
-		r.DownwardAPI = d.DieReleasePtr()
-	})
-}
-
-func (d *VolumeProjectionDie) ConfigMapDie(fn func(d *ConfigMapProjectionDie)) *VolumeProjectionDie {
-	return d.DieStamp(func(r *corev1.VolumeProjection) {
-		d := ConfigMapProjectionBlank.DieImmutable(false).DieFeedPtr(r.ConfigMap)
-		fn(d)
-		r.ConfigMap = d.DieReleasePtr()
-	})
-}
-
-func (d *VolumeProjectionDie) ServiceAccountTokenDie(fn func(d *ServiceAccountTokenProjectionDie)) *VolumeProjectionDie {
-	return d.DieStamp(func(r *corev1.VolumeProjection) {
-		d := ServiceAccountTokenProjectionBlank.DieImmutable(false).DieFeedPtr(r.ServiceAccountToken)
-		fn(d)
-		r.ServiceAccountToken = d.DieReleasePtr()
-	})
-}
-
-func (d *VolumeProjectionDie) ClusterTrustBundleDie(fn func(d *ClusterTrustBundleProjectionDie)) *VolumeProjectionDie {
-	return d.DieStamp(func(r *corev1.VolumeProjection) {
-		d := ClusterTrustBundleProjectionBlank.DieImmutable(false).DieFeedPtr(r.ClusterTrustBundle)
-		fn(d)
-		r.ClusterTrustBundle = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Items,die=KeyToPathDie,listMapKey=Key
 type _ = corev1.SecretProjection
 
 func (d *SecretProjectionDie) Name(v string) *SecretProjectionDie {
@@ -563,44 +423,12 @@ func (d *SecretProjectionDie) Name(v string) *SecretProjectionDie {
 	})
 }
 
-func (d *SecretProjectionDie) ItemDie(key string, fn func(d *KeyToPathDie)) *SecretProjectionDie {
-	return d.DieStamp(func(r *corev1.SecretProjection) {
-		for i := range r.Items {
-			if key == r.Items[i].Key {
-				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
-				fn(d)
-				r.Items[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: key})
-		fn(d)
-		r.Items = append(r.Items, d.DieRelease())
-	})
-}
-
 // +die
+// +die:field:name=Items,die=DownwardAPIVolumeFileDie,listMapKey=Path
 type _ = corev1.DownwardAPIProjection
 
-func (d *DownwardAPIProjectionDie) ItemDie(path string, fn func(d *DownwardAPIVolumeFileDie)) *DownwardAPIProjectionDie {
-	return d.DieStamp(func(r *corev1.DownwardAPIProjection) {
-		for i := range r.Items {
-			if path == r.Items[i].Path {
-				d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(r.Items[i])
-				fn(d)
-				r.Items[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(corev1.DownwardAPIVolumeFile{Path: path})
-		fn(d)
-		r.Items = append(r.Items, d.DieRelease())
-	})
-}
-
 // +die
+// +die:field:name=Items,die=KeyToPathDie,listMapKey=Key
 type _ = corev1.ConfigMapProjection
 
 func (d *ConfigMapProjectionDie) Name(v string) *ConfigMapProjectionDie {
@@ -609,63 +437,26 @@ func (d *ConfigMapProjectionDie) Name(v string) *ConfigMapProjectionDie {
 	})
 }
 
-func (d *ConfigMapProjectionDie) ItemDie(key string, fn func(d *KeyToPathDie)) *ConfigMapProjectionDie {
-	return d.DieStamp(func(r *corev1.ConfigMapProjection) {
-		for i := range r.Items {
-			if key == r.Items[i].Key {
-				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
-				fn(d)
-				r.Items[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: key})
-		fn(d)
-		r.Items = append(r.Items, d.DieRelease())
-	})
-}
-
 // +die
 type _ = corev1.ServiceAccountTokenProjection
 
 // +die
+// +die:field:name=LabelSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
 type _ = corev1.ClusterTrustBundleProjection
-
-func (d *ClusterTrustBundleProjectionDie) LabelSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *ClusterTrustBundleProjectionDie {
-	return d.DieStamp(func(r *corev1.ClusterTrustBundleProjection) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.LabelSelector)
-		fn(d)
-		r.LabelSelector = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.PortworxVolumeSource
 
 // +die
+// +die:field:name=SecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.ScaleIOVolumeSource
 
-func (d *ScaleIOVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *ScaleIOVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.ScaleIOVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=SecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.StorageOSVolumeSource
 
-func (d *StorageOSVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *StorageOSVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.StorageOSVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
-		fn(d)
-		r.SecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=NodePublishSecretRef,die=LocalObjectReferenceDie,pointer=true
 type _ = corev1.CSIVolumeSource
 
 func (d *CSIVolumeSourceDie) VolumeAttribute(key, value string) *CSIVolumeSourceDie {
@@ -674,24 +465,9 @@ func (d *CSIVolumeSourceDie) VolumeAttribute(key, value string) *CSIVolumeSource
 	})
 }
 
-func (d *CSIVolumeSourceDie) NodePublishSecretRefDie(fn func(d *LocalObjectReferenceDie)) *CSIVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.CSIVolumeSource) {
-		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodePublishSecretRef)
-		fn(d)
-		r.NodePublishSecretRef = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=VolumeClaimTemplate,die=PersistentVolumeClaimTemplateDie,pointer=true
 type _ = corev1.EphemeralVolumeSource
-
-func (d *EphemeralVolumeSourceDie) VolumeClaimTemplateDie(fn func(d *PersistentVolumeClaimTemplateDie)) *EphemeralVolumeSourceDie {
-	return d.DieStamp(func(r *corev1.EphemeralVolumeSource) {
-		d := PersistentVolumeClaimTemplateBlank.DieImmutable(false).DieFeedPtr(r.VolumeClaimTemplate)
-		fn(d)
-		r.VolumeClaimTemplate = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = corev1.KeyToPath

--- a/apis/core/v1/zz_generated.die.go
+++ b/apis/core/v1/zz_generated.die.go
@@ -364,6 +364,17 @@ func (d *BindingDie) MetadataDie(fn func(d *metav1.ObjectMetaDie)) *BindingDie {
 	})
 }
 
+// TargetDie mutates Target as a die.
+//
+// The target object that you want to bind to the standard object.
+func (d *BindingDie) TargetDie(fn func(d *ObjectReferenceDie)) *BindingDie {
+	return d.DieStamp(func(r *corev1.Binding) {
+		d := ObjectReferenceBlank.DieImmutable(false).DieFeed(r.Target)
+		fn(d)
+		r.Target = d.DieRelease()
+	})
+}
+
 // The target object that you want to bind to the standard object.
 func (d *BindingDie) Target(v corev1.ObjectReference) *BindingDie {
 	return d.DieStamp(func(r *corev1.Binding) {
@@ -1898,6 +1909,18 @@ func (d *TopologySelectorTermDie) DiePatch(patchType types.PatchType) ([]byte, e
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// MatchLabelExpressionsDie replaces MatchLabelExpressions by collecting the released value from each die passed.
+//
+// A list of topology selector requirements by labels.
+func (d *TopologySelectorTermDie) MatchLabelExpressionsDie(v ...*TopologySelectorLabelRequirementDie) *TopologySelectorTermDie {
+	return d.DieStamp(func(r *corev1.TopologySelectorTerm) {
+		r.MatchLabelExpressions = make([]corev1.TopologySelectorLabelRequirement, len(v))
+		for i := range v {
+			r.MatchLabelExpressions[i] = v[i].DieRelease()
+		}
+	})
+}
+
 // A list of topology selector requirements by labels.
 func (d *TopologySelectorTermDie) MatchLabelExpressions(v ...corev1.TopologySelectorLabelRequirement) *TopologySelectorTermDie {
 	return d.DieStamp(func(r *corev1.TopologySelectorTerm) {
@@ -3043,6 +3066,244 @@ func (d *ContainerDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ResourcesDie mutates Resources as a die.
+//
+// Compute Resources required by this container.
+//
+// Cannot be updated.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+func (d *ContainerDie) ResourcesDie(fn func(d *ResourceRequirementsDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		d := ResourceRequirementsBlank.DieImmutable(false).DieFeed(r.Resources)
+		fn(d)
+		r.Resources = d.DieRelease()
+	})
+}
+
+// LivenessProbeDie mutates LivenessProbe as a die.
+//
+// Periodic probe of container liveness.
+//
+// Container will be restarted if the probe fails.
+//
+// Cannot be updated.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+func (d *ContainerDie) LivenessProbeDie(fn func(d *ProbeDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		d := ProbeBlank.DieImmutable(false).DieFeedPtr(r.LivenessProbe)
+		fn(d)
+		r.LivenessProbe = d.DieReleasePtr()
+	})
+}
+
+// ReadinessProbeDie mutates ReadinessProbe as a die.
+//
+// Periodic probe of container service readiness.
+//
+// Container will be removed from service endpoints if the probe fails.
+//
+// Cannot be updated.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+func (d *ContainerDie) ReadinessProbeDie(fn func(d *ProbeDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		d := ProbeBlank.DieImmutable(false).DieFeedPtr(r.ReadinessProbe)
+		fn(d)
+		r.ReadinessProbe = d.DieReleasePtr()
+	})
+}
+
+// StartupProbeDie mutates StartupProbe as a die.
+//
+// StartupProbe indicates that the Pod has successfully initialized.
+//
+// If specified, no other probes are executed until this completes successfully.
+//
+// If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+//
+// This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+//
+// when it might take a long time to load data or warm a cache, than during steady-state operation.
+//
+// This cannot be updated.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+func (d *ContainerDie) StartupProbeDie(fn func(d *ProbeDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		d := ProbeBlank.DieImmutable(false).DieFeedPtr(r.StartupProbe)
+		fn(d)
+		r.StartupProbe = d.DieReleasePtr()
+	})
+}
+
+// LifecycleDie mutates Lifecycle as a die.
+//
+// Actions that the management system should take in response to container lifecycle events.
+//
+// Cannot be updated.
+func (d *ContainerDie) LifecycleDie(fn func(d *LifecycleDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		d := LifecycleBlank.DieImmutable(false).DieFeedPtr(r.Lifecycle)
+		fn(d)
+		r.Lifecycle = d.DieReleasePtr()
+	})
+}
+
+// SecurityContextDie mutates SecurityContext as a die.
+//
+// SecurityContext defines the security options the container should be run with.
+//
+// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+//
+// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+func (d *ContainerDie) SecurityContextDie(fn func(d *SecurityContextDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		d := SecurityContextBlank.DieImmutable(false).DieFeedPtr(r.SecurityContext)
+		fn(d)
+		r.SecurityContext = d.DieReleasePtr()
+	})
+}
+
+// PortsDie replaces Ports by collecting the released value from each die passed.
+//
+// List of ports to expose from the container. Not specifying a port here
+//
+// DOES NOT prevent that port from being exposed. Any port which is
+//
+// listening on the default "0.0.0.0" address inside a container will be
+//
+// accessible from the network.
+//
+// Modifying this array with strategic merge patch may corrupt the data.
+//
+// For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+//
+// Cannot be updated.
+func (d *ContainerDie) PortsDie(v ...*ContainerPortDie) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		r.Ports = make([]corev1.ContainerPort, len(v))
+		for i := range v {
+			r.Ports[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// EnvFromDie mutates a single item in EnvFrom matched by the nested field Prefix, appending a new item if no match is found.
+//
+// List of sources to populate environment variables in the container.
+//
+// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+//
+// will be reported as an event when the container is starting. When a key exists in multiple
+//
+// sources, the value associated with the last source will take precedence.
+//
+// Values defined by an Env with a duplicate key will take precedence.
+//
+// Cannot be updated.
+func (d *ContainerDie) EnvFromDie(v string, fn func(d *EnvFromSourceDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		for i := range r.EnvFrom {
+			if v == r.EnvFrom[i].Prefix {
+				d := EnvFromSourceBlank.DieImmutable(false).DieFeed(r.EnvFrom[i])
+				fn(d)
+				r.EnvFrom[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := EnvFromSourceBlank.DieImmutable(false).DieFeed(corev1.EnvFromSource{Prefix: v})
+		fn(d)
+		r.EnvFrom = append(r.EnvFrom, d.DieRelease())
+	})
+}
+
+// EnvDie mutates a single item in Env matched by the nested field Name, appending a new item if no match is found.
+//
+// List of environment variables to set in the container.
+//
+// Cannot be updated.
+func (d *ContainerDie) EnvDie(v string, fn func(d *EnvVarDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		for i := range r.Env {
+			if v == r.Env[i].Name {
+				d := EnvVarBlank.DieImmutable(false).DieFeed(r.Env[i])
+				fn(d)
+				r.Env[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := EnvVarBlank.DieImmutable(false).DieFeed(corev1.EnvVar{Name: v})
+		fn(d)
+		r.Env = append(r.Env, d.DieRelease())
+	})
+}
+
+// ResizePolicyDie mutates a single item in ResizePolicy matched by the nested field ResourceName, appending a new item if no match is found.
+//
+// Resources resize policy for the container.
+func (d *ContainerDie) ResizePolicyDie(v corev1.ResourceName, fn func(d *ContainerResizePolicyDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		for i := range r.ResizePolicy {
+			if v == r.ResizePolicy[i].ResourceName {
+				d := ContainerResizePolicyBlank.DieImmutable(false).DieFeed(r.ResizePolicy[i])
+				fn(d)
+				r.ResizePolicy[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ContainerResizePolicyBlank.DieImmutable(false).DieFeed(corev1.ContainerResizePolicy{ResourceName: v})
+		fn(d)
+		r.ResizePolicy = append(r.ResizePolicy, d.DieRelease())
+	})
+}
+
+// VolumeMountDie mutates a single item in VolumeMounts matched by the nested field Name, appending a new item if no match is found.
+//
+// Pod volumes to mount into the container's filesystem.
+//
+// Cannot be updated.
+func (d *ContainerDie) VolumeMountDie(v string, fn func(d *VolumeMountDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		for i := range r.VolumeMounts {
+			if v == r.VolumeMounts[i].Name {
+				d := VolumeMountBlank.DieImmutable(false).DieFeed(r.VolumeMounts[i])
+				fn(d)
+				r.VolumeMounts[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := VolumeMountBlank.DieImmutable(false).DieFeed(corev1.VolumeMount{Name: v})
+		fn(d)
+		r.VolumeMounts = append(r.VolumeMounts, d.DieRelease())
+	})
+}
+
+// VolumeDeviceDie mutates a single item in VolumeDevices matched by the nested field Name, appending a new item if no match is found.
+//
+// volumeDevices is the list of block devices to be used by the container.
+func (d *ContainerDie) VolumeDeviceDie(v string, fn func(d *VolumeDeviceDie)) *ContainerDie {
+	return d.DieStamp(func(r *corev1.Container) {
+		for i := range r.VolumeDevices {
+			if v == r.VolumeDevices[i].Name {
+				d := VolumeDeviceBlank.DieImmutable(false).DieFeed(r.VolumeDevices[i])
+				fn(d)
+				r.VolumeDevices[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := VolumeDeviceBlank.DieImmutable(false).DieFeed(corev1.VolumeDevice{Name: v})
+		fn(d)
+		r.VolumeDevices = append(r.VolumeDevices, d.DieRelease())
+	})
+}
+
 // Name of the container specified as a DNS_LABEL.
 //
 // Each container in a pod must have a unique name (DNS_LABEL).
@@ -3898,6 +4159,28 @@ func (d *EnvFromSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ConfigMapRefDie mutates ConfigMapRef as a die.
+//
+// The ConfigMap to select from
+func (d *EnvFromSourceDie) ConfigMapRefDie(fn func(d *ConfigMapEnvSourceDie)) *EnvFromSourceDie {
+	return d.DieStamp(func(r *corev1.EnvFromSource) {
+		d := ConfigMapEnvSourceBlank.DieImmutable(false).DieFeedPtr(r.ConfigMapRef)
+		fn(d)
+		r.ConfigMapRef = d.DieReleasePtr()
+	})
+}
+
+// SecretRefDie mutates SecretRef as a die.
+//
+// The Secret to select from
+func (d *EnvFromSourceDie) SecretRefDie(fn func(d *SecretEnvSourceDie)) *EnvFromSourceDie {
+	return d.DieStamp(func(r *corev1.EnvFromSource) {
+		d := SecretEnvSourceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
 func (d *EnvFromSourceDie) Prefix(v string) *EnvFromSourceDie {
 	return d.DieStamp(func(r *corev1.EnvFromSource) {
@@ -4631,6 +4914,17 @@ func (d *EnvVarDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ValueFromDie mutates ValueFrom as a die.
+//
+// Source for the environment variable's value. Cannot be used if value is not empty.
+func (d *EnvVarDie) ValueFromDie(fn func(d *EnvVarSourceDie)) *EnvVarDie {
+	return d.DieStamp(func(r *corev1.EnvVar) {
+		d := EnvVarSourceBlank.DieImmutable(false).DieFeedPtr(r.ValueFrom)
+		fn(d)
+		r.ValueFrom = d.DieReleasePtr()
+	})
+}
+
 // Name of the environment variable. Must be a C_IDENTIFIER.
 func (d *EnvVarDie) Name(v string) *EnvVarDie {
 	return d.DieStamp(func(r *corev1.EnvVar) {
@@ -4894,6 +5188,54 @@ func (d *EnvVarSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *EnvVarSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// FieldRefDie mutates FieldRef as a die.
+//
+// Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+//
+// spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+func (d *EnvVarSourceDie) FieldRefDie(fn func(d *ObjectFieldSelectorDie)) *EnvVarSourceDie {
+	return d.DieStamp(func(r *corev1.EnvVarSource) {
+		d := ObjectFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.FieldRef)
+		fn(d)
+		r.FieldRef = d.DieReleasePtr()
+	})
+}
+
+// ResourceFieldRefDie mutates ResourceFieldRef as a die.
+//
+// Selects a resource of the container: only resources limits and requests
+//
+// (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+func (d *EnvVarSourceDie) ResourceFieldRefDie(fn func(d *ResourceFieldSelectorDie)) *EnvVarSourceDie {
+	return d.DieStamp(func(r *corev1.EnvVarSource) {
+		d := ResourceFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.ResourceFieldRef)
+		fn(d)
+		r.ResourceFieldRef = d.DieReleasePtr()
+	})
+}
+
+// ConfigMapKeyRefDie mutates ConfigMapKeyRef as a die.
+//
+// Selects a key of a ConfigMap.
+func (d *EnvVarSourceDie) ConfigMapKeyRefDie(fn func(d *ConfigMapKeySelectorDie)) *EnvVarSourceDie {
+	return d.DieStamp(func(r *corev1.EnvVarSource) {
+		d := ConfigMapKeySelectorBlank.DieImmutable(false).DieFeedPtr(r.ConfigMapKeyRef)
+		fn(d)
+		r.ConfigMapKeyRef = d.DieReleasePtr()
+	})
+}
+
+// SecretKeyRefDie mutates SecretKeyRef as a die.
+//
+// Selects a key of a secret in the pod's namespace
+func (d *EnvVarSourceDie) SecretKeyRefDie(fn func(d *SecretKeySelectorDie)) *EnvVarSourceDie {
+	return d.DieStamp(func(r *corev1.EnvVarSource) {
+		d := SecretKeySelectorBlank.DieImmutable(false).DieFeedPtr(r.SecretKeyRef)
+		fn(d)
+		r.SecretKeyRef = d.DieReleasePtr()
+	})
 }
 
 // Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
@@ -6151,6 +6493,54 @@ func (d *ResourceRequirementsDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ResourceRequirementsDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ClaimsDie replaces Claims by collecting the released value from each die passed.
+//
+// Claims lists the names of resources, defined in spec.resourceClaims,
+//
+// that are used by this container.
+//
+// # This is an alpha field and requires enabling the
+//
+// DynamicResourceAllocation feature gate.
+//
+// This field is immutable. It can only be set for containers.
+func (d *ResourceRequirementsDie) ClaimsDie(v ...*ResourceClaimDie) *ResourceRequirementsDie {
+	return d.DieStamp(func(r *corev1.ResourceRequirements) {
+		r.Claims = make([]corev1.ResourceClaim, len(v))
+		for i := range v {
+			r.Claims[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// ClaimDie mutates a single item in Claims matched by the nested field Name, appending a new item if no match is found.
+//
+// Claims lists the names of resources, defined in spec.resourceClaims,
+//
+// that are used by this container.
+//
+// # This is an alpha field and requires enabling the
+//
+// DynamicResourceAllocation feature gate.
+//
+// This field is immutable. It can only be set for containers.
+func (d *ResourceRequirementsDie) ClaimDie(v string, fn func(d *ResourceClaimDie)) *ResourceRequirementsDie {
+	return d.DieStamp(func(r *corev1.ResourceRequirements) {
+		for i := range r.Claims {
+			if v == r.Claims[i].Name {
+				d := ResourceClaimBlank.DieImmutable(false).DieFeed(r.Claims[i])
+				fn(d)
+				r.Claims[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ResourceClaimBlank.DieImmutable(false).DieFeed(corev1.ResourceClaim{Name: v})
+		fn(d)
+		r.Claims = append(r.Claims, d.DieRelease())
+	})
 }
 
 // Limits describes the maximum amount of compute resources allowed.
@@ -7522,6 +7912,17 @@ func (d *ProbeDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ProbeHandlerDie mutates ProbeHandler as a die.
+//
+// The action taken to determine the health of a container
+func (d *ProbeDie) ProbeHandlerDie(fn func(d *ProbeHandlerDie)) *ProbeDie {
+	return d.DieStamp(func(r *corev1.Probe) {
+		d := ProbeHandlerBlank.DieImmutable(false).DieFeed(r.ProbeHandler)
+		fn(d)
+		r.ProbeHandler = d.DieRelease()
+	})
+}
+
 // The action taken to determine the health of a container
 func (d *ProbeDie) ProbeHandler(v corev1.ProbeHandler) *ProbeDie {
 	return d.DieStamp(func(r *corev1.Probe) {
@@ -7829,6 +8230,50 @@ func (d *LifecycleDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// PostStartDie mutates PostStart as a die.
+//
+// PostStart is called immediately after a container is created. If the handler fails,
+//
+// the container is terminated and restarted according to its restart policy.
+//
+// Other management of the container blocks until the hook completes.
+//
+// More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+func (d *LifecycleDie) PostStartDie(fn func(d *LifecycleHandlerDie)) *LifecycleDie {
+	return d.DieStamp(func(r *corev1.Lifecycle) {
+		d := LifecycleHandlerBlank.DieImmutable(false).DieFeedPtr(r.PostStart)
+		fn(d)
+		r.PostStart = d.DieReleasePtr()
+	})
+}
+
+// PreStopDie mutates PreStop as a die.
+//
+// # PreStop is called immediately before a container is terminated due to an
+//
+// API request or management event such as liveness/startup probe failure,
+//
+// preemption, resource contention, etc. The handler is not called if the
+//
+// container crashes or exits. The Pod's termination grace period countdown begins before the
+//
+// PreStop hook is executed. Regardless of the outcome of the handler, the
+//
+// container will eventually terminate within the Pod's termination grace
+//
+// period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+//
+// or until the termination grace period is reached.
+//
+// More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+func (d *LifecycleDie) PreStopDie(fn func(d *LifecycleHandlerDie)) *LifecycleDie {
+	return d.DieStamp(func(r *corev1.Lifecycle) {
+		d := LifecycleHandlerBlank.DieImmutable(false).DieFeedPtr(r.PreStop)
+		fn(d)
+		r.PreStop = d.DieReleasePtr()
+	})
+}
+
 // PostStart is called immediately after a container is created. If the handler fails,
 //
 // the container is terminated and restarted according to its restart policy.
@@ -8093,6 +8538,54 @@ func (d *LifecycleHandlerDie) DiePatch(patchType types.PatchType) ([]byte, error
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ExecDie mutates Exec as a die.
+//
+// Exec specifies the action to take.
+func (d *LifecycleHandlerDie) ExecDie(fn func(d *ExecActionDie)) *LifecycleHandlerDie {
+	return d.DieStamp(func(r *corev1.LifecycleHandler) {
+		d := ExecActionBlank.DieImmutable(false).DieFeedPtr(r.Exec)
+		fn(d)
+		r.Exec = d.DieReleasePtr()
+	})
+}
+
+// HTTPGetDie mutates HTTPGet as a die.
+//
+// HTTPGet specifies the http request to perform.
+func (d *LifecycleHandlerDie) HTTPGetDie(fn func(d *HTTPGetActionDie)) *LifecycleHandlerDie {
+	return d.DieStamp(func(r *corev1.LifecycleHandler) {
+		d := HTTPGetActionBlank.DieImmutable(false).DieFeedPtr(r.HTTPGet)
+		fn(d)
+		r.HTTPGet = d.DieReleasePtr()
+	})
+}
+
+// TCPSocketDie mutates TCPSocket as a die.
+//
+// Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+//
+// for the backward compatibility. There are no validation of this field and
+//
+// lifecycle hooks will fail in runtime when tcp handler is specified.
+func (d *LifecycleHandlerDie) TCPSocketDie(fn func(d *TCPSocketActionDie)) *LifecycleHandlerDie {
+	return d.DieStamp(func(r *corev1.LifecycleHandler) {
+		d := TCPSocketActionBlank.DieImmutable(false).DieFeedPtr(r.TCPSocket)
+		fn(d)
+		r.TCPSocket = d.DieReleasePtr()
+	})
+}
+
+// SleepDie mutates Sleep as a die.
+//
+// Sleep represents the duration that the container should sleep before being terminated.
+func (d *LifecycleHandlerDie) SleepDie(fn func(d *SleepActionDie)) *LifecycleHandlerDie {
+	return d.DieStamp(func(r *corev1.LifecycleHandler) {
+		d := SleepActionBlank.DieImmutable(false).DieFeedPtr(r.Sleep)
+		fn(d)
+		r.Sleep = d.DieReleasePtr()
+	})
+}
+
 // Exec specifies the action to take.
 func (d *LifecycleHandlerDie) Exec(v *corev1.ExecAction) *LifecycleHandlerDie {
 	return d.DieStamp(func(r *corev1.LifecycleHandler) {
@@ -8351,6 +8844,50 @@ func (d *ProbeHandlerDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ProbeHandlerDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ExecDie mutates Exec as a die.
+//
+// Exec specifies the action to take.
+func (d *ProbeHandlerDie) ExecDie(fn func(d *ExecActionDie)) *ProbeHandlerDie {
+	return d.DieStamp(func(r *corev1.ProbeHandler) {
+		d := ExecActionBlank.DieImmutable(false).DieFeedPtr(r.Exec)
+		fn(d)
+		r.Exec = d.DieReleasePtr()
+	})
+}
+
+// HTTPGetDie mutates HTTPGet as a die.
+//
+// HTTPGet specifies the http request to perform.
+func (d *ProbeHandlerDie) HTTPGetDie(fn func(d *HTTPGetActionDie)) *ProbeHandlerDie {
+	return d.DieStamp(func(r *corev1.ProbeHandler) {
+		d := HTTPGetActionBlank.DieImmutable(false).DieFeedPtr(r.HTTPGet)
+		fn(d)
+		r.HTTPGet = d.DieReleasePtr()
+	})
+}
+
+// TCPSocketDie mutates TCPSocket as a die.
+//
+// TCPSocket specifies an action involving a TCP port.
+func (d *ProbeHandlerDie) TCPSocketDie(fn func(d *TCPSocketActionDie)) *ProbeHandlerDie {
+	return d.DieStamp(func(r *corev1.ProbeHandler) {
+		d := TCPSocketActionBlank.DieImmutable(false).DieFeedPtr(r.TCPSocket)
+		fn(d)
+		r.TCPSocket = d.DieReleasePtr()
+	})
+}
+
+// GRPCDie mutates GRPC as a die.
+//
+// GRPC specifies an action involving a GRPC port.
+func (d *ProbeHandlerDie) GRPCDie(fn func(d *GRPCActionDie)) *ProbeHandlerDie {
+	return d.DieStamp(func(r *corev1.ProbeHandler) {
+		d := GRPCActionBlank.DieImmutable(false).DieFeedPtr(r.GRPC)
+		fn(d)
+		r.GRPC = d.DieReleasePtr()
+	})
 }
 
 // Exec specifies the action to take.
@@ -8850,6 +9387,18 @@ func (d *HTTPGetActionDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *HTTPGetActionDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// HTTPHeadersDie replaces HTTPHeaders by collecting the released value from each die passed.
+//
+// Custom headers to set in the request. HTTP allows repeated headers.
+func (d *HTTPGetActionDie) HTTPHeadersDie(v ...*HTTPHeaderDie) *HTTPGetActionDie {
+	return d.DieStamp(func(r *corev1.HTTPGetAction) {
+		r.HTTPHeaders = make([]corev1.HTTPHeader, len(v))
+		for i := range v {
+			r.HTTPHeaders[i] = v[i].DieRelease()
+		}
+	})
 }
 
 // Path to access on the HTTP server.
@@ -10148,6 +10697,89 @@ func (d *SecurityContextDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *SecurityContextDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// CapabilitiesDie mutates Capabilities as a die.
+//
+// The capabilities to add/drop when running containers.
+//
+// Defaults to the default set of capabilities granted by the container runtime.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *SecurityContextDie) CapabilitiesDie(fn func(d *CapabilitiesDie)) *SecurityContextDie {
+	return d.DieStamp(func(r *corev1.SecurityContext) {
+		d := CapabilitiesBlank.DieImmutable(false).DieFeedPtr(r.Capabilities)
+		fn(d)
+		r.Capabilities = d.DieReleasePtr()
+	})
+}
+
+// SELinuxOptionsDie mutates SELinuxOptions as a die.
+//
+// The SELinux context to be applied to the container.
+//
+// # If unspecified, the container runtime will allocate a random SELinux context for each
+//
+// container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+//
+// PodSecurityContext, the value specified in SecurityContext takes precedence.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *SecurityContextDie) SELinuxOptionsDie(fn func(d *SELinuxOptionsDie)) *SecurityContextDie {
+	return d.DieStamp(func(r *corev1.SecurityContext) {
+		d := SELinuxOptionsBlank.DieImmutable(false).DieFeedPtr(r.SELinuxOptions)
+		fn(d)
+		r.SELinuxOptions = d.DieReleasePtr()
+	})
+}
+
+// WindowsOptionsDie mutates WindowsOptions as a die.
+//
+// The Windows specific settings applied to all containers.
+//
+// If unspecified, the options from the PodSecurityContext will be used.
+//
+// If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+//
+// Note that this field cannot be set when spec.os.name is linux.
+func (d *SecurityContextDie) WindowsOptionsDie(fn func(d *WindowsSecurityContextOptionsDie)) *SecurityContextDie {
+	return d.DieStamp(func(r *corev1.SecurityContext) {
+		d := WindowsSecurityContextOptionsBlank.DieImmutable(false).DieFeedPtr(r.WindowsOptions)
+		fn(d)
+		r.WindowsOptions = d.DieReleasePtr()
+	})
+}
+
+// SeccompProfileDie mutates SeccompProfile as a die.
+//
+// The seccomp options to use by this container. If seccomp options are
+//
+// provided at both the pod & container level, the container options
+//
+// override the pod options.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *SecurityContextDie) SeccompProfileDie(fn func(d *SeccompProfileDie)) *SecurityContextDie {
+	return d.DieStamp(func(r *corev1.SecurityContext) {
+		d := SeccompProfileBlank.DieImmutable(false).DieFeedPtr(r.SeccompProfile)
+		fn(d)
+		r.SeccompProfile = d.DieReleasePtr()
+	})
+}
+
+// AppArmorProfileDie mutates AppArmorProfile as a die.
+//
+// appArmorProfile is the AppArmor options to use by this container. If set, this profile
+//
+// overrides the pod's appArmorProfile.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *SecurityContextDie) AppArmorProfileDie(fn func(d *AppArmorProfileDie)) *SecurityContextDie {
+	return d.DieStamp(func(r *corev1.SecurityContext) {
+		d := AppArmorProfileBlank.DieImmutable(false).DieFeedPtr(r.AppArmorProfile)
+		fn(d)
+		r.AppArmorProfile = d.DieReleasePtr()
+	})
 }
 
 // The capabilities to add/drop when running containers.
@@ -11828,6 +12460,65 @@ func (d *ContainerStatusDie) DiePatch(patchType types.PatchType) ([]byte, error)
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// StateDie mutates State as a die.
+//
+// State holds details about the container's current condition.
+func (d *ContainerStatusDie) StateDie(fn func(d *ContainerStateDie)) *ContainerStatusDie {
+	return d.DieStamp(func(r *corev1.ContainerStatus) {
+		d := ContainerStateBlank.DieImmutable(false).DieFeed(r.State)
+		fn(d)
+		r.State = d.DieRelease()
+	})
+}
+
+// LastTerminationStateDie mutates LastTerminationState as a die.
+//
+// # LastTerminationState holds the last termination state of the container to
+//
+// help debug container crashes and restarts. This field is not
+//
+// populated if the container is still running and RestartCount is 0.
+func (d *ContainerStatusDie) LastTerminationStateDie(fn func(d *ContainerStateDie)) *ContainerStatusDie {
+	return d.DieStamp(func(r *corev1.ContainerStatus) {
+		d := ContainerStateBlank.DieImmutable(false).DieFeed(r.LastTerminationState)
+		fn(d)
+		r.LastTerminationState = d.DieRelease()
+	})
+}
+
+// ResourcesDie mutates Resources as a die.
+//
+// # Resources represents the compute resource requests and limits that have been successfully
+//
+// enacted on the running container after it has been started or has been successfully resized.
+func (d *ContainerStatusDie) ResourcesDie(fn func(d *ResourceRequirementsDie)) *ContainerStatusDie {
+	return d.DieStamp(func(r *corev1.ContainerStatus) {
+		d := ResourceRequirementsBlank.DieImmutable(false).DieFeedPtr(r.Resources)
+		fn(d)
+		r.Resources = d.DieReleasePtr()
+	})
+}
+
+// VolumeMountDie mutates a single item in VolumeMounts matched by the nested field Name, appending a new item if no match is found.
+//
+// Status of volume mounts.
+func (d *ContainerStatusDie) VolumeMountDie(v string, fn func(d *VolumeMountStatusDie)) *ContainerStatusDie {
+	return d.DieStamp(func(r *corev1.ContainerStatus) {
+		for i := range r.VolumeMounts {
+			if v == r.VolumeMounts[i].Name {
+				d := VolumeMountStatusBlank.DieImmutable(false).DieFeed(r.VolumeMounts[i])
+				fn(d)
+				r.VolumeMounts[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := VolumeMountStatusBlank.DieImmutable(false).DieFeed(corev1.VolumeMountStatus{Name: v})
+		fn(d)
+		r.VolumeMounts = append(r.VolumeMounts, d.DieRelease())
+	})
+}
+
 // Name is a DNS_LABEL representing the unique name of the container.
 //
 // Each container in a pod must have a unique name across all container types.
@@ -12224,6 +12915,39 @@ func (d *ContainerStateDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ContainerStateDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// WaitingDie mutates Waiting as a die.
+//
+// Details about a waiting container
+func (d *ContainerStateDie) WaitingDie(fn func(d *ContainerStateWaitingDie)) *ContainerStateDie {
+	return d.DieStamp(func(r *corev1.ContainerState) {
+		d := ContainerStateWaitingBlank.DieImmutable(false).DieFeedPtr(r.Waiting)
+		fn(d)
+		r.Waiting = d.DieReleasePtr()
+	})
+}
+
+// RunningDie mutates Running as a die.
+//
+// Details about a running container
+func (d *ContainerStateDie) RunningDie(fn func(d *ContainerStateRunningDie)) *ContainerStateDie {
+	return d.DieStamp(func(r *corev1.ContainerState) {
+		d := ContainerStateRunningBlank.DieImmutable(false).DieFeedPtr(r.Running)
+		fn(d)
+		r.Running = d.DieReleasePtr()
+	})
+}
+
+// TerminatedDie mutates Terminated as a die.
+//
+// Details about a terminated container
+func (d *ContainerStateDie) TerminatedDie(fn func(d *ContainerStateTerminatedDie)) *ContainerStateDie {
+	return d.DieStamp(func(r *corev1.ContainerState) {
+		d := ContainerStateTerminatedBlank.DieImmutable(false).DieFeedPtr(r.Terminated)
+		fn(d)
+		r.Terminated = d.DieReleasePtr()
+	})
 }
 
 // Details about a waiting container
@@ -13584,6 +14308,30 @@ func (d *EndpointsDie) MetadataDie(fn func(d *metav1.ObjectMetaDie)) *EndpointsD
 	})
 }
 
+// SubsetsDie replaces Subsets by collecting the released value from each die passed.
+//
+// The set of all endpoints is the union of all subsets. Addresses are placed into
+//
+// subsets according to the IPs they share. A single address with multiple ports,
+//
+// some of which are ready and some of which are not (because they come from
+//
+// different containers) will result in the address being displayed in different
+//
+// subsets for the different ports. No address will appear in both Addresses and
+//
+// NotReadyAddresses in the same subset.
+//
+// Sets of addresses and ports that comprise a service.
+func (d *EndpointsDie) SubsetsDie(v ...*EndpointSubsetDie) *EndpointsDie {
+	return d.DieStamp(func(r *corev1.Endpoints) {
+		r.Subsets = make([]corev1.EndpointSubset, len(v))
+		for i := range v {
+			r.Subsets[i] = v[i].DieRelease()
+		}
+	})
+}
+
 // The set of all endpoints is the union of all subsets. Addresses are placed into
 //
 // subsets according to the IPs they share. A single address with multiple ports,
@@ -13829,6 +14577,48 @@ func (d *EndpointSubsetDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *EndpointSubsetDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// AddressesDie replaces Addresses by collecting the released value from each die passed.
+//
+// IP addresses which offer the related ports that are marked as ready. These endpoints
+//
+// should be considered safe for load balancers and clients to utilize.
+func (d *EndpointSubsetDie) AddressesDie(v ...*EndpointAddressDie) *EndpointSubsetDie {
+	return d.DieStamp(func(r *corev1.EndpointSubset) {
+		r.Addresses = make([]corev1.EndpointAddress, len(v))
+		for i := range v {
+			r.Addresses[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// NotReadyAddressesDie replaces NotReadyAddresses by collecting the released value from each die passed.
+//
+// # IP addresses which offer the related ports but are not currently marked as ready
+//
+// because they have not yet finished starting, have recently failed a readiness check,
+//
+// or have recently failed a liveness check.
+func (d *EndpointSubsetDie) NotReadyAddressesDie(v ...*EndpointAddressDie) *EndpointSubsetDie {
+	return d.DieStamp(func(r *corev1.EndpointSubset) {
+		r.NotReadyAddresses = make([]corev1.EndpointAddress, len(v))
+		for i := range v {
+			r.NotReadyAddresses[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// PortsDie replaces Ports by collecting the released value from each die passed.
+//
+// Port numbers available on the related IP addresses.
+func (d *EndpointSubsetDie) PortsDie(v ...*EndpointPortDie) *EndpointSubsetDie {
+	return d.DieStamp(func(r *corev1.EndpointSubset) {
+		r.Ports = make([]corev1.EndpointPort, len(v))
+		for i := range v {
+			r.Ports[i] = v[i].DieRelease()
+		}
+	})
 }
 
 // IP addresses which offer the related ports that are marked as ready. These endpoints
@@ -14084,6 +14874,17 @@ func (d *EndpointAddressDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *EndpointAddressDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// TargetRefDie mutates TargetRef as a die.
+//
+// Reference to object providing the endpoint.
+func (d *EndpointAddressDie) TargetRefDie(fn func(d *ObjectReferenceDie)) *EndpointAddressDie {
+	return d.DieStamp(func(r *corev1.EndpointAddress) {
+		d := ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.TargetRef)
+		fn(d)
+		r.TargetRef = d.DieReleasePtr()
+	})
 }
 
 // The IP of this endpoint.
@@ -14726,6 +15527,50 @@ func (d *EventDie) MetadataDie(fn func(d *metav1.ObjectMetaDie)) *EventDie {
 		d := metav1.ObjectMetaBlank.DieImmutable(false).DieFeed(r.ObjectMeta)
 		fn(d)
 		r.ObjectMeta = d.DieRelease()
+	})
+}
+
+// InvolvedObjectDie mutates InvolvedObject as a die.
+//
+// The object that this event is about.
+func (d *EventDie) InvolvedObjectDie(fn func(d *ObjectReferenceDie)) *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		d := ObjectReferenceBlank.DieImmutable(false).DieFeed(r.InvolvedObject)
+		fn(d)
+		r.InvolvedObject = d.DieRelease()
+	})
+}
+
+// SourceDie mutates Source as a die.
+//
+// The component reporting this event. Should be a short machine understandable string.
+func (d *EventDie) SourceDie(fn func(d *EventSourceDie)) *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		d := EventSourceBlank.DieImmutable(false).DieFeed(r.Source)
+		fn(d)
+		r.Source = d.DieRelease()
+	})
+}
+
+// SeriesDie mutates Series as a die.
+//
+// Data about the Event series this event represents or nil if it's a singleton Event.
+func (d *EventDie) SeriesDie(fn func(d *EventSeriesDie)) *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		d := EventSeriesBlank.DieImmutable(false).DieFeedPtr(r.Series)
+		fn(d)
+		r.Series = d.DieReleasePtr()
+	})
+}
+
+// RelatedDie mutates Related as a die.
+//
+// Optional secondary object for more complex actions.
+func (d *EventDie) RelatedDie(fn func(d *ObjectReferenceDie)) *EventDie {
+	return d.DieStamp(func(r *corev1.Event) {
+		d := ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.Related)
+		fn(d)
+		r.Related = d.DieReleasePtr()
 	})
 }
 
@@ -15884,6 +16729,18 @@ func (d *LimitRangeSpecDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *LimitRangeSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// LimitsDie replaces Limits by collecting the released value from each die passed.
+//
+// Limits is the list of LimitRangeItem objects that are enforced.
+func (d *LimitRangeSpecDie) LimitsDie(v ...*LimitRangeItemDie) *LimitRangeSpecDie {
+	return d.DieStamp(func(r *corev1.LimitRangeSpec) {
+		r.Limits = make([]corev1.LimitRangeItem, len(v))
+		for i := range v {
+			r.Limits[i] = v[i].DieRelease()
+		}
+	})
 }
 
 // Limits is the list of LimitRangeItem objects that are enforced.
@@ -17694,6 +18551,37 @@ func (d *NodeSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ConfigSourceDie mutates ConfigSource as a die.
+//
+// Deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature. This feature is removed.
+func (d *NodeSpecDie) ConfigSourceDie(fn func(d *NodeConfigSourceDie)) *NodeSpecDie {
+	return d.DieStamp(func(r *corev1.NodeSpec) {
+		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.ConfigSource)
+		fn(d)
+		r.ConfigSource = d.DieReleasePtr()
+	})
+}
+
+// TaintDie mutates a single item in Taints matched by the nested field Key, appending a new item if no match is found.
+//
+// If specified, the node's taints.
+func (d *NodeSpecDie) TaintDie(v string, fn func(d *TaintDie)) *NodeSpecDie {
+	return d.DieStamp(func(r *corev1.NodeSpec) {
+		for i := range r.Taints {
+			if v == r.Taints[i].Key {
+				d := TaintBlank.DieImmutable(false).DieFeed(r.Taints[i])
+				fn(d)
+				r.Taints[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := TaintBlank.DieImmutable(false).DieFeed(corev1.Taint{Key: v})
+		fn(d)
+		r.Taints = append(r.Taints, d.DieRelease())
+	})
+}
+
 // PodCIDR represents the pod IP range assigned to the node.
 func (d *NodeSpecDie) PodCIDR(v string) *NodeSpecDie {
 	return d.DieStamp(func(r *corev1.NodeSpec) {
@@ -18241,6 +19129,17 @@ func (d *NodeConfigSourceDie) DiePatch(patchType types.PatchType) ([]byte, error
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ConfigMapDie mutates ConfigMap as a die.
+//
+// ConfigMap is a reference to a Node's ConfigMap
+func (d *NodeConfigSourceDie) ConfigMapDie(fn func(d *ConfigMapNodeConfigSourceDie)) *NodeConfigSourceDie {
+	return d.DieStamp(func(r *corev1.NodeConfigSource) {
+		d := ConfigMapNodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.ConfigMap)
+		fn(d)
+		r.ConfigMap = d.DieReleasePtr()
+	})
+}
+
 // ConfigMap is a reference to a Node's ConfigMap
 func (d *NodeConfigSourceDie) ConfigMap(v *corev1.ConfigMapNodeConfigSource) *NodeConfigSourceDie {
 	return d.DieStamp(func(r *corev1.NodeConfigSource) {
@@ -18747,6 +19646,115 @@ func (d *NodeStatusDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *NodeStatusDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// DaemonEndpointsDie mutates DaemonEndpoints as a die.
+//
+// Endpoints of daemons running on the Node.
+func (d *NodeStatusDie) DaemonEndpointsDie(fn func(d *NodeDaemonEndpointsDie)) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		d := NodeDaemonEndpointsBlank.DieImmutable(false).DieFeed(r.DaemonEndpoints)
+		fn(d)
+		r.DaemonEndpoints = d.DieRelease()
+	})
+}
+
+// NodeInfoDie mutates NodeInfo as a die.
+//
+// Set of ids/uuids to uniquely identify the node.
+//
+// More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+func (d *NodeStatusDie) NodeInfoDie(fn func(d *NodeSystemInfoDie)) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		d := NodeSystemInfoBlank.DieImmutable(false).DieFeed(r.NodeInfo)
+		fn(d)
+		r.NodeInfo = d.DieRelease()
+	})
+}
+
+// ConfigDie mutates Config as a die.
+//
+// Status of the config assigned to the node via the dynamic Kubelet config feature.
+func (d *NodeStatusDie) ConfigDie(fn func(d *NodeConfigStatusDie)) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		d := NodeConfigStatusBlank.DieImmutable(false).DieFeedPtr(r.Config)
+		fn(d)
+		r.Config = d.DieReleasePtr()
+	})
+}
+
+// AddressesDie replaces Addresses by collecting the released value from each die passed.
+//
+// List of addresses reachable to the node.
+//
+// Queried from cloud provider, if available.
+//
+// More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses
+//
+// Note: This field is declared as mergeable, but the merge key is not sufficiently
+//
+// unique, which can cause data corruption when it is merged. Callers should instead
+//
+// use a full-replacement patch. See https://pr.k8s.io/79391 for an example.
+//
+// # Consumers should assume that addresses can change during the
+//
+// lifetime of a Node. However, there are some exceptions where this may not
+//
+// be possible, such as Pods that inherit a Node's address in its own status or
+//
+// consumers of the downward API (status.hostIP).
+func (d *NodeStatusDie) AddressesDie(v ...*NodeAddressDie) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		r.Addresses = make([]corev1.NodeAddress, len(v))
+		for i := range v {
+			r.Addresses[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// ImagesDie replaces Images by collecting the released value from each die passed.
+//
+// List of container images on this node
+func (d *NodeStatusDie) ImagesDie(v ...*ContainerImageDie) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		r.Images = make([]corev1.ContainerImage, len(v))
+		for i := range v {
+			r.Images[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// VolumeAttachedDie mutates a single item in VolumesAttached matched by the nested field Name, appending a new item if no match is found.
+//
+// List of volumes that are attached to the node.
+func (d *NodeStatusDie) VolumeAttachedDie(v corev1.UniqueVolumeName, fn func(d *AttachedVolumeDie)) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		for i := range r.VolumesAttached {
+			if v == r.VolumesAttached[i].Name {
+				d := AttachedVolumeBlank.DieImmutable(false).DieFeed(r.VolumesAttached[i])
+				fn(d)
+				r.VolumesAttached[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := AttachedVolumeBlank.DieImmutable(false).DieFeed(corev1.AttachedVolume{Name: v})
+		fn(d)
+		r.VolumesAttached = append(r.VolumesAttached, d.DieRelease())
+	})
+}
+
+// RuntimeHandlersDie replaces RuntimeHandlers by collecting the released value from each die passed.
+//
+// The available runtime handlers.
+func (d *NodeStatusDie) RuntimeHandlersDie(v ...*NodeRuntimeHandlerDie) *NodeStatusDie {
+	return d.DieStamp(func(r *corev1.NodeStatus) {
+		r.RuntimeHandlers = make([]corev1.NodeRuntimeHandler, len(v))
+		for i := range v {
+			r.RuntimeHandlers[i] = v[i].DieRelease()
+		}
+	})
 }
 
 // Capacity represents the total resources of a node.
@@ -19379,6 +20387,17 @@ func (d *NodeDaemonEndpointsDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *NodeDaemonEndpointsDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// KubeletEndpointDie mutates KubeletEndpoint as a die.
+//
+// Endpoint on which Kubelet is listening.
+func (d *NodeDaemonEndpointsDie) KubeletEndpointDie(fn func(d *DaemonEndpointDie)) *NodeDaemonEndpointsDie {
+	return d.DieStamp(func(r *corev1.NodeDaemonEndpoints) {
+		d := DaemonEndpointBlank.DieImmutable(false).DieFeed(r.KubeletEndpoint)
+		fn(d)
+		r.KubeletEndpoint = d.DieRelease()
+	})
 }
 
 // Endpoint on which Kubelet is listening.
@@ -20643,6 +21662,79 @@ func (d *NodeConfigStatusDie) DiePatch(patchType types.PatchType) ([]byte, error
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// AssignedDie mutates Assigned as a die.
+//
+// Assigned reports the checkpointed config the node will try to use.
+//
+// # When Node.Spec.ConfigSource is updated, the node checkpoints the associated
+//
+// config payload to local disk, along with a record indicating intended
+//
+// config. The node refers to this record to choose its config checkpoint, and
+//
+// reports this record in Assigned. Assigned only updates in the status after
+//
+// the record has been checkpointed to disk. When the Kubelet is restarted,
+//
+// it tries to make the Assigned config the Active config by loading and
+//
+// validating the checkpointed payload identified by Assigned.
+func (d *NodeConfigStatusDie) AssignedDie(fn func(d *NodeConfigSourceDie)) *NodeConfigStatusDie {
+	return d.DieStamp(func(r *corev1.NodeConfigStatus) {
+		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.Assigned)
+		fn(d)
+		r.Assigned = d.DieReleasePtr()
+	})
+}
+
+// ActiveDie mutates Active as a die.
+//
+// Active reports the checkpointed config the node is actively using.
+//
+// Active will represent either the current version of the Assigned config,
+//
+// or the current LastKnownGood config, depending on whether attempting to use the
+//
+// Assigned config results in an error.
+func (d *NodeConfigStatusDie) ActiveDie(fn func(d *NodeConfigSourceDie)) *NodeConfigStatusDie {
+	return d.DieStamp(func(r *corev1.NodeConfigStatus) {
+		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.Active)
+		fn(d)
+		r.Active = d.DieReleasePtr()
+	})
+}
+
+// LastKnownGoodDie mutates LastKnownGood as a die.
+//
+// # LastKnownGood reports the checkpointed config the node will fall back to
+//
+// when it encounters an error attempting to use the Assigned config.
+//
+// # The Assigned config becomes the LastKnownGood config when the node determines
+//
+// that the Assigned config is stable and correct.
+//
+// # This is currently implemented as a 10-minute soak period starting when the local
+//
+// record of Assigned config is updated. If the Assigned config is Active at the end
+//
+// of this period, it becomes the LastKnownGood. Note that if Spec.ConfigSource is
+//
+// reset to nil (use local defaults), the LastKnownGood is also immediately reset to nil,
+//
+// because the local default config is always assumed good.
+//
+// # You should not make assumptions about the node's method of determining config stability
+//
+// and correctness, as this may change or become configurable in the future.
+func (d *NodeConfigStatusDie) LastKnownGoodDie(fn func(d *NodeConfigSourceDie)) *NodeConfigStatusDie {
+	return d.DieStamp(func(r *corev1.NodeConfigStatus) {
+		d := NodeConfigSourceBlank.DieImmutable(false).DieFeedPtr(r.LastKnownGood)
+		fn(d)
+		r.LastKnownGood = d.DieReleasePtr()
+	})
+}
+
 // Assigned reports the checkpointed config the node will try to use.
 //
 // # When Node.Spec.ConfigSource is updated, the node checkpoints the associated
@@ -20959,6 +22051,17 @@ func (d *NodeRuntimeHandlerDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *NodeRuntimeHandlerDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// FeaturesDie mutates Features as a die.
+//
+// Supported features.
+func (d *NodeRuntimeHandlerDie) FeaturesDie(fn func(d *NodeRuntimeHandlerFeaturesDie)) *NodeRuntimeHandlerDie {
+	return d.DieStamp(func(r *corev1.NodeRuntimeHandler) {
+		d := NodeRuntimeHandlerFeaturesBlank.DieImmutable(false).DieFeedPtr(r.Features)
+		fn(d)
+		r.Features = d.DieReleasePtr()
+	})
 }
 
 // Runtime handler name.
@@ -21803,6 +22906,19 @@ func (d *PersistentVolumeSpecDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *PersistentVolumeSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// NodeAffinityDie mutates NodeAffinity as a die.
+//
+// nodeAffinity defines constraints that limit what nodes this volume can be accessed from.
+//
+// This field influences the scheduling of pods that use this volume.
+func (d *PersistentVolumeSpecDie) NodeAffinityDie(fn func(d *VolumeNodeAffinityDie)) *PersistentVolumeSpecDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeSpec) {
+		d := VolumeNodeAffinityBlank.DieImmutable(false).DieFeedPtr(r.NodeAffinity)
+		fn(d)
+		r.NodeAffinity = d.DieReleasePtr()
+	})
 }
 
 // capacity is the description of the persistent volume's resources and capacity.
@@ -22699,6 +23815,23 @@ func (d *RBDPersistentVolumeSourceDie) DiePatch(patchType types.PatchType) ([]by
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is name of the authentication secret for RBDUser. If provided
+//
+// overrides keyring.
+//
+// Default is nil.
+//
+// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+func (d *RBDPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *RBDPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.RBDPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // monitors is a collection of Ceph monitors.
 //
 // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -23015,6 +24148,17 @@ func (d *ISCSIPersistentVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ISCSIPersistentVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is the CHAP Secret for iSCSI target and initiator authentication
+func (d *ISCSIPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *ISCSIPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.ISCSIPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
 }
 
 // targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
@@ -23342,6 +24486,19 @@ func (d *CinderPersistentVolumeSourceDie) DiePatch(patchType types.PatchType) ([
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is Optional: points to a secret object containing parameters used to connect
+//
+// to OpenStack.
+func (d *CinderPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *CinderPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CinderPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // volumeID used to identify the volume in cinder.
 //
 // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
@@ -23610,6 +24767,19 @@ func (d *CephFSPersistentVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *CephFSPersistentVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+//
+// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+func (d *CephFSPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *CephFSPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CephFSPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
 }
 
 // monitors is Required: Monitors is a collection of Ceph monitors
@@ -23892,6 +25062,25 @@ func (d *FlexPersistentVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *FlexPersistentVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is Optional: SecretRef is reference to the secret object containing
+//
+// sensitive information to pass to the plugin scripts. This may be
+//
+// empty if no secret object is specified. If the secret object
+//
+// contains more than one secret, all secrets are passed to the plugin
+//
+// scripts.
+func (d *FlexPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *FlexPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.FlexPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
 }
 
 // driver is the name of the driver to use for this volume.
@@ -24429,6 +25618,19 @@ func (d *ScaleIOPersistentVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ScaleIOPersistentVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef references to the secret for ScaleIO user and other
+//
+// sensitive information. If this is not provided, Login operation will fail.
+func (d *ScaleIOPersistentVolumeSourceDie) SecretRefDie(fn func(d *SecretReferenceDie)) *ScaleIOPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.ScaleIOPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
 }
 
 // gateway is the host address of the ScaleIO API Gateway.
@@ -24993,6 +26195,19 @@ func (d *StorageOSPersistentVolumeSourceDie) DiePatch(patchType types.PatchType)
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef specifies the secret to use for obtaining the StorageOS API
+//
+// credentials.  If not specified, default values will be attempted.
+func (d *StorageOSPersistentVolumeSourceDie) SecretRefDie(fn func(d *ObjectReferenceDie)) *StorageOSPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.StorageOSPersistentVolumeSource) {
+		d := ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // volumeName is the human-readable name of the StorageOS volume.  Volume
 //
 // names are only unique within a namespace.
@@ -25274,6 +26489,101 @@ func (d *CSIPersistentVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *CSIPersistentVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ControllerPublishSecretRefDie mutates ControllerPublishSecretRef as a die.
+//
+// controllerPublishSecretRef is a reference to the secret object containing
+//
+// sensitive information to pass to the CSI driver to complete the CSI
+//
+// ControllerPublishVolume and ControllerUnpublishVolume calls.
+//
+// This field is optional, and may be empty if no secret is required. If the
+//
+// secret object contains more than one secret, all secrets are passed.
+func (d *CSIPersistentVolumeSourceDie) ControllerPublishSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.ControllerPublishSecretRef)
+		fn(d)
+		r.ControllerPublishSecretRef = d.DieReleasePtr()
+	})
+}
+
+// NodeStageSecretRefDie mutates NodeStageSecretRef as a die.
+//
+// nodeStageSecretRef is a reference to the secret object containing sensitive
+//
+// information to pass to the CSI driver to complete the CSI NodeStageVolume
+//
+// and NodeStageVolume and NodeUnstageVolume calls.
+//
+// This field is optional, and may be empty if no secret is required. If the
+//
+// secret object contains more than one secret, all secrets are passed.
+func (d *CSIPersistentVolumeSourceDie) NodeStageSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodeStageSecretRef)
+		fn(d)
+		r.NodeStageSecretRef = d.DieReleasePtr()
+	})
+}
+
+// NodePublishSecretRefDie mutates NodePublishSecretRef as a die.
+//
+// nodePublishSecretRef is a reference to the secret object containing
+//
+// sensitive information to pass to the CSI driver to complete the CSI
+//
+// NodePublishVolume and NodeUnpublishVolume calls.
+//
+// This field is optional, and may be empty if no secret is required. If the
+//
+// secret object contains more than one secret, all secrets are passed.
+func (d *CSIPersistentVolumeSourceDie) NodePublishSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodePublishSecretRef)
+		fn(d)
+		r.NodePublishSecretRef = d.DieReleasePtr()
+	})
+}
+
+// ControllerExpandSecretRefDie mutates ControllerExpandSecretRef as a die.
+//
+// controllerExpandSecretRef is a reference to the secret object containing
+//
+// sensitive information to pass to the CSI driver to complete the CSI
+//
+// ControllerExpandVolume call.
+//
+// This field is optional, and may be empty if no secret is required. If the
+//
+// secret object contains more than one secret, all secrets are passed.
+func (d *CSIPersistentVolumeSourceDie) ControllerExpandSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.ControllerExpandSecretRef)
+		fn(d)
+		r.ControllerExpandSecretRef = d.DieReleasePtr()
+	})
+}
+
+// NodeExpandSecretRefDie mutates NodeExpandSecretRef as a die.
+//
+// nodeExpandSecretRef is a reference to the secret object containing
+//
+// sensitive information to pass to the CSI driver to complete the CSI
+//
+// NodeExpandVolume call.
+//
+// This field is optional, may be omitted if no secret is required. If the
+//
+// secret object contains more than one secret, all secrets are passed.
+func (d *CSIPersistentVolumeSourceDie) NodeExpandSecretRefDie(fn func(d *SecretReferenceDie)) *CSIPersistentVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CSIPersistentVolumeSource) {
+		d := SecretReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodeExpandSecretRef)
+		fn(d)
+		r.NodeExpandSecretRef = d.DieReleasePtr()
+	})
 }
 
 // driver is the name of the driver to use for this volume.
@@ -25624,6 +26934,17 @@ func (d *VolumeNodeAffinityDie) DiePatch(patchType types.PatchType) ([]byte, err
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// RequiredDie mutates Required as a die.
+//
+// required specifies hard node constraints that must be met.
+func (d *VolumeNodeAffinityDie) RequiredDie(fn func(d *NodeSelectorDie)) *VolumeNodeAffinityDie {
+	return d.DieStamp(func(r *corev1.VolumeNodeAffinity) {
+		d := NodeSelectorBlank.DieImmutable(false).DieFeedPtr(r.Required)
+		fn(d)
+		r.Required = d.DieReleasePtr()
+	})
+}
+
 // required specifies hard node constraints that must be met.
 func (d *VolumeNodeAffinityDie) Required(v *corev1.NodeSelector) *VolumeNodeAffinityDie {
 	return d.DieStamp(func(r *corev1.VolumeNodeAffinity) {
@@ -25859,6 +27180,18 @@ func (d *NodeSelectorDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// NodeSelectorTermsDie replaces NodeSelectorTerms by collecting the released value from each die passed.
+//
+// Required. A list of node selector terms. The terms are ORed.
+func (d *NodeSelectorDie) NodeSelectorTermsDie(v ...*NodeSelectorTermDie) *NodeSelectorDie {
+	return d.DieStamp(func(r *corev1.NodeSelector) {
+		r.NodeSelectorTerms = make([]corev1.NodeSelectorTerm, len(v))
+		for i := range v {
+			r.NodeSelectorTerms[i] = v[i].DieRelease()
+		}
+	})
+}
+
 // Required. A list of node selector terms. The terms are ORed.
 func (d *NodeSelectorDie) NodeSelectorTerms(v ...corev1.NodeSelectorTerm) *NodeSelectorDie {
 	return d.DieStamp(func(r *corev1.NodeSelector) {
@@ -26092,6 +27425,46 @@ func (d *NodeSelectorTermDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *NodeSelectorTermDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// MatchExpressionDie mutates a single item in MatchExpressions matched by the nested field Key, appending a new item if no match is found.
+//
+// A list of node selector requirements by node's labels.
+func (d *NodeSelectorTermDie) MatchExpressionDie(v string, fn func(d *NodeSelectorRequirementDie)) *NodeSelectorTermDie {
+	return d.DieStamp(func(r *corev1.NodeSelectorTerm) {
+		for i := range r.MatchExpressions {
+			if v == r.MatchExpressions[i].Key {
+				d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(r.MatchExpressions[i])
+				fn(d)
+				r.MatchExpressions[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(corev1.NodeSelectorRequirement{Key: v})
+		fn(d)
+		r.MatchExpressions = append(r.MatchExpressions, d.DieRelease())
+	})
+}
+
+// MatchFieldDie mutates a single item in MatchFields matched by the nested field Key, appending a new item if no match is found.
+//
+// A list of node selector requirements by node's fields.
+func (d *NodeSelectorTermDie) MatchFieldDie(v string, fn func(d *NodeSelectorRequirementDie)) *NodeSelectorTermDie {
+	return d.DieStamp(func(r *corev1.NodeSelectorTerm) {
+		for i := range r.MatchFields {
+			if v == r.MatchFields[i].Key {
+				d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(r.MatchFields[i])
+				fn(d)
+				r.MatchFields[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := NodeSelectorRequirementBlank.DieImmutable(false).DieFeed(corev1.NodeSelectorRequirement{Key: v})
+		fn(d)
+		r.MatchFields = append(r.MatchFields, d.DieRelease())
+	})
 }
 
 // A list of node selector requirements by node's labels.
@@ -26956,6 +28329,116 @@ func (d *PersistentVolumeClaimSpecDie) DiePatch(patchType types.PatchType) ([]by
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SelectorDie mutates Selector as a die.
+//
+// selector is a label query over volumes to consider for binding.
+func (d *PersistentVolumeClaimSpecDie) SelectorDie(fn func(d *metav1.LabelSelectorDie)) *PersistentVolumeClaimSpecDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
+		d := metav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.Selector)
+		fn(d)
+		r.Selector = d.DieReleasePtr()
+	})
+}
+
+// ResourcesDie mutates Resources as a die.
+//
+// resources represents the minimum resources the volume should have.
+//
+// # If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+//
+// that are lower than previous value but must still be higher than capacity recorded in the
+//
+// status field of the claim.
+//
+// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+func (d *PersistentVolumeClaimSpecDie) ResourcesDie(fn func(d *VolumeResourceRequirementsDie)) *PersistentVolumeClaimSpecDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
+		d := VolumeResourceRequirementsBlank.DieImmutable(false).DieFeed(r.Resources)
+		fn(d)
+		r.Resources = d.DieRelease()
+	})
+}
+
+// DataSourceDie mutates DataSource as a die.
+//
+// dataSource field can be used to specify either:
+//
+// * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+//
+// * An existing PVC (PersistentVolumeClaim)
+//
+// If the provisioner or an external controller can support the specified data source,
+//
+// it will create a new volume based on the contents of the specified data source.
+//
+// When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+//
+// and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+//
+// If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+func (d *PersistentVolumeClaimSpecDie) DataSourceDie(fn func(d *TypedLocalObjectReferenceDie)) *PersistentVolumeClaimSpecDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
+		d := TypedLocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.DataSource)
+		fn(d)
+		r.DataSource = d.DieReleasePtr()
+	})
+}
+
+// DataSourceRefDie mutates DataSourceRef as a die.
+//
+// dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+//
+// volume is desired. This may be any object from a non-empty API group (non
+//
+// core object) or a PersistentVolumeClaim object.
+//
+// # When this field is specified, volume binding will only succeed if the type of
+//
+// the specified object matches some installed volume populator or dynamic
+//
+// provisioner.
+//
+// # This field will replace the functionality of the dataSource field and as such
+//
+// if both fields are non-empty, they must have the same value. For backwards
+//
+// compatibility, when namespace isn't specified in dataSourceRef,
+//
+// both fields (dataSource and dataSourceRef) will be set to the same
+//
+// value automatically if one of them is empty and the other is non-empty.
+//
+// When namespace is specified in dataSourceRef,
+//
+// dataSource isn't set to the same value and must be empty.
+//
+// There are three important differences between dataSource and dataSourceRef:
+//
+// * While dataSource only allows two specific types of objects, dataSourceRef
+//
+// allows any non-core object, as well as PersistentVolumeClaim objects.
+//
+// * While dataSource ignores disallowed values (dropping them), dataSourceRef
+//
+// preserves all values, and generates an error if a disallowed value is
+//
+// specified.
+//
+// * While dataSource only allows local objects, dataSourceRef allows objects
+//
+// in any namespaces.
+//
+// (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+//
+// (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+func (d *PersistentVolumeClaimSpecDie) DataSourceRefDie(fn func(d *TypedObjectReferenceDie)) *PersistentVolumeClaimSpecDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimSpec) {
+		d := TypedObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.DataSourceRef)
+		fn(d)
+		r.DataSourceRef = d.DieReleasePtr()
+	})
+}
+
 // accessModes contains the desired access modes the volume should have.
 //
 // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
@@ -27645,6 +29128,21 @@ func (d *PersistentVolumeClaimStatusDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *PersistentVolumeClaimStatusDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ModifyVolumeStatusDie mutates ModifyVolumeStatus as a die.
+//
+// ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
+//
+// When this is unset, there is no ModifyVolume operation being attempted.
+//
+// This is an alpha field and requires enabling VolumeAttributesClass feature.
+func (d *PersistentVolumeClaimStatusDie) ModifyVolumeStatusDie(fn func(d *ModifyVolumeStatusDie)) *PersistentVolumeClaimStatusDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
+		d := ModifyVolumeStatusBlank.DieImmutable(false).DieFeedPtr(r.ModifyVolumeStatus)
+		fn(d)
+		r.ModifyVolumeStatus = d.DieReleasePtr()
+	})
 }
 
 // phase represents the current phase of PersistentVolumeClaim.
@@ -28344,6 +29842,38 @@ func (d *PersistentVolumeClaimTemplateDie) DiePatch(patchType types.PatchType) (
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ObjectMetaDie mutates ObjectMeta as a die.
+//
+// # May contain labels and annotations that will be copied into the PVC
+//
+// when creating it. No other fields are allowed and will be rejected during
+//
+// validation.
+func (d *PersistentVolumeClaimTemplateDie) ObjectMetaDie(fn func(d *metav1.ObjectMetaDie)) *PersistentVolumeClaimTemplateDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimTemplate) {
+		d := metav1.ObjectMetaBlank.DieImmutable(false).DieFeed(r.ObjectMeta)
+		fn(d)
+		r.ObjectMeta = d.DieRelease()
+	})
+}
+
+// SpecDie mutates Spec as a die.
+//
+// The specification for the PersistentVolumeClaim. The entire content is
+//
+// copied unchanged into the PVC that gets created from this
+//
+// template. The same fields as in a PersistentVolumeClaim
+//
+// are also valid here.
+func (d *PersistentVolumeClaimTemplateDie) SpecDie(fn func(d *PersistentVolumeClaimSpecDie)) *PersistentVolumeClaimTemplateDie {
+	return d.DieStamp(func(r *corev1.PersistentVolumeClaimTemplate) {
+		d := PersistentVolumeClaimSpecBlank.DieImmutable(false).DieFeed(r.Spec)
+		fn(d)
+		r.Spec = d.DieRelease()
+	})
+}
+
 // May contain labels and annotations that will be copied into the PVC
 //
 // when creating it. No other fields are allowed and will be rejected during
@@ -28959,6 +30489,309 @@ func (d *PodSpecDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *PodSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecurityContextDie mutates SecurityContext as a die.
+//
+// SecurityContext holds pod-level security attributes and common container settings.
+//
+// Optional: Defaults to empty.  See type description for default values of each field.
+func (d *PodSpecDie) SecurityContextDie(fn func(d *PodSecurityContextDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		d := PodSecurityContextBlank.DieImmutable(false).DieFeedPtr(r.SecurityContext)
+		fn(d)
+		r.SecurityContext = d.DieReleasePtr()
+	})
+}
+
+// DNSConfigDie mutates DNSConfig as a die.
+//
+// Specifies the DNS parameters of a pod.
+//
+// # Parameters specified here will be merged to the generated DNS
+//
+// configuration based on DNSPolicy.
+func (d *PodSpecDie) DNSConfigDie(fn func(d *PodDNSConfigDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		d := PodDNSConfigBlank.DieImmutable(false).DieFeedPtr(r.DNSConfig)
+		fn(d)
+		r.DNSConfig = d.DieReleasePtr()
+	})
+}
+
+// OSDie mutates OS as a die.
+//
+// Specifies the OS of the containers in the pod.
+//
+// Some pod and container fields are restricted if this is set.
+//
+// If the OS field is set to linux, the following fields must be unset:
+//
+// -securityContext.windowsOptions
+//
+// If the OS field is set to windows, following fields must be unset:
+//
+// - spec.hostPID
+//
+// - spec.hostIPC
+//
+// - spec.hostUsers
+//
+// - spec.securityContext.appArmorProfile
+//
+// - spec.securityContext.seLinuxOptions
+//
+// - spec.securityContext.seccompProfile
+//
+// - spec.securityContext.fsGroup
+//
+// - spec.securityContext.fsGroupChangePolicy
+//
+// - spec.securityContext.sysctls
+//
+// - spec.shareProcessNamespace
+//
+// - spec.securityContext.runAsUser
+//
+// - spec.securityContext.runAsGroup
+//
+// - spec.securityContext.supplementalGroups
+//
+// - spec.containers[*].securityContext.appArmorProfile
+//
+// - spec.containers[*].securityContext.seLinuxOptions
+//
+// - spec.containers[*].securityContext.seccompProfile
+//
+// - spec.containers[*].securityContext.capabilities
+//
+// - spec.containers[*].securityContext.readOnlyRootFilesystem
+//
+// - spec.containers[*].securityContext.privileged
+//
+// - spec.containers[*].securityContext.allowPrivilegeEscalation
+//
+// - spec.containers[*].securityContext.procMount
+//
+// - spec.containers[*].securityContext.runAsUser
+//
+// - spec.containers[*].securityContext.runAsGroup
+func (d *PodSpecDie) OSDie(fn func(d *PodOSDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		d := PodOSBlank.DieImmutable(false).DieFeedPtr(r.OS)
+		fn(d)
+		r.OS = d.DieReleasePtr()
+	})
+}
+
+// VolumeDie mutates a single item in Volumes matched by the nested field Name, appending a new item if no match is found.
+//
+// List of volumes that can be mounted by containers belonging to the pod.
+//
+// More info: https://kubernetes.io/docs/concepts/storage/volumes
+func (d *PodSpecDie) VolumeDie(v string, fn func(d *VolumeDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		for i := range r.Volumes {
+			if v == r.Volumes[i].Name {
+				d := VolumeBlank.DieImmutable(false).DieFeed(r.Volumes[i])
+				fn(d)
+				r.Volumes[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := VolumeBlank.DieImmutable(false).DieFeed(corev1.Volume{Name: v})
+		fn(d)
+		r.Volumes = append(r.Volumes, d.DieRelease())
+	})
+}
+
+// InitContainerDie mutates a single item in InitContainers matched by the nested field Name, appending a new item if no match is found.
+//
+// List of initialization containers belonging to the pod.
+//
+// Init containers are executed in order prior to containers being started. If any
+//
+// init container fails, the pod is considered to have failed and is handled according
+//
+// to its restartPolicy. The name for an init container or normal container must be
+//
+// unique among all containers.
+//
+// Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+//
+// # The resourceRequirements of an init container are taken into account during scheduling
+//
+// by finding the highest request/limit for each resource type, and then using the max of
+//
+// of that value or the sum of the normal containers. Limits are applied to init containers
+//
+// in a similar fashion.
+//
+// Init containers cannot currently be added or removed.
+//
+// Cannot be updated.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+func (d *PodSpecDie) InitContainerDie(v string, fn func(d *ContainerDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		for i := range r.InitContainers {
+			if v == r.InitContainers[i].Name {
+				d := ContainerBlank.DieImmutable(false).DieFeed(r.InitContainers[i])
+				fn(d)
+				r.InitContainers[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ContainerBlank.DieImmutable(false).DieFeed(corev1.Container{Name: v})
+		fn(d)
+		r.InitContainers = append(r.InitContainers, d.DieRelease())
+	})
+}
+
+// ContainerDie mutates a single item in Containers matched by the nested field Name, appending a new item if no match is found.
+//
+// List of containers belonging to the pod.
+//
+// Containers cannot currently be added or removed.
+//
+// There must be at least one container in a Pod.
+//
+// Cannot be updated.
+func (d *PodSpecDie) ContainerDie(v string, fn func(d *ContainerDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		for i := range r.Containers {
+			if v == r.Containers[i].Name {
+				d := ContainerBlank.DieImmutable(false).DieFeed(r.Containers[i])
+				fn(d)
+				r.Containers[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ContainerBlank.DieImmutable(false).DieFeed(corev1.Container{Name: v})
+		fn(d)
+		r.Containers = append(r.Containers, d.DieRelease())
+	})
+}
+
+// TolerationDie mutates a single item in Tolerations matched by the nested field Key, appending a new item if no match is found.
+//
+// If specified, the pod's tolerations.
+func (d *PodSpecDie) TolerationDie(v string, fn func(d *TolerationDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		for i := range r.Tolerations {
+			if v == r.Tolerations[i].Key {
+				d := TolerationBlank.DieImmutable(false).DieFeed(r.Tolerations[i])
+				fn(d)
+				r.Tolerations[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := TolerationBlank.DieImmutable(false).DieFeed(corev1.Toleration{Key: v})
+		fn(d)
+		r.Tolerations = append(r.Tolerations, d.DieRelease())
+	})
+}
+
+// HostAliasesDie replaces HostAliases by collecting the released value from each die passed.
+//
+// # HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+//
+// file if specified.
+func (d *PodSpecDie) HostAliasesDie(v ...*HostAliasDie) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		r.HostAliases = make([]corev1.HostAlias, len(v))
+		for i := range v {
+			r.HostAliases[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// ReadinessGatesDie replaces ReadinessGates by collecting the released value from each die passed.
+//
+// If specified, all readiness gates will be evaluated for pod readiness.
+//
+// # A pod is ready when all its containers are ready AND
+//
+// all conditions specified in the readiness gates have status equal to "True"
+//
+// More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+func (d *PodSpecDie) ReadinessGatesDie(v ...*PodReadinessGateDie) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		r.ReadinessGates = make([]corev1.PodReadinessGate, len(v))
+		for i := range v {
+			r.ReadinessGates[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// TopologySpreadConstraintDie mutates a single item in TopologySpreadConstraints matched by the nested field TopologyKey, appending a new item if no match is found.
+//
+// # TopologySpreadConstraints describes how a group of pods ought to spread across topology
+//
+// domains. Scheduler will schedule pods in a way which abides by the constraints.
+//
+// All topologySpreadConstraints are ANDed.
+func (d *PodSpecDie) TopologySpreadConstraintDie(v string, fn func(d *TopologySpreadConstraintDie)) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		for i := range r.TopologySpreadConstraints {
+			if v == r.TopologySpreadConstraints[i].TopologyKey {
+				d := TopologySpreadConstraintBlank.DieImmutable(false).DieFeed(r.TopologySpreadConstraints[i])
+				fn(d)
+				r.TopologySpreadConstraints[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := TopologySpreadConstraintBlank.DieImmutable(false).DieFeed(corev1.TopologySpreadConstraint{TopologyKey: v})
+		fn(d)
+		r.TopologySpreadConstraints = append(r.TopologySpreadConstraints, d.DieRelease())
+	})
+}
+
+// SchedulingGatesDie replaces SchedulingGates by collecting the released value from each die passed.
+//
+// SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+//
+// # If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+//
+// scheduler will not attempt to schedule the pod.
+//
+// SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+func (d *PodSpecDie) SchedulingGatesDie(v ...*PodSchedulingGateDie) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		r.SchedulingGates = make([]corev1.PodSchedulingGate, len(v))
+		for i := range v {
+			r.SchedulingGates[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// ResourceClaimsDie replaces ResourceClaims by collecting the released value from each die passed.
+//
+// # ResourceClaims defines which ResourceClaims must be allocated
+//
+// and reserved before the Pod is allowed to start. The resources
+//
+// will be made available to those containers which consume them
+//
+// by name.
+//
+// # This is an alpha field and requires enabling the
+//
+// DynamicResourceAllocation feature gate.
+//
+// This field is immutable.
+func (d *PodSpecDie) ResourceClaimsDie(v ...*PodResourceClaimDie) *PodSpecDie {
+	return d.DieStamp(func(r *corev1.PodSpec) {
+		r.ResourceClaims = make([]corev1.PodResourceClaim, len(v))
+		for i := range v {
+			r.ResourceClaims[i] = v[i].DieRelease()
+		}
+	})
 }
 
 // List of volumes that can be mounted by containers belonging to the pod.
@@ -30013,6 +31846,17 @@ func (d *PodResourceClaimDie) DiePatch(patchType types.PatchType) ([]byte, error
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SourceDie mutates Source as a die.
+//
+// Source describes where to find the ResourceClaim.
+func (d *PodResourceClaimDie) SourceDie(fn func(d *ClaimSourceDie)) *PodResourceClaimDie {
+	return d.DieStamp(func(r *corev1.PodResourceClaim) {
+		d := ClaimSourceBlank.DieImmutable(false).DieFeed(r.Source)
+		fn(d)
+		r.Source = d.DieRelease()
+	})
+}
+
 // Name uniquely identifies this resource claim inside the pod.
 //
 // This must be a DNS_LABEL.
@@ -30517,6 +32361,86 @@ func (d *PodSecurityContextDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *PodSecurityContextDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SELinuxOptionsDie mutates SELinuxOptions as a die.
+//
+// The SELinux context to be applied to all containers.
+//
+// # If unspecified, the container runtime will allocate a random SELinux context for each
+//
+// container.  May also be set in SecurityContext.  If set in
+//
+// both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+//
+// takes precedence for that container.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *PodSecurityContextDie) SELinuxOptionsDie(fn func(d *SELinuxOptionsDie)) *PodSecurityContextDie {
+	return d.DieStamp(func(r *corev1.PodSecurityContext) {
+		d := SELinuxOptionsBlank.DieImmutable(false).DieFeedPtr(r.SELinuxOptions)
+		fn(d)
+		r.SELinuxOptions = d.DieReleasePtr()
+	})
+}
+
+// WindowsOptionsDie mutates WindowsOptions as a die.
+//
+// The Windows specific settings applied to all containers.
+//
+// If unspecified, the options within a container's SecurityContext will be used.
+//
+// If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+//
+// Note that this field cannot be set when spec.os.name is linux.
+func (d *PodSecurityContextDie) WindowsOptionsDie(fn func(d *WindowsSecurityContextOptionsDie)) *PodSecurityContextDie {
+	return d.DieStamp(func(r *corev1.PodSecurityContext) {
+		d := WindowsSecurityContextOptionsBlank.DieImmutable(false).DieFeedPtr(r.WindowsOptions)
+		fn(d)
+		r.WindowsOptions = d.DieReleasePtr()
+	})
+}
+
+// AppArmorProfileDie mutates AppArmorProfile as a die.
+//
+// appArmorProfile is the AppArmor options to use by the containers in this pod.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *PodSecurityContextDie) AppArmorProfileDie(fn func(d *AppArmorProfileDie)) *PodSecurityContextDie {
+	return d.DieStamp(func(r *corev1.PodSecurityContext) {
+		d := AppArmorProfileBlank.DieImmutable(false).DieFeedPtr(r.AppArmorProfile)
+		fn(d)
+		r.AppArmorProfile = d.DieReleasePtr()
+	})
+}
+
+// SysctlsDie replaces Sysctls by collecting the released value from each die passed.
+//
+// Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+//
+// sysctls (by the container runtime) might fail to launch.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *PodSecurityContextDie) SysctlsDie(v ...*SysctlDie) *PodSecurityContextDie {
+	return d.DieStamp(func(r *corev1.PodSecurityContext) {
+		r.Sysctls = make([]corev1.Sysctl, len(v))
+		for i := range v {
+			r.Sysctls[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// SeccompProfileDie mutates SeccompProfile as a die.
+//
+// The seccomp options to use by the containers in this pod.
+//
+// Note that this field cannot be set when spec.os.name is windows.
+func (d *PodSecurityContextDie) SeccompProfileDie(fn func(d *SeccompProfileDie)) *PodSecurityContextDie {
+	return d.DieStamp(func(r *corev1.PodSecurityContext) {
+		d := SeccompProfileBlank.DieImmutable(false).DieFeedPtr(r.SeccompProfile)
+		fn(d)
+		r.SeccompProfile = d.DieReleasePtr()
+	})
 }
 
 // The SELinux context to be applied to all containers.
@@ -31681,6 +33605,24 @@ func (d *PodDNSConfigDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// OptionsDie replaces Options by collecting the released value from each die passed.
+//
+// A list of DNS resolver options.
+//
+// This will be merged with the base options generated from DNSPolicy.
+//
+// Duplicated entries will be removed. Resolution options given in Options
+//
+// will override those that appear in the base DNSPolicy.
+func (d *PodDNSConfigDie) OptionsDie(v ...*PodDNSConfigOptionDie) *PodDNSConfigDie {
+	return d.DieStamp(func(r *corev1.PodDNSConfig) {
+		r.Options = make([]corev1.PodDNSConfigOption, len(v))
+		for i := range v {
+			r.Options[i] = v[i].DieRelease()
+		}
+	})
+}
+
 // A list of DNS name server IP addresses.
 //
 // This will be appended to the base nameservers generated from DNSPolicy.
@@ -32420,6 +34362,21 @@ func (d *TopologySpreadConstraintDie) DiePatch(patchType types.PatchType) ([]byt
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// LabelSelectorDie mutates LabelSelector as a die.
+//
+// LabelSelector is used to find matching pods.
+//
+// # Pods that match this label selector are counted to determine the number of pods
+//
+// in their corresponding topology domain.
+func (d *TopologySpreadConstraintDie) LabelSelectorDie(fn func(d *metav1.LabelSelectorDie)) *TopologySpreadConstraintDie {
+	return d.DieStamp(func(r *corev1.TopologySpreadConstraint) {
+		d := metav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.LabelSelector)
+		fn(d)
+		r.LabelSelector = d.DieReleasePtr()
+	})
+}
+
 // MaxSkew describes the degree to which pods may be unevenly distributed.
 //
 // When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
@@ -33105,6 +35062,74 @@ func (d *PodStatusDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// InitContainerStatusDie mutates a single item in InitContainerStatuses matched by the nested field Name, appending a new item if no match is found.
+//
+// The list has one entry per init container in the manifest. The most recent successful
+//
+// init container will have ready = true, the most recently started container will have
+//
+// startTime set.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+func (d *PodStatusDie) InitContainerStatusDie(v string, fn func(d *ContainerStatusDie)) *PodStatusDie {
+	return d.DieStamp(func(r *corev1.PodStatus) {
+		for i := range r.InitContainerStatuses {
+			if v == r.InitContainerStatuses[i].Name {
+				d := ContainerStatusBlank.DieImmutable(false).DieFeed(r.InitContainerStatuses[i])
+				fn(d)
+				r.InitContainerStatuses[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ContainerStatusBlank.DieImmutable(false).DieFeed(corev1.ContainerStatus{Name: v})
+		fn(d)
+		r.InitContainerStatuses = append(r.InitContainerStatuses, d.DieRelease())
+	})
+}
+
+// ContainerStatusDie mutates a single item in ContainerStatuses matched by the nested field Name, appending a new item if no match is found.
+//
+// The list has one entry per container in the manifest.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+func (d *PodStatusDie) ContainerStatusDie(v string, fn func(d *ContainerStatusDie)) *PodStatusDie {
+	return d.DieStamp(func(r *corev1.PodStatus) {
+		for i := range r.ContainerStatuses {
+			if v == r.ContainerStatuses[i].Name {
+				d := ContainerStatusBlank.DieImmutable(false).DieFeed(r.ContainerStatuses[i])
+				fn(d)
+				r.ContainerStatuses[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ContainerStatusBlank.DieImmutable(false).DieFeed(corev1.ContainerStatus{Name: v})
+		fn(d)
+		r.ContainerStatuses = append(r.ContainerStatuses, d.DieRelease())
+	})
+}
+
+// EphemeralContainerStatusDie mutates a single item in EphemeralContainerStatuses matched by the nested field Name, appending a new item if no match is found.
+//
+// Status for any ephemeral containers that have run in this pod.
+func (d *PodStatusDie) EphemeralContainerStatusDie(v string, fn func(d *ContainerStatusDie)) *PodStatusDie {
+	return d.DieStamp(func(r *corev1.PodStatus) {
+		for i := range r.EphemeralContainerStatuses {
+			if v == r.EphemeralContainerStatuses[i].Name {
+				d := ContainerStatusBlank.DieImmutable(false).DieFeed(r.EphemeralContainerStatuses[i])
+				fn(d)
+				r.EphemeralContainerStatuses[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ContainerStatusBlank.DieImmutable(false).DieFeed(corev1.ContainerStatus{Name: v})
+		fn(d)
+		r.EphemeralContainerStatuses = append(r.EphemeralContainerStatuses, d.DieRelease())
+	})
+}
+
 // The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle.
 //
 // # The conditions array, the reason and message fields, and the individual container status
@@ -33612,6 +35637,19 @@ func (d *PodTemplateDie) MetadataDie(fn func(d *metav1.ObjectMetaDie)) *PodTempl
 	})
 }
 
+// TemplateDie mutates Template as a die.
+//
+// Template defines the pods that will be created from this pod template.
+//
+// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+func (d *PodTemplateDie) TemplateDie(fn func(d *PodTemplateSpecDie)) *PodTemplateDie {
+	return d.DieStamp(func(r *corev1.PodTemplate) {
+		d := PodTemplateSpecBlank.DieImmutable(false).DieFeed(r.Template)
+		fn(d)
+		r.Template = d.DieRelease()
+	})
+}
+
 // Template defines the pods that will be created from this pod template.
 //
 // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -33847,6 +35885,32 @@ func (d *PodTemplateSpecDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *PodTemplateSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// MetadataDie mutates ObjectMeta as a die.
+//
+// Standard object's metadata.
+//
+// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+func (d *PodTemplateSpecDie) MetadataDie(fn func(d *metav1.ObjectMetaDie)) *PodTemplateSpecDie {
+	return d.DieStamp(func(r *corev1.PodTemplateSpec) {
+		d := metav1.ObjectMetaBlank.DieImmutable(false).DieFeed(r.ObjectMeta)
+		fn(d)
+		r.ObjectMeta = d.DieRelease()
+	})
+}
+
+// SpecDie mutates Spec as a die.
+//
+// Specification of the desired behavior of the pod.
+//
+// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+func (d *PodTemplateSpecDie) SpecDie(fn func(d *PodSpecDie)) *PodTemplateSpecDie {
+	return d.DieStamp(func(r *corev1.PodTemplateSpec) {
+		d := PodSpecBlank.DieImmutable(false).DieFeed(r.Spec)
+		fn(d)
+		r.Spec = d.DieRelease()
+	})
 }
 
 // Standard object's metadata.
@@ -34458,6 +36522,23 @@ func (d *ReplicationControllerSpecDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ReplicationControllerSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// TemplateDie mutates Template as a die.
+//
+// # Template is the object that describes the pod that will be created if
+//
+// insufficient replicas are detected. This takes precedence over a TemplateRef.
+//
+// The only allowed template.spec.restartPolicy value is "Always".
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+func (d *ReplicationControllerSpecDie) TemplateDie(fn func(d *PodTemplateSpecDie)) *ReplicationControllerSpecDie {
+	return d.DieStamp(func(r *corev1.ReplicationControllerSpec) {
+		d := PodTemplateSpecBlank.DieImmutable(false).DieFeedPtr(r.Template)
+		fn(d)
+		r.Template = d.DieReleasePtr()
+	})
 }
 
 // Replicas is the number of desired replicas.
@@ -35371,6 +37452,21 @@ func (d *ResourceQuotaSpecDie) DiePatch(patchType types.PatchType) ([]byte, erro
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ScopeSelectorDie mutates ScopeSelector as a die.
+//
+// scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota
+//
+// but expressed using ScopeSelectorOperator in combination with possible values.
+//
+// For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+func (d *ResourceQuotaSpecDie) ScopeSelectorDie(fn func(d *ScopeSelectorDie)) *ResourceQuotaSpecDie {
+	return d.DieStamp(func(r *corev1.ResourceQuotaSpec) {
+		d := ScopeSelectorBlank.DieImmutable(false).DieFeedPtr(r.ScopeSelector)
+		fn(d)
+		r.ScopeSelector = d.DieReleasePtr()
+	})
+}
+
 // hard is the set of desired hard limits for each named resource.
 //
 // More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
@@ -35650,6 +37746,26 @@ func (d *ScopeSelectorDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ScopeSelectorDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// MatchExpressionDie mutates a single item in MatchExpressions matched by the nested field ScopeName, appending a new item if no match is found.
+//
+// A list of scope selector requirements by scope of the resources.
+func (d *ScopeSelectorDie) MatchExpressionDie(v corev1.ResourceQuotaScope, fn func(d *ScopedResourceSelectorRequirementDie)) *ScopeSelectorDie {
+	return d.DieStamp(func(r *corev1.ScopeSelector) {
+		for i := range r.MatchExpressions {
+			if v == r.MatchExpressions[i].ScopeName {
+				d := ScopedResourceSelectorRequirementBlank.DieImmutable(false).DieFeed(r.MatchExpressions[i])
+				fn(d)
+				r.MatchExpressions[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := ScopedResourceSelectorRequirementBlank.DieImmutable(false).DieFeed(corev1.ScopedResourceSelectorRequirement{ScopeName: v})
+		fn(d)
+		r.MatchExpressions = append(r.MatchExpressions, d.DieRelease())
+	})
 }
 
 // A list of scope selector requirements by scope of the resources.
@@ -37140,6 +39256,17 @@ func (d *ServiceSpecDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SessionAffinityConfigDie mutates SessionAffinityConfig as a die.
+//
+// sessionAffinityConfig contains the configurations of session affinity.
+func (d *ServiceSpecDie) SessionAffinityConfigDie(fn func(d *SessionAffinityConfigDie)) *ServiceSpecDie {
+	return d.DieStamp(func(r *corev1.ServiceSpec) {
+		d := SessionAffinityConfigBlank.DieImmutable(false).DieFeedPtr(r.SessionAffinityConfig)
+		fn(d)
+		r.SessionAffinityConfig = d.DieReleasePtr()
+	})
+}
+
 // The list of ports that are exposed by this service.
 //
 // More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
@@ -38188,6 +40315,17 @@ func (d *SessionAffinityConfigDie) DiePatch(patchType types.PatchType) ([]byte, 
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ClientIPDie mutates ClientIP as a die.
+//
+// clientIP contains the configurations of Client IP based session affinity.
+func (d *SessionAffinityConfigDie) ClientIPDie(fn func(d *ClientIPConfigDie)) *SessionAffinityConfigDie {
+	return d.DieStamp(func(r *corev1.SessionAffinityConfig) {
+		d := ClientIPConfigBlank.DieImmutable(false).DieFeedPtr(r.ClientIP)
+		fn(d)
+		r.ClientIP = d.DieReleasePtr()
+	})
+}
+
 // clientIP contains the configurations of Client IP based session affinity.
 func (d *SessionAffinityConfigDie) ClientIP(v *corev1.ClientIPConfig) *SessionAffinityConfigDie {
 	return d.DieStamp(func(r *corev1.SessionAffinityConfig) {
@@ -38662,6 +40800,19 @@ func (d *ServiceStatusDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// LoadBalancerDie mutates LoadBalancer as a die.
+//
+// LoadBalancer contains the current status of the load-balancer,
+//
+// if one is present.
+func (d *ServiceStatusDie) LoadBalancerDie(fn func(d *LoadBalancerStatusDie)) *ServiceStatusDie {
+	return d.DieStamp(func(r *corev1.ServiceStatus) {
+		d := LoadBalancerStatusBlank.DieImmutable(false).DieFeed(r.LoadBalancer)
+		fn(d)
+		r.LoadBalancer = d.DieRelease()
+	})
+}
+
 // LoadBalancer contains the current status of the load-balancer,
 //
 // if one is present.
@@ -38906,6 +41057,20 @@ func (d *LoadBalancerStatusDie) DiePatch(patchType types.PatchType) ([]byte, err
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// IngressDie replaces Ingress by collecting the released value from each die passed.
+//
+// Ingress is a list containing ingress points for the load-balancer.
+//
+// Traffic intended for the service should be sent to these ingress points.
+func (d *LoadBalancerStatusDie) IngressDie(v ...*LoadBalancerIngressDie) *LoadBalancerStatusDie {
+	return d.DieStamp(func(r *corev1.LoadBalancerStatus) {
+		r.Ingress = make([]corev1.LoadBalancerIngress, len(v))
+		for i := range v {
+			r.Ingress[i] = v[i].DieRelease()
+		}
+	})
+}
+
 // Ingress is a list containing ingress points for the load-balancer.
 //
 // Traffic intended for the service should be sent to these ingress points.
@@ -39141,6 +41306,20 @@ func (d *LoadBalancerIngressDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *LoadBalancerIngressDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// PortsDie replaces Ports by collecting the released value from each die passed.
+//
+// # Ports is a list of records of service ports
+//
+// If used, every port defined in the service should have an entry in it
+func (d *LoadBalancerIngressDie) PortsDie(v ...*PortStatusDie) *LoadBalancerIngressDie {
+	return d.DieStamp(func(r *corev1.LoadBalancerIngress) {
+		r.Ports = make([]corev1.PortStatus, len(v))
+		for i := range v {
+			r.Ports[i] = v[i].DieRelease()
+		}
+	})
 }
 
 // IP is set for load-balancer ingress points that are IP based
@@ -39772,6 +41951,44 @@ func (d *ServiceAccountDie) MetadataDie(fn func(d *metav1.ObjectMetaDie)) *Servi
 		d := metav1.ObjectMetaBlank.DieImmutable(false).DieFeed(r.ObjectMeta)
 		fn(d)
 		r.ObjectMeta = d.DieRelease()
+	})
+}
+
+// SecretsDie replaces Secrets by collecting the released value from each die passed.
+//
+// Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use.
+//
+// Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true".
+//
+// This field should not be used to find auto-generated service account token secrets for use outside of pods.
+//
+// Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created.
+//
+// More info: https://kubernetes.io/docs/concepts/configuration/secret
+func (d *ServiceAccountDie) SecretsDie(v ...*ObjectReferenceDie) *ServiceAccountDie {
+	return d.DieStamp(func(r *corev1.ServiceAccount) {
+		r.Secrets = make([]corev1.ObjectReference, len(v))
+		for i := range v {
+			r.Secrets[i] = v[i].DieRelease()
+		}
+	})
+}
+
+// ImagePullSecretsDie replaces ImagePullSecrets by collecting the released value from each die passed.
+//
+// # ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
+//
+// in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets
+//
+// can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
+//
+// More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+func (d *ServiceAccountDie) ImagePullSecretsDie(v ...*LocalObjectReferenceDie) *ServiceAccountDie {
+	return d.DieStamp(func(r *corev1.ServiceAccount) {
+		r.ImagePullSecrets = make([]corev1.LocalObjectReference, len(v))
+		for i := range v {
+			r.ImagePullSecrets[i] = v[i].DieRelease()
+		}
 	})
 }
 
@@ -41623,6 +43840,38 @@ func (d *SecretVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, err
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ItemDie mutates a single item in Items matched by the nested field Key, appending a new item if no match is found.
+//
+// items If unspecified, each key-value pair in the Data field of the referenced
+//
+// # Secret will be projected into the volume as a file whose name is the
+//
+// key and content is the value. If specified, the listed keys will be
+//
+// projected into the specified paths, and unlisted keys will not be
+//
+// present. If a key is specified which is not present in the Secret,
+//
+// the volume setup will error unless it is marked optional. Paths must be
+//
+// relative and may not contain the '..' path or start with '..'.
+func (d *SecretVolumeSourceDie) ItemDie(v string, fn func(d *KeyToPathDie)) *SecretVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.SecretVolumeSource) {
+		for i := range r.Items {
+			if v == r.Items[i].Key {
+				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
+				fn(d)
+				r.Items[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: v})
+		fn(d)
+		r.Items = append(r.Items, d.DieRelease())
+	})
+}
+
 // secretName is the name of the secret in the pod's namespace to use.
 //
 // More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
@@ -42160,6 +44409,17 @@ func (d *ISCSIVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ISCSIVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is the CHAP Secret for iSCSI target and initiator authentication
+func (d *ISCSIVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *ISCSIVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.ISCSIVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
 }
 
 // targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
@@ -42990,6 +45250,23 @@ func (d *RBDVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error)
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is name of the authentication secret for RBDUser. If provided
+//
+// overrides keyring.
+//
+// Default is nil.
+//
+// More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+func (d *RBDVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *RBDVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.RBDVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // monitors is a collection of Ceph monitors.
 //
 // More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
@@ -43308,6 +45585,25 @@ func (d *FlexVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is Optional: secretRef is reference to the secret object containing
+//
+// sensitive information to pass to the plugin scripts. This may be
+//
+// empty if no secret object is specified. If the secret object
+//
+// contains more than one secret, all secrets are passed to the plugin
+//
+// scripts.
+func (d *FlexVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *FlexVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.FlexVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // driver is the name of the driver to use for this volume.
 func (d *FlexVolumeSourceDie) Driver(v string) *FlexVolumeSourceDie {
 	return d.DieStamp(func(r *corev1.FlexVolumeSource) {
@@ -43585,6 +45881,19 @@ func (d *CinderVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, err
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is optional: points to a secret object containing parameters used to connect
+//
+// to OpenStack.
+func (d *CinderVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *CinderVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CinderVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // volumeID used to identify the volume in cinder.
 //
 // More info: https://examples.k8s.io/mysql-cinder-pd/README.md
@@ -43853,6 +46162,19 @@ func (d *CephFSVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *CephFSVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+//
+// More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+func (d *CephFSVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *CephFSVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CephFSVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
 }
 
 // monitors is Required: Monitors is a collection of Ceph monitors
@@ -44381,6 +46703,26 @@ func (d *DownwardAPIVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ItemDie mutates a single item in Items matched by the nested field Path, appending a new item if no match is found.
+//
+// Items is a list of downward API volume file
+func (d *DownwardAPIVolumeSourceDie) ItemDie(v string, fn func(d *DownwardAPIVolumeFileDie)) *DownwardAPIVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.DownwardAPIVolumeSource) {
+		for i := range r.Items {
+			if v == r.Items[i].Path {
+				d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(r.Items[i])
+				fn(d)
+				r.Items[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(corev1.DownwardAPIVolumeFile{Path: v})
+		fn(d)
+		r.Items = append(r.Items, d.DieRelease())
+	})
+}
+
 // Items is a list of downward API volume file
 func (d *DownwardAPIVolumeSourceDie) Items(v ...corev1.DownwardAPIVolumeFile) *DownwardAPIVolumeSourceDie {
 	return d.DieStamp(func(r *corev1.DownwardAPIVolumeSource) {
@@ -44635,6 +46977,30 @@ func (d *DownwardAPIVolumeFileDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *DownwardAPIVolumeFileDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// FieldRefDie mutates FieldRef as a die.
+//
+// Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.
+func (d *DownwardAPIVolumeFileDie) FieldRefDie(fn func(d *ObjectFieldSelectorDie)) *DownwardAPIVolumeFileDie {
+	return d.DieStamp(func(r *corev1.DownwardAPIVolumeFile) {
+		d := ObjectFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.FieldRef)
+		fn(d)
+		r.FieldRef = d.DieReleasePtr()
+	})
+}
+
+// ResourceFieldRefDie mutates ResourceFieldRef as a die.
+//
+// Selects a resource of the container: only resources limits and requests
+//
+// (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+func (d *DownwardAPIVolumeFileDie) ResourceFieldRefDie(fn func(d *ResourceFieldSelectorDie)) *DownwardAPIVolumeFileDie {
+	return d.DieStamp(func(r *corev1.DownwardAPIVolumeFile) {
+		d := ResourceFieldSelectorBlank.DieImmutable(false).DieFeedPtr(r.ResourceFieldRef)
+		fn(d)
+		r.ResourceFieldRef = d.DieReleasePtr()
+	})
 }
 
 // Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
@@ -45427,6 +47793,38 @@ func (d *ConfigMapVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ConfigMapVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ItemDie mutates a single item in Items matched by the nested field Key, appending a new item if no match is found.
+//
+// items if unspecified, each key-value pair in the Data field of the referenced
+//
+// # ConfigMap will be projected into the volume as a file whose name is the
+//
+// key and content is the value. If specified, the listed keys will be
+//
+// projected into the specified paths, and unlisted keys will not be
+//
+// present. If a key is specified which is not present in the ConfigMap,
+//
+// the volume setup will error unless it is marked optional. Paths must be
+//
+// relative and may not contain the '..' path or start with '..'.
+func (d *ConfigMapVolumeSourceDie) ItemDie(v string, fn func(d *KeyToPathDie)) *ConfigMapVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.ConfigMapVolumeSource) {
+		for i := range r.Items {
+			if v == r.Items[i].Key {
+				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
+				fn(d)
+				r.Items[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: v})
+		fn(d)
+		r.Items = append(r.Items, d.DieRelease())
+	})
 }
 
 func (d *ConfigMapVolumeSourceDie) LocalObjectReference(v corev1.LocalObjectReference) *ConfigMapVolumeSourceDie {
@@ -46772,6 +49170,18 @@ func (d *ProjectedVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, 
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SourcesDie replaces Sources by collecting the released value from each die passed.
+//
+// sources is the list of volume projections
+func (d *ProjectedVolumeSourceDie) SourcesDie(v ...*VolumeProjectionDie) *ProjectedVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.ProjectedVolumeSource) {
+		r.Sources = make([]corev1.VolumeProjection, len(v))
+		for i := range v {
+			r.Sources[i] = v[i].DieRelease()
+		}
+	})
+}
+
 // sources is the list of volume projections
 func (d *ProjectedVolumeSourceDie) Sources(v ...corev1.VolumeProjection) *ProjectedVolumeSourceDie {
 	return d.DieStamp(func(r *corev1.ProjectedVolumeSource) {
@@ -47022,6 +49432,79 @@ func (d *VolumeProjectionDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *VolumeProjectionDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// SecretDie mutates Secret as a die.
+//
+// secret information about the secret data to project
+func (d *VolumeProjectionDie) SecretDie(fn func(d *SecretProjectionDie)) *VolumeProjectionDie {
+	return d.DieStamp(func(r *corev1.VolumeProjection) {
+		d := SecretProjectionBlank.DieImmutable(false).DieFeedPtr(r.Secret)
+		fn(d)
+		r.Secret = d.DieReleasePtr()
+	})
+}
+
+// DownwardAPIDie mutates DownwardAPI as a die.
+//
+// downwardAPI information about the downwardAPI data to project
+func (d *VolumeProjectionDie) DownwardAPIDie(fn func(d *DownwardAPIProjectionDie)) *VolumeProjectionDie {
+	return d.DieStamp(func(r *corev1.VolumeProjection) {
+		d := DownwardAPIProjectionBlank.DieImmutable(false).DieFeedPtr(r.DownwardAPI)
+		fn(d)
+		r.DownwardAPI = d.DieReleasePtr()
+	})
+}
+
+// ConfigMapDie mutates ConfigMap as a die.
+//
+// configMap information about the configMap data to project
+func (d *VolumeProjectionDie) ConfigMapDie(fn func(d *ConfigMapProjectionDie)) *VolumeProjectionDie {
+	return d.DieStamp(func(r *corev1.VolumeProjection) {
+		d := ConfigMapProjectionBlank.DieImmutable(false).DieFeedPtr(r.ConfigMap)
+		fn(d)
+		r.ConfigMap = d.DieReleasePtr()
+	})
+}
+
+// ServiceAccountTokenDie mutates ServiceAccountToken as a die.
+//
+// serviceAccountToken is information about the serviceAccountToken data to project
+func (d *VolumeProjectionDie) ServiceAccountTokenDie(fn func(d *ServiceAccountTokenProjectionDie)) *VolumeProjectionDie {
+	return d.DieStamp(func(r *corev1.VolumeProjection) {
+		d := ServiceAccountTokenProjectionBlank.DieImmutable(false).DieFeedPtr(r.ServiceAccountToken)
+		fn(d)
+		r.ServiceAccountToken = d.DieReleasePtr()
+	})
+}
+
+// ClusterTrustBundleDie mutates ClusterTrustBundle as a die.
+//
+// # ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+//
+// of ClusterTrustBundle objects in an auto-updating file.
+//
+// Alpha, gated by the ClusterTrustBundleProjection feature gate.
+//
+// # ClusterTrustBundle objects can either be selected by name, or by the
+//
+// combination of signer name and a label selector.
+//
+// # Kubelet performs aggressive normalization of the PEM contents written
+//
+// into the pod filesystem.  Esoteric PEM features such as inter-block
+//
+// comments and block headers are stripped.  Certificates are deduplicated.
+//
+// # The ordering of certificates within the file is arbitrary, and Kubelet
+//
+// may change the order over time.
+func (d *VolumeProjectionDie) ClusterTrustBundleDie(fn func(d *ClusterTrustBundleProjectionDie)) *VolumeProjectionDie {
+	return d.DieStamp(func(r *corev1.VolumeProjection) {
+		d := ClusterTrustBundleProjectionBlank.DieImmutable(false).DieFeedPtr(r.ClusterTrustBundle)
+		fn(d)
+		r.ClusterTrustBundle = d.DieReleasePtr()
+	})
 }
 
 // secret information about the secret data to project
@@ -47305,6 +49788,38 @@ func (d *SecretProjectionDie) DiePatch(patchType types.PatchType) ([]byte, error
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ItemDie mutates a single item in Items matched by the nested field Key, appending a new item if no match is found.
+//
+// items if unspecified, each key-value pair in the Data field of the referenced
+//
+// # Secret will be projected into the volume as a file whose name is the
+//
+// key and content is the value. If specified, the listed keys will be
+//
+// projected into the specified paths, and unlisted keys will not be
+//
+// present. If a key is specified which is not present in the Secret,
+//
+// the volume setup will error unless it is marked optional. Paths must be
+//
+// relative and may not contain the '..' path or start with '..'.
+func (d *SecretProjectionDie) ItemDie(v string, fn func(d *KeyToPathDie)) *SecretProjectionDie {
+	return d.DieStamp(func(r *corev1.SecretProjection) {
+		for i := range r.Items {
+			if v == r.Items[i].Key {
+				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
+				fn(d)
+				r.Items[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: v})
+		fn(d)
+		r.Items = append(r.Items, d.DieRelease())
+	})
+}
+
 func (d *SecretProjectionDie) LocalObjectReference(v corev1.LocalObjectReference) *SecretProjectionDie {
 	return d.DieStamp(func(r *corev1.SecretProjection) {
 		r.LocalObjectReference = v
@@ -47565,6 +50080,26 @@ func (d *DownwardAPIProjectionDie) DiePatch(patchType types.PatchType) ([]byte, 
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ItemDie mutates a single item in Items matched by the nested field Path, appending a new item if no match is found.
+//
+// Items is a list of DownwardAPIVolume file
+func (d *DownwardAPIProjectionDie) ItemDie(v string, fn func(d *DownwardAPIVolumeFileDie)) *DownwardAPIProjectionDie {
+	return d.DieStamp(func(r *corev1.DownwardAPIProjection) {
+		for i := range r.Items {
+			if v == r.Items[i].Path {
+				d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(r.Items[i])
+				fn(d)
+				r.Items[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := DownwardAPIVolumeFileBlank.DieImmutable(false).DieFeed(corev1.DownwardAPIVolumeFile{Path: v})
+		fn(d)
+		r.Items = append(r.Items, d.DieRelease())
+	})
+}
+
 // Items is a list of DownwardAPIVolume file
 func (d *DownwardAPIProjectionDie) Items(v ...corev1.DownwardAPIVolumeFile) *DownwardAPIProjectionDie {
 	return d.DieStamp(func(r *corev1.DownwardAPIProjection) {
@@ -47798,6 +50333,38 @@ func (d *ConfigMapProjectionDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ConfigMapProjectionDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// ItemDie mutates a single item in Items matched by the nested field Key, appending a new item if no match is found.
+//
+// items if unspecified, each key-value pair in the Data field of the referenced
+//
+// # ConfigMap will be projected into the volume as a file whose name is the
+//
+// key and content is the value. If specified, the listed keys will be
+//
+// projected into the specified paths, and unlisted keys will not be
+//
+// present. If a key is specified which is not present in the ConfigMap,
+//
+// the volume setup will error unless it is marked optional. Paths must be
+//
+// relative and may not contain the '..' path or start with '..'.
+func (d *ConfigMapProjectionDie) ItemDie(v string, fn func(d *KeyToPathDie)) *ConfigMapProjectionDie {
+	return d.DieStamp(func(r *corev1.ConfigMapProjection) {
+		for i := range r.Items {
+			if v == r.Items[i].Key {
+				d := KeyToPathBlank.DieImmutable(false).DieFeed(r.Items[i])
+				fn(d)
+				r.Items[i] = d.DieRelease()
+				return
+			}
+		}
+
+		d := KeyToPathBlank.DieImmutable(false).DieFeed(corev1.KeyToPath{Key: v})
+		fn(d)
+		r.Items = append(r.Items, d.DieRelease())
+	})
 }
 
 func (d *ConfigMapProjectionDie) LocalObjectReference(v corev1.LocalObjectReference) *ConfigMapProjectionDie {
@@ -48325,6 +50892,23 @@ func (d *ClusterTrustBundleProjectionDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *ClusterTrustBundleProjectionDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// LabelSelectorDie mutates LabelSelector as a die.
+//
+// Select all ClusterTrustBundles that match this label selector.  Only has
+//
+// effect if signerName is set.  Mutually-exclusive with name.  If unset,
+//
+// interpreted as "match nothing".  If set but empty, interpreted as "match
+//
+// everything".
+func (d *ClusterTrustBundleProjectionDie) LabelSelectorDie(fn func(d *metav1.LabelSelectorDie)) *ClusterTrustBundleProjectionDie {
+	return d.DieStamp(func(r *corev1.ClusterTrustBundleProjection) {
+		d := metav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.LabelSelector)
+		fn(d)
+		r.LabelSelector = d.DieReleasePtr()
+	})
 }
 
 // Select a single ClusterTrustBundle by object name.  Mutually-exclusive
@@ -48865,6 +51449,19 @@ func (d *ScaleIOVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, er
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef references to the secret for ScaleIO user and other
+//
+// sensitive information. If this is not provided, Login operation will fail.
+func (d *ScaleIOVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *ScaleIOVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.ScaleIOVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // gateway is the host address of the ScaleIO API Gateway.
 func (d *ScaleIOVolumeSourceDie) Gateway(v string) *ScaleIOVolumeSourceDie {
 	return d.DieStamp(func(r *corev1.ScaleIOVolumeSource) {
@@ -49177,6 +51774,19 @@ func (d *StorageOSVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, 
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// SecretRefDie mutates SecretRef as a die.
+//
+// secretRef specifies the secret to use for obtaining the StorageOS API
+//
+// credentials.  If not specified, default values will be attempted.
+func (d *StorageOSVolumeSourceDie) SecretRefDie(fn func(d *LocalObjectReferenceDie)) *StorageOSVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.StorageOSVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.SecretRef)
+		fn(d)
+		r.SecretRef = d.DieReleasePtr()
+	})
+}
+
 // volumeName is the human-readable name of the StorageOS volume.  Volume
 //
 // names are only unique within a namespace.
@@ -49460,6 +52070,25 @@ func (d *CSIVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error)
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// NodePublishSecretRefDie mutates NodePublishSecretRef as a die.
+//
+// nodePublishSecretRef is a reference to the secret object containing
+//
+// sensitive information to pass to the CSI driver to complete the CSI
+//
+// NodePublishVolume and NodeUnpublishVolume calls.
+//
+// This field is optional, and  may be empty if no secret is required. If the
+//
+// secret object contains more than one secret, all secret references are passed.
+func (d *CSIVolumeSourceDie) NodePublishSecretRefDie(fn func(d *LocalObjectReferenceDie)) *CSIVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.CSIVolumeSource) {
+		d := LocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.NodePublishSecretRef)
+		fn(d)
+		r.NodePublishSecretRef = d.DieReleasePtr()
+	})
+}
+
 // driver is the name of the CSI driver that handles this volume.
 //
 // Consult with your admin for the correct name as registered in the cluster.
@@ -49739,6 +52368,51 @@ func (d *EphemeralVolumeSourceDie) DieDiff(opts ...cmp.Option) string {
 // DiePatch generates a patch between the current value of the die and the sealed value.
 func (d *EphemeralVolumeSourceDie) DiePatch(patchType types.PatchType) ([]byte, error) {
 	return patch.Create(d.seal, d.r, patchType)
+}
+
+// VolumeClaimTemplateDie mutates VolumeClaimTemplate as a die.
+//
+// Will be used to create a stand-alone PVC to provision the volume.
+//
+// # The pod in which this EphemeralVolumeSource is embedded will be the
+//
+// owner of the PVC, i.e. the PVC will be deleted together with the
+//
+// pod.  The name of the PVC will be `<pod name>-<volume name>` where
+//
+// `<volume name>` is the name from the `PodSpec.Volumes` array
+//
+// entry. Pod validation will reject the pod if the concatenated name
+//
+// is not valid for a PVC (for example, too long).
+//
+// # An existing PVC with that name that is not owned by the pod
+//
+// will *not* be used for the pod to avoid using an unrelated
+//
+// volume by mistake. Starting the pod is then blocked until
+//
+// the unrelated PVC is removed. If such a pre-created PVC is
+//
+// meant to be used by the pod, the PVC has to updated with an
+//
+// owner reference to the pod once the pod exists. Normally
+//
+// this should not be necessary, but it may be useful when
+//
+// manually reconstructing a broken cluster.
+//
+// # This field is read-only and no changes will be made by Kubernetes
+//
+// to the PVC after it has been created.
+//
+// Required, must not be nil.
+func (d *EphemeralVolumeSourceDie) VolumeClaimTemplateDie(fn func(d *PersistentVolumeClaimTemplateDie)) *EphemeralVolumeSourceDie {
+	return d.DieStamp(func(r *corev1.EphemeralVolumeSource) {
+		d := PersistentVolumeClaimTemplateBlank.DieImmutable(false).DieFeedPtr(r.VolumeClaimTemplate)
+		fn(d)
+		r.VolumeClaimTemplate = d.DieReleasePtr()
+	})
 }
 
 // Will be used to create a stand-alone PVC to provision the volume.

--- a/apis/discovery/v1/endpointslice.go
+++ b/apis/discovery/v1/endpointslice.go
@@ -18,48 +18,18 @@ package v1
 
 import (
 	discoveryv1 "k8s.io/api/discovery/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
 // +die:object=true,apiVersion=discovery.k8s.io/v1,kind=EndpointSlice
+// +die:field:name=Endpoints,die=EndpointDie,listType=atomic
+// +die:field:name=Ports,die=EndpointPortDie,listType=atomic
 type _ = discoveryv1.EndpointSlice
 
-func (d *EndpointSliceDie) EndpointsDie(endpoints ...*EndpointDie) *EndpointSliceDie {
-	return d.DieStamp(func(r *discoveryv1.EndpointSlice) {
-		r.Endpoints = make([]discoveryv1.Endpoint, len(endpoints))
-		for i := range endpoints {
-			r.Endpoints[i] = endpoints[i].DieRelease()
-		}
-	})
-}
-
-func (d *EndpointSliceDie) PortsDie(ports ...*EndpointPortDie) *EndpointSliceDie {
-	return d.DieStamp(func(r *discoveryv1.EndpointSlice) {
-		r.Ports = make([]discoveryv1.EndpointPort, len(ports))
-		for i := range ports {
-			r.Ports[i] = ports[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Conditions,die=EndpointConditionsDie
+// +die:field:name=TargetRef,package=_/core/v1,die=ObjectReferenceDie,pointer=true
+// +die:field:name=Hints,die=EndpointHintsDie,pointer=true
 type _ = discoveryv1.Endpoint
-
-func (d *EndpointDie) ConditionsDie(fn func(d *EndpointConditionsDie)) *EndpointDie {
-	return d.DieStamp(func(r *discoveryv1.Endpoint) {
-		d := EndpointConditionsBlank.DieImmutable(false).DieFeed(r.Conditions)
-		fn(d)
-		r.Conditions = d.DieRelease()
-	})
-}
-
-func (d *EndpointDie) TargetRefDie(fn func(d *diecorev1.ObjectReferenceDie)) *EndpointDie {
-	return d.DieStamp(func(r *discoveryv1.Endpoint) {
-		d := diecorev1.ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.TargetRef)
-		fn(d)
-		r.TargetRef = d.DieReleasePtr()
-	})
-}
 
 func (d *EndpointDie) AddDeprecatedTopology(key, value string) *EndpointDie {
 	return d.DieStamp(func(r *discoveryv1.Endpoint) {
@@ -70,28 +40,12 @@ func (d *EndpointDie) AddDeprecatedTopology(key, value string) *EndpointDie {
 	})
 }
 
-func (d *EndpointDie) HintsDie(fn func(d *EndpointHintsDie)) *EndpointDie {
-	return d.DieStamp(func(r *discoveryv1.Endpoint) {
-		d := EndpointHintsBlank.DieImmutable(false).DieFeedPtr(r.Hints)
-		fn(d)
-		r.Hints = d.DieReleasePtr()
-	})
-}
-
 // +die
 type _ = discoveryv1.EndpointConditions
 
 // +die
+// +die:field:name=ForZones,die=ForZoneDie,listType=atomic
 type _ = discoveryv1.EndpointHints
-
-func (d *EndpointHintsDie) ForZonesDie(zones ...*ForZoneDie) *EndpointHintsDie {
-	return d.DieStamp(func(r *discoveryv1.EndpointHints) {
-		r.ForZones = make([]discoveryv1.ForZone, len(zones))
-		for i := range zones {
-			r.ForZones[i] = zones[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = discoveryv1.ForZone

--- a/apis/events/v1/event.go
+++ b/apis/events/v1/event.go
@@ -18,43 +18,14 @@ package v1
 
 import (
 	eventsv1 "k8s.io/api/events/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
 // +die:object=true,apiVersion=events.k8s.io/v1,kind=Event
+// +die:field:name=Series,die=EventSeriesDie,pointer=true
+// +die:field:name=Regarding,package=_/core/v1,die=ObjectReferenceDie
+// +die:field:name=Related,package=_/core/v1,die=ObjectReferenceDie,pointer=true
+// +die:field:name=DeprecatedSource,package=_/core/v1,die=EventSourceDie
 type _ = eventsv1.Event
-
-func (d *EventDie) SeriesDie(fn func(d *EventSeriesDie)) *EventDie {
-	return d.DieStamp(func(r *eventsv1.Event) {
-		d := EventSeriesBlank.DieImmutable(false).DieFeedPtr(r.Series)
-		fn(d)
-		r.Series = d.DieReleasePtr()
-	})
-}
-
-func (d *EventDie) RegardingDie(fn func(d *diecorev1.ObjectReferenceDie)) *EventDie {
-	return d.DieStamp(func(r *eventsv1.Event) {
-		d := diecorev1.ObjectReferenceBlank.DieImmutable(false).DieFeed(r.Regarding)
-		fn(d)
-		r.Regarding = d.DieRelease()
-	})
-}
-
-func (d *EventDie) RelatedDie(fn func(d *diecorev1.ObjectReferenceDie)) *EventDie {
-	return d.DieStamp(func(r *eventsv1.Event) {
-		d := diecorev1.ObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.Related)
-		fn(d)
-		r.Related = d.DieReleasePtr()
-	})
-}
-
-func (d *EventDie) DeprecatedSourceDie(fn func(d *diecorev1.EventSourceDie)) *EventDie {
-	return d.DieStamp(func(r *eventsv1.Event) {
-		d := diecorev1.EventSourceBlank.DieImmutable(false).DieFeed(r.DeprecatedSource)
-		fn(d)
-		r.DeprecatedSource = d.DieRelease()
-	})
-}
 
 // +die
 type _ = eventsv1.EventSeries

--- a/apis/meta/v1/objectmeta.go
+++ b/apis/meta/v1/objectmeta.go
@@ -26,6 +26,7 @@ import (
 )
 
 // +die
+// +die:field:name=ManagedFields,die=ManagedFieldsEntryDie,listType=atomic
 type _ = metav1.ObjectMeta
 
 func (d *ObjectMetaDie) AddLabel(key, value string) *ObjectMetaDie {
@@ -60,15 +61,6 @@ func (d *ObjectMetaDie) ControlledBy(obj runtime.Object, scheme *runtime.Scheme)
 		UID:                obj.(metav1.Object).GetUID(),
 		BlockOwnerDeletion: ptr.To(true),
 		Controller:         ptr.To(true),
-	})
-}
-
-func (d *ObjectMetaDie) ManagedFieldsDie(fields ...*ManagedFieldsEntryDie) *ObjectMetaDie {
-	return d.DieStamp(func(r *metav1.ObjectMeta) {
-		r.ManagedFields = make([]metav1.ManagedFieldsEntry, len(fields))
-		for i := range fields {
-			r.ManagedFields[i] = fields[i].DieRelease()
-		}
 	})
 }
 

--- a/apis/meta/v1/status.go
+++ b/apis/meta/v1/status.go
@@ -21,6 +21,8 @@ import (
 )
 
 // +die
+// +die:field:name=ListMeta,die=ListMetaDie
+// +die:field:name=Details,die=StatusDetailsDie,pointer=true
 type _ = metav1.Status
 
 // Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -37,34 +39,9 @@ func (d *StatusDie) APIVersion(v string) *StatusDie {
 	})
 }
 
-func (d *StatusDie) ListMetaDie(fn func(d *ListMetaDie)) *StatusDie {
-	return d.DieStamp(func(r *metav1.Status) {
-		d := ListMetaBlank.DieImmutable(false).DieFeed(r.ListMeta)
-		fn(d)
-		r.ListMeta = d.DieRelease()
-	})
-}
-
-func (d *StatusDie) DetailDie(fn func(d *StatusDetailsDie)) *StatusDie {
-	return d.DieStamp(func(r *metav1.Status) {
-		d := StatusDetailsBlank.DieImmutable(false).DieFeedPtr(r.Details)
-		fn(d)
-		r.Details = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Causes,die=StatusCauseDie,listType=atomic
 type _ = metav1.StatusDetails
-
-func (d *StatusDetailsDie) CausesDie(causes ...*StatusCauseDie) *StatusDetailsDie {
-	return d.DieStamp(func(r *metav1.StatusDetails) {
-		r.Causes = make([]metav1.StatusCause, len(causes))
-		for i := range causes {
-			c := causes[i].DieRelease()
-			r.Causes[i] = c
-		}
-	})
-}
 
 // +die
 type _ = metav1.StatusCause

--- a/apis/meta/v1/typemeta.go
+++ b/apis/meta/v1/typemeta.go
@@ -17,11 +17,19 @@ limitations under the License.
 package v1
 
 import (
-	json "encoding/json"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/jsonpath"
+	"reconciler.io/dies/patch"
+	"sigs.k8s.io/yaml"
 )
 
 var TypeMetaBlank = (&TypeMetaDie{}).DieFeed(metav1.TypeMeta{})
@@ -29,6 +37,7 @@ var TypeMetaBlank = (&TypeMetaDie{}).DieFeed(metav1.TypeMeta{})
 type TypeMetaDie struct {
 	mutable bool
 	r       metav1.TypeMeta
+	seal    metav1.TypeMeta
 }
 
 // DieImmutable returns a new die for the current die's state that is either mutable (`false`) or immutable (`true`).
@@ -50,6 +59,7 @@ func (d *TypeMetaDie) DieFeed(r metav1.TypeMeta) *TypeMetaDie {
 	return &TypeMetaDie{
 		mutable: d.mutable,
 		r:       r,
+		seal:    d.seal,
 	}
 }
 
@@ -61,12 +71,40 @@ func (d *TypeMetaDie) DieFeedPtr(r *metav1.TypeMeta) *TypeMetaDie {
 	return d.DieFeed(*r)
 }
 
-// DieFeedRawExtension returns the resource managed by the die as an raw extension.
-func (d *TypeMetaDie) DieFeedRawExtension(raw runtime.RawExtension) *TypeMetaDie {
-	b, _ := json.Marshal(raw)
+// DieFeedJSON returns a new die with the provided JSON. Panics on error.
+func (d *TypeMetaDie) DieFeedJSON(j []byte) *TypeMetaDie {
 	r := metav1.TypeMeta{}
-	_ = json.Unmarshal(b, &r)
+	if err := json.Unmarshal(j, &r); err != nil {
+		panic(err)
+	}
 	return d.DieFeed(r)
+}
+
+// DieFeedYAML returns a new die with the provided YAML. Panics on error.
+func (d *TypeMetaDie) DieFeedYAML(y []byte) *TypeMetaDie {
+	r := metav1.TypeMeta{}
+	if err := yaml.Unmarshal(y, &r); err != nil {
+		panic(err)
+	}
+	return d.DieFeed(r)
+}
+
+// DieFeedYAMLFile returns a new die loading YAML from a file path. Panics on error.
+func (d *TypeMetaDie) DieFeedYAMLFile(name string) *TypeMetaDie {
+	y, err := os.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedYAML(y)
+}
+
+// DieFeedRawExtension returns the resource managed by the die as an raw extension. Panics on error.
+func (d *TypeMetaDie) DieFeedRawExtension(raw runtime.RawExtension) *TypeMetaDie {
+	j, err := json.Marshal(raw)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(j)
 }
 
 // DieRelease returns the resource managed by the die.
@@ -86,12 +124,33 @@ func (d *TypeMetaDie) DieReleasePtr() *metav1.TypeMeta {
 	return &r
 }
 
-// DieReleaseRawExtension returns the resource managed by the die as an raw extension.
-func (d *TypeMetaDie) DieReleaseRawExtension() runtime.RawExtension {
+// DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
+func (d *TypeMetaDie) DieReleaseJSON() []byte {
 	r := d.DieReleasePtr()
-	b, _ := json.Marshal(r)
+	j, err := json.Marshal(r)
+	if err != nil {
+		panic(err)
+	}
+	return j
+}
+
+// DieReleaseYAML returns the resource managed by the die as YAML. Panics on error.
+func (d *TypeMetaDie) DieReleaseYAML() []byte {
+	r := d.DieReleasePtr()
+	y, err := yaml.Marshal(r)
+	if err != nil {
+		panic(err)
+	}
+	return y
+}
+
+// DieReleaseRawExtension returns the resource managed by the die as an raw extension. Panics on error.
+func (d *TypeMetaDie) DieReleaseRawExtension() runtime.RawExtension {
+	j := d.DieReleaseJSON()
 	raw := runtime.RawExtension{}
-	_ = json.Unmarshal(b, &raw)
+	if err := json.Unmarshal(j, &raw); err != nil {
+		panic(err)
+	}
 	return raw
 }
 
@@ -102,25 +161,139 @@ func (d *TypeMetaDie) DieStamp(fn func(r *metav1.TypeMeta)) *TypeMetaDie {
 	return d.DieFeed(r)
 }
 
+// Experimental: DieStampAt uses a JSON path (http://goessner.net/articles/JsonPath/) expression to stamp portions of the resource. The callback is invoked with each JSON path match. Panics if the callback function does not accept a single argument of the same type or a pointer to that type as found on the resource at the target location.
+//
+// Future iterations will improve type coercion from the resource to the callback argument.
+func (d *TypeMetaDie) DieStampAt(jp string, fn interface{}) *TypeMetaDie {
+	return d.DieStamp(func(r *metav1.TypeMeta) {
+		if ni := reflect.ValueOf(fn).Type().NumIn(); ni != 1 {
+			panic(fmt.Errorf("callback function must have 1 input parameters, found %d", ni))
+		}
+		if no := reflect.ValueOf(fn).Type().NumOut(); no != 0 {
+			panic(fmt.Errorf("callback function must have 0 output parameters, found %d", no))
+		}
+
+		cp := jsonpath.New("")
+		if err := cp.Parse(fmt.Sprintf("{%s}", jp)); err != nil {
+			panic(err)
+		}
+		cr, err := cp.FindResults(r)
+		if err != nil {
+			// errors are expected if a path is not found
+			return
+		}
+		for _, cv := range cr[0] {
+			arg0t := reflect.ValueOf(fn).Type().In(0)
+
+			var args []reflect.Value
+			if cv.Type().AssignableTo(arg0t) {
+				args = []reflect.Value{cv}
+			} else if cv.CanAddr() && cv.Addr().Type().AssignableTo(arg0t) {
+				args = []reflect.Value{cv.Addr()}
+			} else {
+				panic(fmt.Errorf("callback function must accept value of type %q, found type %q", cv.Type(), arg0t))
+			}
+
+			reflect.ValueOf(fn).Call(args)
+		}
+	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TypeMetaDie) DieWith(fns ...func(d *TypeMetaDie)) *TypeMetaDie {
+	nd := TypeMetaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *TypeMetaDie) DeepCopy() *TypeMetaDie {
+	r := metav1.TypeMeta{
+		APIVersion: d.r.APIVersion,
+		Kind:       d.r.Kind,
+	}
 	return &TypeMetaDie{
 		mutable: d.mutable,
-		r: metav1.TypeMeta{
-			APIVersion: d.r.APIVersion,
-			Kind:       d.r.Kind,
-		},
+		r:       r,
+		seal:    d.seal,
 	}
 }
 
-// Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+// DieSeal returns a new die for the current die's state that is sealed for comparison in future diff and patch operations.
+func (d *TypeMetaDie) DieSeal() *TypeMetaDie {
+	return d.DieSealFeed(d.r)
+}
+
+// DieSealFeed returns a new die for the current die's state that uses a specific resource for comparison in future diff and patch operations.
+func (d *TypeMetaDie) DieSealFeed(r metav1.TypeMeta) *TypeMetaDie {
+	if !d.mutable {
+		d = d.DeepCopy()
+	}
+	d.seal = metav1.TypeMeta{
+		APIVersion: r.APIVersion,
+		Kind:       r.Kind,
+	}
+	return d
+}
+
+// DieSealFeedPtr returns a new die for the current die's state that uses a specific resource pointer for comparison in future diff and patch operations. If the resource is nil, the empty value is used instead.
+func (d *TypeMetaDie) DieSealFeedPtr(r *metav1.TypeMeta) *TypeMetaDie {
+	if r == nil {
+		r = &metav1.TypeMeta{}
+	}
+	return d.DieSealFeed(*r)
+}
+
+// DieSealRelease returns the sealed resource managed by the die.
+func (d *TypeMetaDie) DieSealRelease() metav1.TypeMeta {
+	return metav1.TypeMeta{
+		APIVersion: d.seal.APIVersion,
+		Kind:       d.seal.Kind,
+	}
+}
+
+// DieSealReleasePtr returns the sealed resource pointer managed by the die.
+func (d *TypeMetaDie) DieSealReleasePtr() *metav1.TypeMeta {
+	r := d.DieSealRelease()
+	return &r
+}
+
+// DieDiff uses cmp.Diff to compare the current value of the die with the sealed value.
+func (d *TypeMetaDie) DieDiff(opts ...cmp.Option) string {
+	return cmp.Diff(d.seal, d.r, opts...)
+}
+
+// DiePatch generates a patch between the current value of the die and the sealed value.
+func (d *TypeMetaDie) DiePatch(patchType types.PatchType) ([]byte, error) {
+	return patch.Create(d.seal, d.r, patchType)
+}
+
+// Kind is a string value representing the REST resource this object represents.
+//
+// Servers may infer this from the endpoint the client submits requests to.
+//
+// Cannot be updated.
+//
+// In CamelCase.
+//
+// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 func (d *TypeMetaDie) Kind(v string) *TypeMetaDie {
 	return d.DieStamp(func(r *metav1.TypeMeta) {
 		r.Kind = v
 	})
 }
 
-// APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+// APIVersion defines the versioned schema of this representation of an object.
+//
+// # Servers should convert recognized schemas to the latest internal value, and
+//
+// may reject unrecognized values.
+//
+// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 func (d *TypeMetaDie) APIVersion(v string) *TypeMetaDie {
 	return d.DieStamp(func(r *metav1.TypeMeta) {
 		r.APIVersion = v

--- a/apis/networking/v1/ingress.go
+++ b/apis/networking/v1/ingress.go
@@ -18,70 +18,25 @@ package v1
 
 import (
 	networkingv1 "k8s.io/api/networking/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
 // +die:object=true,apiVersion=networking.k8s.io/v1,kind=Ingress
 type _ = networkingv1.Ingress
 
 // +die
+// +die:field:name=DefaultBackend,die=IngressBackendDie,pointer=true
+// +die:field:name=TLS,die=IngressTLSDie,listType=atomic
+// +die:field:name=Rules,die=IngressRuleDie,listType=atomic
 type _ = networkingv1.IngressSpec
 
-func (d *IngressSpecDie) DefaultBackendDie(fn func(d *IngressBackendDie)) *IngressSpecDie {
-	return d.DieStamp(func(r *networkingv1.IngressSpec) {
-		d := IngressBackendBlank.DieImmutable(false).DieFeedPtr(r.DefaultBackend)
-		fn(d)
-		r.DefaultBackend = d.DieReleasePtr()
-	})
-}
-
-func (d *IngressSpecDie) TLSDie(tls ...*IngressTLSDie) *IngressSpecDie {
-	return d.DieStamp(func(r *networkingv1.IngressSpec) {
-		r.TLS = make([]networkingv1.IngressTLS, len(tls))
-		for i := range tls {
-			r.TLS[i] = tls[i].DieRelease()
-		}
-	})
-}
-
-func (d *IngressSpecDie) RulesDie(rules ...*IngressRuleDie) *IngressSpecDie {
-	return d.DieStamp(func(r *networkingv1.IngressSpec) {
-		r.Rules = make([]networkingv1.IngressRule, len(rules))
-		for i := range rules {
-			r.Rules[i] = rules[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Service,die=IngressServiceBackendDie,pointer=true
+// +die:field:name=Resource,package=_/core/v1,die=TypedLocalObjectReferenceDie,pointer=true
 type _ = networkingv1.IngressBackend
 
-func (d *IngressBackendDie) ServiceDie(fn func(d *IngressServiceBackendDie)) *IngressBackendDie {
-	return d.DieStamp(func(r *networkingv1.IngressBackend) {
-		d := IngressServiceBackendBlank.DieImmutable(false).DieFeedPtr(r.Service)
-		fn(d)
-		r.Service = d.DieReleasePtr()
-	})
-}
-
-func (d *IngressBackendDie) ResourceDie(fn func(d *diecorev1.TypedLocalObjectReferenceDie)) *IngressBackendDie {
-	return d.DieStamp(func(r *networkingv1.IngressBackend) {
-		d := diecorev1.TypedLocalObjectReferenceBlank.DieImmutable(false).DieFeedPtr(r.Resource)
-		fn(d)
-		r.Resource = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Port,die=ServiceBackendPortDie
 type _ = networkingv1.IngressServiceBackend
-
-func (d *IngressServiceBackendDie) PortDie(fn func(d *ServiceBackendPortDie)) *IngressServiceBackendDie {
-	return d.DieStamp(func(r *networkingv1.IngressServiceBackend) {
-		d := ServiceBackendPortBlank.DieImmutable(false).DieFeed(r.Port)
-		fn(d)
-		r.Port = d.DieRelease()
-	})
-}
 
 // +die
 type _ = networkingv1.ServiceBackendPort
@@ -90,73 +45,28 @@ type _ = networkingv1.ServiceBackendPort
 type _ = networkingv1.IngressTLS
 
 // +die
+// +die:field:name=HTTP,die=HTTPIngressRuleValueDie,pointer=true
 type _ = networkingv1.IngressRule
 
-func (d *IngressRuleDie) HTTPDie(fn func(d *HTTPIngressRuleValueDie)) *IngressRuleDie {
-	return d.DieStamp(func(r *networkingv1.IngressRule) {
-		d := HTTPIngressRuleValueBlank.DieImmutable(false).DieFeedPtr(r.HTTP)
-		fn(d)
-		r.HTTP = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=Paths,die=HTTPIngressPathDie,listType=atomic
 type _ = networkingv1.HTTPIngressRuleValue
 
-func (d *HTTPIngressRuleValueDie) PathsDie(paths ...*HTTPIngressPathDie) *HTTPIngressRuleValueDie {
-	return d.DieStamp(func(r *networkingv1.HTTPIngressRuleValue) {
-		r.Paths = make([]networkingv1.HTTPIngressPath, len(paths))
-		for i := range paths {
-			r.Paths[i] = paths[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Backend,die=IngressBackendDie
 type _ = networkingv1.HTTPIngressPath
 
-func (d *HTTPIngressPathDie) BackendDie(fn func(d *IngressBackendDie)) *HTTPIngressPathDie {
-	return d.DieStamp(func(r *networkingv1.HTTPIngressPath) {
-		d := IngressBackendBlank.DieImmutable(false).DieFeed(r.Backend)
-		fn(d)
-		r.Backend = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=LoadBalancer,die=IngressLoadBalancerStatusDie
 type IngressStatus = networkingv1.IngressStatus
 
-func (d *IngressStatusDie) LoadBalancerDie(fn func(d *IngressLoadBalancerStatusDie)) *IngressStatusDie {
-	return d.DieStamp(func(r *networkingv1.IngressStatus) {
-		d := IngressLoadBalancerStatusBlank.DieImmutable(false).DieFeed(r.LoadBalancer)
-		fn(d)
-		r.LoadBalancer = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=Ingress,die=IngressLoadBalancerIngressDie,listType=atomic
 type IngressLoadBalancerStatus = networkingv1.IngressLoadBalancerStatus
 
-func (d *IngressLoadBalancerStatusDie) IngressDie(ingress ...*IngressLoadBalancerIngressDie) *IngressLoadBalancerStatusDie {
-	return d.DieStamp(func(r *networkingv1.IngressLoadBalancerStatus) {
-		r.Ingress = make([]networkingv1.IngressLoadBalancerIngress, len(ingress))
-		for i := range ingress {
-			r.Ingress[i] = ingress[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Ports,die=IngressPortStatusDie,listType=atomic
 type IngressLoadBalancerIngress = networkingv1.IngressLoadBalancerIngress
-
-func (d *IngressLoadBalancerIngressDie) PortsDie(ports ...*IngressPortStatusDie) *IngressLoadBalancerIngressDie {
-	return d.DieStamp(func(r *networkingv1.IngressLoadBalancerIngress) {
-		r.Ports = make([]networkingv1.IngressPortStatus, len(ports))
-		for i := range ports {
-			r.Ports[i] = ports[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type IngressPortStatus = networkingv1.IngressPortStatus

--- a/apis/networking/v1/ingressclass.go
+++ b/apis/networking/v1/ingressclass.go
@@ -24,15 +24,8 @@ import (
 type _ = networkingv1.IngressClass
 
 // +die
+// +die:field:name=Parameters,die=IngressClassParametersReferenceDie,pointer=true
 type _ = networkingv1.IngressClassSpec
-
-func (d *IngressClassSpecDie) ParametersDie(fn func(d *IngressClassParametersReferenceDie)) *IngressClassSpecDie {
-	return d.DieStamp(func(r *networkingv1.IngressClassSpec) {
-		d := IngressClassParametersReferenceBlank.DieImmutable(false).DieFeedPtr(r.Parameters)
-		fn(d)
-		r.Parameters = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = networkingv1.IngressClassParametersReference

--- a/apis/networking/v1/networkpolicy.go
+++ b/apis/networking/v1/networkpolicy.go
@@ -18,112 +18,35 @@ package v1
 
 import (
 	networkingv1 "k8s.io/api/networking/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=networking.k8s.io/v1,kind=NetworkPolicy
 type _ = networkingv1.NetworkPolicy
 
 // +die
+// +die:field:name=PodSelector,package=_/meta/v1,die=LabelSelectorDie
+// +die:field:name=Ingress,die=NetworkPolicyIngressRuleDie,listType=atomic
+// +die:field:name=Egress,die=NetworkPolicyEgressRuleDie,listType=atomic
 type _ = networkingv1.NetworkPolicySpec
 
-func (d *NetworkPolicySpecDie) PodSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *NetworkPolicySpecDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicySpec) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeed(r.PodSelector)
-		fn(d)
-		r.PodSelector = d.DieRelease()
-	})
-}
-
-func (d *NetworkPolicySpecDie) IngressDie(ingress ...*NetworkPolicyIngressRuleDie) *NetworkPolicySpecDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicySpec) {
-		r.Ingress = make([]networkingv1.NetworkPolicyIngressRule, len(ingress))
-		for i := range ingress {
-			r.Ingress[i] = ingress[i].DieRelease()
-		}
-	})
-}
-
-func (d *NetworkPolicySpecDie) EgressDie(egress ...*NetworkPolicyEgressRuleDie) *NetworkPolicySpecDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicySpec) {
-		r.Egress = make([]networkingv1.NetworkPolicyEgressRule, len(egress))
-		for i := range egress {
-			r.Egress[i] = egress[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Ports,die=NetworkPolicyPortDie,listType=atomic
+// +die:field:name=From,die=NetworkPolicyPeerDie,listType=atomic
 type _ = networkingv1.NetworkPolicyIngressRule
 
-func (d *NetworkPolicyIngressRuleDie) PortsDie(ports ...*NetworkPolicyPortDie) *NetworkPolicyIngressRuleDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicyIngressRule) {
-		r.Ports = make([]networkingv1.NetworkPolicyPort, len(ports))
-		for i := range ports {
-			r.Ports[i] = ports[i].DieRelease()
-		}
-	})
-}
-
-func (d *NetworkPolicyIngressRuleDie) FromDie(from ...*NetworkPolicyPeerDie) *NetworkPolicyIngressRuleDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicyIngressRule) {
-		r.From = make([]networkingv1.NetworkPolicyPeer, len(from))
-		for i := range from {
-			r.From[i] = from[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Ports,die=NetworkPolicyPortDie,listType=atomic
+// +die:field:name=To,die=NetworkPolicyPeerDie,listType=atomic
 type _ = networkingv1.NetworkPolicyEgressRule
-
-func (d *NetworkPolicyEgressRuleDie) PortsDie(ports ...*NetworkPolicyPortDie) *NetworkPolicyEgressRuleDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicyEgressRule) {
-		r.Ports = make([]networkingv1.NetworkPolicyPort, len(ports))
-		for i := range ports {
-			r.Ports[i] = ports[i].DieRelease()
-		}
-	})
-}
-
-func (d *NetworkPolicyEgressRuleDie) ToDie(to ...*NetworkPolicyPeerDie) *NetworkPolicyEgressRuleDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicyEgressRule) {
-		r.To = make([]networkingv1.NetworkPolicyPeer, len(to))
-		for i := range to {
-			r.To[i] = to[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = networkingv1.NetworkPolicyPort
 
 // +die
+// +die:field:name=PodSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=NamespaceSelector,package=_/meta/v1,die=LabelSelectorDie,pointer=true
+// +die:field:name=IPBlock,die=IPBlockDie,pointer=true
 type _ = networkingv1.NetworkPolicyPeer
-
-func (d *NetworkPolicyPeerDie) PodSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *NetworkPolicyPeerDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicyPeer) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.PodSelector)
-		fn(d)
-		r.PodSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *NetworkPolicyPeerDie) NamespaceSelectorDie(fn func(d *diemetav1.LabelSelectorDie)) *NetworkPolicyPeerDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicyPeer) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.NamespaceSelector)
-		fn(d)
-		r.NamespaceSelector = d.DieReleasePtr()
-	})
-}
-
-func (d *NetworkPolicyPeerDie) IPBlockDie(fn func(d *IPBlockDie)) *NetworkPolicyPeerDie {
-	return d.DieStamp(func(r *networkingv1.NetworkPolicyPeer) {
-		d := IPBlockBlank.DieImmutable(false).DieFeedPtr(r.IPBlock)
-		fn(d)
-		r.IPBlock = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = networkingv1.IPBlock

--- a/apis/node/v1/runtimeclass.go
+++ b/apis/node/v1/runtimeclass.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
 	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
@@ -29,21 +28,10 @@ type _ = nodev1.RuntimeClass
 type _ = nodev1.Overhead
 
 // +die
+// +die:field:name=Tolerations,package=_/core/v1,die=TolerationDie,listMapKey=Key
 type _ = nodev1.Scheduling
 
+// deprecated?: use TolerationDie
 func (d *SchedulingDie) TolerationsDie(key string, fn func(d *diecorev1.TolerationDie)) *SchedulingDie {
-	return d.DieStamp(func(r *nodev1.Scheduling) {
-		for i := range r.Tolerations {
-			if key == r.Tolerations[i].Key {
-				d := diecorev1.TolerationBlank.DieImmutable(false).DieFeed(r.Tolerations[i])
-				fn(d)
-				r.Tolerations[i] = d.DieRelease()
-				return
-			}
-		}
-
-		d := diecorev1.TolerationBlank.DieImmutable(false).DieFeed(corev1.Toleration{Key: key})
-		fn(d)
-		r.Tolerations = append(r.Tolerations, d.DieRelease())
-	})
+	return d.TolerationDie(key, fn)
 }

--- a/apis/policy/v1/poddisruptionbudget.go
+++ b/apis/policy/v1/poddisruptionbudget.go
@@ -19,7 +19,6 @@ package v1
 import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=policy/v1,kind=PodDisruptionBudget
@@ -31,6 +30,7 @@ type _ = policyv1.PodDisruptionBudgetSpec
 // TODO(scothis) fix import for maps with struct values, ignore the 'DisruptedPods' field until then
 
 // +die:ignore={DisruptedPods}
+// +die:field:name=Conditions,package=_/meta/v1,die=ConditionDie,listType=atomic
 type _ = policyv1.PodDisruptionBudgetStatus
 
 // DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.
@@ -46,14 +46,5 @@ func (d *PodDisruptionBudgetStatusDie) DisruptedPodDie(key string, value metav1.
 			r.DisruptedPods = map[string]metav1.Time{}
 		}
 		r.DisruptedPods[key] = value
-	})
-}
-
-func (d *PodDisruptionBudgetStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie) *PodDisruptionBudgetStatusDie {
-	return d.DieStamp(func(r *policyv1.PodDisruptionBudgetStatus) {
-		r.Conditions = make([]metav1.Condition, len(conditions))
-		for i := range conditions {
-			r.Conditions[i] = conditions[i].DieRelease()
-		}
 	})
 }

--- a/apis/policy/v1/zz_generated.die.go
+++ b/apis/policy/v1/zz_generated.die.go
@@ -999,6 +999,40 @@ func (d *PodDisruptionBudgetStatusDie) DiePatch(patchType types.PatchType) ([]by
 	return patch.Create(d.seal, d.r, patchType)
 }
 
+// ConditionsDie replaces Conditions by collecting the released value from each die passed.
+//
+// Conditions contain conditions for PDB. The disruption controller sets the
+//
+// DisruptionAllowed condition. The following are known values for the reason field
+//
+// (additional reasons could be added in the future):
+//
+// - SyncFailed: The controller encountered an error and wasn't able to compute
+//
+// the number of allowed disruptions. Therefore no disruptions are
+//
+// allowed and the status of the condition will be False.
+//
+// - InsufficientPods: The number of pods are either at or below the number
+//
+// required by the PodDisruptionBudget. No disruptions are
+//
+// allowed and the status of the condition will be False.
+//
+// - SufficientPods: There are more pods than required by the PodDisruptionBudget.
+//
+// # The condition will be True, and the number of allowed
+//
+// disruptions are provided by the disruptionsAllowed property.
+func (d *PodDisruptionBudgetStatusDie) ConditionsDie(v ...*metav1.ConditionDie) *PodDisruptionBudgetStatusDie {
+	return d.DieStamp(func(r *policyv1.PodDisruptionBudgetStatus) {
+		r.Conditions = make([]apismetav1.Condition, len(v))
+		for i := range v {
+			r.Conditions[i] = v[i].DieRelease()
+		}
+	})
+}
+
 // Most recent generation observed when updating this PDB status. DisruptionsAllowed and other
 //
 // status information is valid only if observedGeneration equals to PDB's object generation.

--- a/apis/storage/v1/csidriver.go
+++ b/apis/storage/v1/csidriver.go
@@ -24,16 +24,8 @@ import (
 type _ = storagev1.CSIDriver
 
 // +die
+// +die:field:name=TokenRequests,die=TokenRequestDie,listType=atomic
 type _ = storagev1.CSIDriverSpec
-
-func (d *CSIDriverSpecDie) TokenRequestsDie(requests ...*TokenRequestDie) *CSIDriverSpecDie {
-	return d.DieStamp(func(r *storagev1.CSIDriverSpec) {
-		r.TokenRequests = make([]storagev1.TokenRequest, len(requests))
-		for i := range requests {
-			r.TokenRequests[i] = requests[i].DieRelease()
-		}
-	})
-}
 
 // +die
 type _ = storagev1.TokenRequest

--- a/apis/storage/v1/csinode.go
+++ b/apis/storage/v1/csinode.go
@@ -24,27 +24,12 @@ import (
 type _ = storagev1.CSINode
 
 // +die
+// +die:field:name=Drivers,die=CSINodeDriverDie,listType=atomic
 type _ = storagev1.CSINodeSpec
 
-func (d *CSINodeSpecDie) DriversDie(drivers ...*CSINodeDriverDie) *CSINodeSpecDie {
-	return d.DieStamp(func(r *storagev1.CSINodeSpec) {
-		r.Drivers = make([]storagev1.CSINodeDriver, len(drivers))
-		for i := range drivers {
-			r.Drivers[i] = drivers[i].DieRelease()
-		}
-	})
-}
-
 // +die
+// +die:field:name=Allocatable,die=VolumeNodeResourcesDie,pointer=true
 type _ = storagev1.CSINodeDriver
-
-func (d *CSINodeDriverDie) AllocatableDie(fn func(d *VolumeNodeResourcesDie)) *CSINodeDriverDie {
-	return d.DieStamp(func(r *storagev1.CSINodeDriver) {
-		d := VolumeNodeResourcesBlank.DieImmutable(false).DieFeedPtr(r.Allocatable)
-		fn(d)
-		r.Allocatable = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = storagev1.VolumeNodeResources

--- a/apis/storage/v1/csistoragecapacities.go
+++ b/apis/storage/v1/csistoragecapacities.go
@@ -18,16 +18,8 @@ package v1
 
 import (
 	storagev1 "k8s.io/api/storage/v1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=storage.k8s.io/v1,kind=CSIStorageCapacity
+// +die:field:name=NodeTopology,package=_/meta/v1,die=LabelSelectorDie,pointer=true
 type _ = storagev1.CSIStorageCapacity
-
-func (d *CSIStorageCapacityDie) NodeTopologyDie(fn func(d *diemetav1.LabelSelectorDie)) *CSIStorageCapacityDie {
-	return d.DieStamp(func(r *storagev1.CSIStorageCapacity) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.NodeTopology)
-		fn(d)
-		r.NodeTopology = d.DieReleasePtr()
-	})
-}

--- a/apis/storage/v1/storageclass.go
+++ b/apis/storage/v1/storageclass.go
@@ -17,12 +17,11 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
 // +die:object=true,apiVersion=storage.k8s.io/v1,kind=StorageClass
+// +die:field:name=AllowedTopologies,package=_/core/v1,die=TopologySelectorTermDie,listType=atomic
 type _ = storagev1.StorageClass
 
 func (d *StorageClassDie) AddParameter(key, value string) *StorageClassDie {
@@ -31,14 +30,5 @@ func (d *StorageClassDie) AddParameter(key, value string) *StorageClassDie {
 			r.Parameters = map[string]string{}
 		}
 		r.Parameters[key] = value
-	})
-}
-
-func (d *StorageClassDie) AllowedTopologiesDie(topologies ...*diecorev1.TopologySelectorTermDie) *StorageClassDie {
-	return d.DieStamp(func(r *storagev1.StorageClass) {
-		r.AllowedTopologies = make([]corev1.TopologySelectorTerm, len(topologies))
-		for i := range topologies {
-			r.AllowedTopologies[i] = topologies[i].DieRelease()
-		}
 	})
 }

--- a/apis/storage/v1/volumeattachment.go
+++ b/apis/storage/v1/volumeattachment.go
@@ -18,52 +18,23 @@ package v1
 
 import (
 	storagev1 "k8s.io/api/storage/v1"
-	diecorev1 "reconciler.io/dies/apis/core/v1"
 )
 
 // +die:object=true,apiVersion=storage.k8s.io/v1,kind=VolumeAttachment
 type _ = storagev1.VolumeAttachment
 
 // +die
+// +die:field:name=Source,die=VolumeAttachmentSourceDie
 type _ = storagev1.VolumeAttachmentSpec
 
-func (d *VolumeAttachmentSpecDie) SourceDie(fn func(d *VolumeAttachmentSourceDie)) *VolumeAttachmentSpecDie {
-	return d.DieStamp(func(r *storagev1.VolumeAttachmentSpec) {
-		d := VolumeAttachmentSourceBlank.DieImmutable(false).DieFeed(r.Source)
-		fn(d)
-		r.Source = d.DieRelease()
-	})
-}
-
 // +die
+// +die:field:name=InlineVolumeSpec,package=_/core/v1,die=PersistentVolumeSpecDie,pointer=true
 type _ = storagev1.VolumeAttachmentSource
 
-func (d *VolumeAttachmentSourceDie) SourceDie(fn func(d *diecorev1.PersistentVolumeSpecDie)) *VolumeAttachmentSourceDie {
-	return d.DieStamp(func(r *storagev1.VolumeAttachmentSource) {
-		d := diecorev1.PersistentVolumeSpecBlank.DieImmutable(false).DieFeedPtr(r.InlineVolumeSpec)
-		fn(d)
-		r.InlineVolumeSpec = d.DieReleasePtr()
-	})
-}
-
 // +die
+// +die:field:name=AttachError,die=VolumeErrorDie,pointer=true
+// +die:field:name=DetachError,die=VolumeErrorDie,pointer=true
 type _ = storagev1.VolumeAttachmentStatus
-
-func (d *VolumeAttachmentStatusDie) AttachErrorDie(fn func(d *VolumeErrorDie)) *VolumeAttachmentStatusDie {
-	return d.DieStamp(func(r *storagev1.VolumeAttachmentStatus) {
-		d := VolumeErrorBlank.DieImmutable(false).DieFeedPtr(r.AttachError)
-		fn(d)
-		r.AttachError = d.DieReleasePtr()
-	})
-}
-
-func (d *VolumeAttachmentStatusDie) DetachErrorDie(fn func(d *VolumeErrorDie)) *VolumeAttachmentStatusDie {
-	return d.DieStamp(func(r *storagev1.VolumeAttachmentStatus) {
-		d := VolumeErrorBlank.DieImmutable(false).DieFeedPtr(r.DetachError)
-		fn(d)
-		r.DetachError = d.DieReleasePtr()
-	})
-}
 
 // +die
 type _ = storagev1.VolumeError

--- a/apis/storage/v1beta1/csistoragecapacity.go
+++ b/apis/storage/v1beta1/csistoragecapacity.go
@@ -18,16 +18,8 @@ package v1beta1
 
 import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
-	diemetav1 "reconciler.io/dies/apis/meta/v1"
 )
 
 // +die:object=true,apiVersion=storage.k8s.io/v1beta1,kind=CSIStorageCapacity
+// +die:field:name=NodeTopology,package=_/meta/v1,die=LabelSelectorDie,pointer=true
 type _ = storagev1beta1.CSIStorageCapacity
-
-func (d *CSIStorageCapacityDie) NodeTopologyDie(fn func(d *diemetav1.LabelSelectorDie)) *CSIStorageCapacityDie {
-	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
-		d := diemetav1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.NodeTopology)
-		fn(d)
-		r.NodeTopology = d.DieReleasePtr()
-	})
-}

--- a/apis/storage/v1beta1/zz_generated.die.go
+++ b/apis/storage/v1beta1/zz_generated.die.go
@@ -34,7 +34,7 @@ import (
 	json "k8s.io/apimachinery/pkg/util/json"
 	jsonpath "k8s.io/client-go/util/jsonpath"
 	osx "os"
-	"reconciler.io/dies/apis/meta/v1"
+	v1 "reconciler.io/dies/apis/meta/v1"
 	patch "reconciler.io/dies/patch"
 	reflectx "reflect"
 	yaml "sigs.k8s.io/yaml"
@@ -360,6 +360,25 @@ func (d *CSIStorageCapacityDie) MetadataDie(fn func(d *v1.ObjectMetaDie)) *CSISt
 		d := v1.ObjectMetaBlank.DieImmutable(false).DieFeed(r.ObjectMeta)
 		fn(d)
 		r.ObjectMeta = d.DieRelease()
+	})
+}
+
+// NodeTopologyDie mutates NodeTopology as a die.
+//
+// nodeTopology defines which nodes have access to the storage
+//
+// for which capacity was reported. If not set, the storage is
+//
+// not accessible from any node in the cluster. If empty, the
+//
+// storage is accessible from all nodes. This field is
+//
+// immutable.
+func (d *CSIStorageCapacityDie) NodeTopologyDie(fn func(d *v1.LabelSelectorDie)) *CSIStorageCapacityDie {
+	return d.DieStamp(func(r *storagev1beta1.CSIStorageCapacity) {
+		d := v1.LabelSelectorBlank.DieImmutable(false).DieFeedPtr(r.NodeTopology)
+		fn(d)
+		r.NodeTopology = d.DieReleasePtr()
 	})
 }
 


### PR DESCRIPTION
Many more common mutation methods are now generated. These methods require additional metadata since they use dies backing a field value within the current die. Typically the required metadata is the name of the field on the current die, and the type for the Die backing the nested field's type. Additional metadata is required for fields backed by slices.

See updates to the README for details.

Where possible, existing mutation methods are updated to use the new code generation. In cases where the generated method name is different, the previous method was deprecated in favor of the new method. Where there is a discrepancy, the new names are more consistent.

Remaining mutation methods are mostly custom one-off methods that will likely never be generated. Adding additional methods in the future will be much easier as all applicable dies will get the new behavior.

Future enhancements can reduce the amount of metadata that the user must provide for each field by looking up type information and existing doc tags about the target field.