### PR TITLE
Create owner references for types not in scheme

### DIFF
--- a/apis/meta/v1/objectmeta.go
+++ b/apis/meta/v1/objectmeta.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
@@ -52,7 +53,11 @@ func (d *ObjectMetaDie) ControlledBy(obj runtime.Object, scheme *runtime.Scheme)
 	obj = obj.DeepCopyObject()
 	gvks, _, err := scheme.ObjectKinds(obj)
 	if err != nil {
-		panic(err)
+		if gvk := obj.GetObjectKind().GroupVersionKind(); gvk != (schema.GroupVersionKind{}) {
+			gvks = []schema.GroupVersionKind{gvk}
+		} else {
+			panic(err)
+		}
 	}
 	return d.OwnerReferences(metav1.OwnerReference{
 		APIVersion:         gvks[0].GroupVersion().String(),

--- a/apis/meta/v1/objectmeta_test.go
+++ b/apis/meta/v1/objectmeta_test.go
@@ -88,6 +88,58 @@ func TestObjectMeta(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "controlled by - local typemeta ignored if type in scheme",
+			die: diemetav1.ObjectMetaBlank.
+				ControlledBy(
+					diecorev1.PodBlank.
+						APIVersion("v1").
+						Kind("NotAPod").
+						MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+							d.Name("my-name")
+							d.UID("123e4567-e89b-12d3-a456-426614174000")
+						}),
+					scheme,
+				),
+			expected: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "v1",
+						Kind:               "Pod",
+						Name:               "my-name",
+						UID:                "123e4567-e89b-12d3-a456-426614174000",
+						BlockOwnerDeletion: ptr.To(true),
+						Controller:         ptr.To(true),
+					},
+				},
+			},
+		},
+		{
+			name: "controlled by - local typemeta use if type not in scheme",
+			die: diemetav1.ObjectMetaBlank.
+				ControlledBy(
+					diecorev1.PodBlank.
+						APIVersion("v1").
+						Kind("NotAPod").
+						MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+							d.Name("my-name")
+							d.UID("123e4567-e89b-12d3-a456-426614174000")
+						}),
+					runtime.NewScheme(),
+				),
+			expected: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "v1",
+						Kind:               "NotAPod",
+						Name:               "my-name",
+						UID:                "123e4567-e89b-12d3-a456-426614174000",
+						BlockOwnerDeletion: ptr.To(true),
+						Controller:         ptr.To(true),
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range tests {


### PR DESCRIPTION
Duck typed resources are objects that represent many resource types in a cluster. While they are strongly typed, they are not registered in the scheme.

When creating a owner reference from an object, if the owner is not in the scheme, inspect the local TypeMeta. Continue to panic if no value is available.