### PR TITLE
Add DieFeedDuck/DieReleaseDuck

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ type MyResourceDie interface {
     // resource is nil, the empty value is used instead.
     DieFeedPtr(r *MyResource) *MyResourceDie
 
+    // DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+    DieFeedDuck(v any) *MyResourceDie
+
     // DieFeedJSON returns a new die with the provided JSON. Panics on error.
     DieFeedJSON(j []byte) *MyResourceDie
 
@@ -160,6 +163,9 @@ type MyResourceDie interface {
 
     // DieReleasePtr returns a pointer to the resource managed by the die.
     DieReleasePtr() *MyResource
+
+	// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+	DieReleaseDuck(v any) any
 
     // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
     DieReleaseJSON() []byte

--- a/apis/admission/v1/zz_generated.die.go
+++ b/apis/admission/v1/zz_generated.die.go
@@ -78,6 +78,15 @@ func (d *AdmissionRequestDie) DieFeedPtr(r *admissionv1.AdmissionRequest) *Admis
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AdmissionRequestDie) DieFeedDuck(v any) *AdmissionRequestDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AdmissionRequestDie) DieFeedJSON(j []byte) *AdmissionRequestDie {
 	r := admissionv1.AdmissionRequest{}
@@ -126,6 +135,15 @@ func (d *AdmissionRequestDie) DieRelease() admissionv1.AdmissionRequest {
 func (d *AdmissionRequestDie) DieReleasePtr() *admissionv1.AdmissionRequest {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AdmissionRequestDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -546,6 +564,15 @@ func (d *AdmissionResponseDie) DieFeedPtr(r *admissionv1.AdmissionResponse) *Adm
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AdmissionResponseDie) DieFeedDuck(v any) *AdmissionResponseDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AdmissionResponseDie) DieFeedJSON(j []byte) *AdmissionResponseDie {
 	r := admissionv1.AdmissionResponse{}
@@ -594,6 +621,15 @@ func (d *AdmissionResponseDie) DieRelease() admissionv1.AdmissionResponse {
 func (d *AdmissionResponseDie) DieReleasePtr() *admissionv1.AdmissionResponse {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AdmissionResponseDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -852,6 +888,15 @@ func (d *AdmissionReviewDie) DieFeedPtr(r *admissionv1.AdmissionReview) *Admissi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AdmissionReviewDie) DieFeedDuck(v any) *AdmissionReviewDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AdmissionReviewDie) DieFeedJSON(j []byte) *AdmissionReviewDie {
 	r := admissionv1.AdmissionReview{}
@@ -900,6 +945,15 @@ func (d *AdmissionReviewDie) DieRelease() admissionv1.AdmissionReview {
 func (d *AdmissionReviewDie) DieReleasePtr() *admissionv1.AdmissionReview {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AdmissionReviewDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/admissionregistration/v1/zz_generated.die.go
+++ b/apis/admissionregistration/v1/zz_generated.die.go
@@ -78,6 +78,15 @@ func (d *WebhookClientConfigDie) DieFeedPtr(r *admissionregistrationv1.WebhookCl
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *WebhookClientConfigDie) DieFeedDuck(v any) *WebhookClientConfigDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *WebhookClientConfigDie) DieFeedJSON(j []byte) *WebhookClientConfigDie {
 	r := admissionregistrationv1.WebhookClientConfig{}
@@ -126,6 +135,15 @@ func (d *WebhookClientConfigDie) DieRelease() admissionregistrationv1.WebhookCli
 func (d *WebhookClientConfigDie) DieReleasePtr() *admissionregistrationv1.WebhookClientConfig {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *WebhookClientConfigDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -386,6 +404,15 @@ func (d *ServiceReferenceDie) DieFeedPtr(r *admissionregistrationv1.ServiceRefer
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceReferenceDie) DieFeedDuck(v any) *ServiceReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceReferenceDie) DieFeedJSON(j []byte) *ServiceReferenceDie {
 	r := admissionregistrationv1.ServiceReference{}
@@ -434,6 +461,15 @@ func (d *ServiceReferenceDie) DieRelease() admissionregistrationv1.ServiceRefere
 func (d *ServiceReferenceDie) DieReleasePtr() *admissionregistrationv1.ServiceReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -652,6 +688,15 @@ func (d *RuleWithOperationsDie) DieFeedPtr(r *admissionregistrationv1.RuleWithOp
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RuleWithOperationsDie) DieFeedDuck(v any) *RuleWithOperationsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RuleWithOperationsDie) DieFeedJSON(j []byte) *RuleWithOperationsDie {
 	r := admissionregistrationv1.RuleWithOperations{}
@@ -700,6 +745,15 @@ func (d *RuleWithOperationsDie) DieRelease() admissionregistrationv1.RuleWithOpe
 func (d *RuleWithOperationsDie) DieReleasePtr() *admissionregistrationv1.RuleWithOperations {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RuleWithOperationsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -902,6 +956,15 @@ func (d *RuleDie) DieFeedPtr(r *admissionregistrationv1.Rule) *RuleDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RuleDie) DieFeedDuck(v any) *RuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RuleDie) DieFeedJSON(j []byte) *RuleDie {
 	r := admissionregistrationv1.Rule{}
@@ -950,6 +1013,15 @@ func (d *RuleDie) DieRelease() admissionregistrationv1.Rule {
 func (d *RuleDie) DieReleasePtr() *admissionregistrationv1.Rule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1202,6 +1274,15 @@ func (d *MatchConditionDie) DieFeedPtr(r *admissionregistrationv1.MatchCondition
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MatchConditionDie) DieFeedDuck(v any) *MatchConditionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MatchConditionDie) DieFeedJSON(j []byte) *MatchConditionDie {
 	r := admissionregistrationv1.MatchCondition{}
@@ -1250,6 +1331,15 @@ func (d *MatchConditionDie) DieRelease() admissionregistrationv1.MatchCondition 
 func (d *MatchConditionDie) DieReleasePtr() *admissionregistrationv1.MatchCondition {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MatchConditionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1481,6 +1571,15 @@ func (d *MutatingWebhookConfigurationDie) DieFeedPtr(r *admissionregistrationv1.
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MutatingWebhookConfigurationDie) DieFeedDuck(v any) *MutatingWebhookConfigurationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MutatingWebhookConfigurationDie) DieFeedJSON(j []byte) *MutatingWebhookConfigurationDie {
 	r := admissionregistrationv1.MutatingWebhookConfiguration{}
@@ -1541,6 +1640,15 @@ func (d *MutatingWebhookConfigurationDie) DieReleaseUnstructured() *unstructured
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MutatingWebhookConfigurationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1828,6 +1936,15 @@ func (d *MutatingWebhookDie) DieFeedPtr(r *admissionregistrationv1.MutatingWebho
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MutatingWebhookDie) DieFeedDuck(v any) *MutatingWebhookDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MutatingWebhookDie) DieFeedJSON(j []byte) *MutatingWebhookDie {
 	r := admissionregistrationv1.MutatingWebhook{}
@@ -1876,6 +1993,15 @@ func (d *MutatingWebhookDie) DieRelease() admissionregistrationv1.MutatingWebhoo
 func (d *MutatingWebhookDie) DieReleasePtr() *admissionregistrationv1.MutatingWebhook {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MutatingWebhookDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2542,6 +2668,15 @@ func (d *ValidatingAdmissionPolicyDie) DieFeedPtr(r *admissionregistrationv1.Val
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidatingAdmissionPolicyDie) DieFeedDuck(v any) *ValidatingAdmissionPolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidatingAdmissionPolicyDie) DieFeedJSON(j []byte) *ValidatingAdmissionPolicyDie {
 	r := admissionregistrationv1.ValidatingAdmissionPolicy{}
@@ -2602,6 +2737,15 @@ func (d *ValidatingAdmissionPolicyDie) DieReleaseUnstructured() *unstructured.Un
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidatingAdmissionPolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2900,6 +3044,15 @@ func (d *ValidatingAdmissionPolicySpecDie) DieFeedPtr(r *admissionregistrationv1
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidatingAdmissionPolicySpecDie) DieFeedDuck(v any) *ValidatingAdmissionPolicySpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidatingAdmissionPolicySpecDie) DieFeedJSON(j []byte) *ValidatingAdmissionPolicySpecDie {
 	r := admissionregistrationv1.ValidatingAdmissionPolicySpec{}
@@ -2948,6 +3101,15 @@ func (d *ValidatingAdmissionPolicySpecDie) DieRelease() admissionregistrationv1.
 func (d *ValidatingAdmissionPolicySpecDie) DieReleasePtr() *admissionregistrationv1.ValidatingAdmissionPolicySpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidatingAdmissionPolicySpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3391,6 +3553,15 @@ func (d *ParamKindDie) DieFeedPtr(r *admissionregistrationv1.ParamKind) *ParamKi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ParamKindDie) DieFeedDuck(v any) *ParamKindDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ParamKindDie) DieFeedJSON(j []byte) *ParamKindDie {
 	r := admissionregistrationv1.ParamKind{}
@@ -3439,6 +3610,15 @@ func (d *ParamKindDie) DieRelease() admissionregistrationv1.ParamKind {
 func (d *ParamKindDie) DieReleasePtr() *admissionregistrationv1.ParamKind {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ParamKindDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3639,6 +3819,15 @@ func (d *MatchResourcesDie) DieFeedPtr(r *admissionregistrationv1.MatchResources
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MatchResourcesDie) DieFeedDuck(v any) *MatchResourcesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MatchResourcesDie) DieFeedJSON(j []byte) *MatchResourcesDie {
 	r := admissionregistrationv1.MatchResources{}
@@ -3687,6 +3876,15 @@ func (d *MatchResourcesDie) DieRelease() admissionregistrationv1.MatchResources 
 func (d *MatchResourcesDie) DieReleasePtr() *admissionregistrationv1.MatchResources {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MatchResourcesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4168,6 +4366,15 @@ func (d *NamedRuleWithOperationsDie) DieFeedPtr(r *admissionregistrationv1.Named
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NamedRuleWithOperationsDie) DieFeedDuck(v any) *NamedRuleWithOperationsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NamedRuleWithOperationsDie) DieFeedJSON(j []byte) *NamedRuleWithOperationsDie {
 	r := admissionregistrationv1.NamedRuleWithOperations{}
@@ -4216,6 +4423,15 @@ func (d *NamedRuleWithOperationsDie) DieRelease() admissionregistrationv1.NamedR
 func (d *NamedRuleWithOperationsDie) DieReleasePtr() *admissionregistrationv1.NamedRuleWithOperations {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NamedRuleWithOperationsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4410,6 +4626,15 @@ func (d *ValidationDie) DieFeedPtr(r *admissionregistrationv1.Validation) *Valid
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidationDie) DieFeedDuck(v any) *ValidationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidationDie) DieFeedJSON(j []byte) *ValidationDie {
 	r := admissionregistrationv1.Validation{}
@@ -4458,6 +4683,15 @@ func (d *ValidationDie) DieRelease() admissionregistrationv1.Validation {
 func (d *ValidationDie) DieReleasePtr() *admissionregistrationv1.Validation {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4778,6 +5012,15 @@ func (d *AuditAnnotationDie) DieFeedPtr(r *admissionregistrationv1.AuditAnnotati
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AuditAnnotationDie) DieFeedDuck(v any) *AuditAnnotationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AuditAnnotationDie) DieFeedJSON(j []byte) *AuditAnnotationDie {
 	r := admissionregistrationv1.AuditAnnotation{}
@@ -4826,6 +5069,15 @@ func (d *AuditAnnotationDie) DieRelease() admissionregistrationv1.AuditAnnotatio
 func (d *AuditAnnotationDie) DieReleasePtr() *admissionregistrationv1.AuditAnnotation {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AuditAnnotationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5066,6 +5318,15 @@ func (d *VariableDie) DieFeedPtr(r *admissionregistrationv1.Variable) *VariableD
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VariableDie) DieFeedDuck(v any) *VariableDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VariableDie) DieFeedJSON(j []byte) *VariableDie {
 	r := admissionregistrationv1.Variable{}
@@ -5114,6 +5375,15 @@ func (d *VariableDie) DieRelease() admissionregistrationv1.Variable {
 func (d *VariableDie) DieReleasePtr() *admissionregistrationv1.Variable {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VariableDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5314,6 +5584,15 @@ func (d *ValidatingAdmissionPolicyStatusDie) DieFeedPtr(r *admissionregistration
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidatingAdmissionPolicyStatusDie) DieFeedDuck(v any) *ValidatingAdmissionPolicyStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidatingAdmissionPolicyStatusDie) DieFeedJSON(j []byte) *ValidatingAdmissionPolicyStatusDie {
 	r := admissionregistrationv1.ValidatingAdmissionPolicyStatus{}
@@ -5362,6 +5641,15 @@ func (d *ValidatingAdmissionPolicyStatusDie) DieRelease() admissionregistrationv
 func (d *ValidatingAdmissionPolicyStatusDie) DieReleasePtr() *admissionregistrationv1.ValidatingAdmissionPolicyStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidatingAdmissionPolicyStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5590,6 +5878,15 @@ func (d *TypeCheckingDie) DieFeedPtr(r *admissionregistrationv1.TypeChecking) *T
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TypeCheckingDie) DieFeedDuck(v any) *TypeCheckingDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TypeCheckingDie) DieFeedJSON(j []byte) *TypeCheckingDie {
 	r := admissionregistrationv1.TypeChecking{}
@@ -5638,6 +5935,15 @@ func (d *TypeCheckingDie) DieRelease() admissionregistrationv1.TypeChecking {
 func (d *TypeCheckingDie) DieReleasePtr() *admissionregistrationv1.TypeChecking {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TypeCheckingDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5837,6 +6143,15 @@ func (d *ExpressionWarningDie) DieFeedPtr(r *admissionregistrationv1.ExpressionW
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ExpressionWarningDie) DieFeedDuck(v any) *ExpressionWarningDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ExpressionWarningDie) DieFeedJSON(j []byte) *ExpressionWarningDie {
 	r := admissionregistrationv1.ExpressionWarning{}
@@ -5885,6 +6200,15 @@ func (d *ExpressionWarningDie) DieRelease() admissionregistrationv1.ExpressionWa
 func (d *ExpressionWarningDie) DieReleasePtr() *admissionregistrationv1.ExpressionWarning {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ExpressionWarningDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6090,6 +6414,15 @@ func (d *ValidatingAdmissionPolicyBindingDie) DieFeedPtr(r *admissionregistratio
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidatingAdmissionPolicyBindingDie) DieFeedDuck(v any) *ValidatingAdmissionPolicyBindingDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidatingAdmissionPolicyBindingDie) DieFeedJSON(j []byte) *ValidatingAdmissionPolicyBindingDie {
 	r := admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
@@ -6150,6 +6483,15 @@ func (d *ValidatingAdmissionPolicyBindingDie) DieReleaseUnstructured() *unstruct
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidatingAdmissionPolicyBindingDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6426,6 +6768,15 @@ func (d *ValidatingAdmissionPolicyBindingSpecDie) DieFeedPtr(r *admissionregistr
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidatingAdmissionPolicyBindingSpecDie) DieFeedDuck(v any) *ValidatingAdmissionPolicyBindingSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidatingAdmissionPolicyBindingSpecDie) DieFeedJSON(j []byte) *ValidatingAdmissionPolicyBindingSpecDie {
 	r := admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{}
@@ -6474,6 +6825,15 @@ func (d *ValidatingAdmissionPolicyBindingSpecDie) DieRelease() admissionregistra
 func (d *ValidatingAdmissionPolicyBindingSpecDie) DieReleasePtr() *admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidatingAdmissionPolicyBindingSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6794,6 +7154,15 @@ func (d *ParamRefDie) DieFeedPtr(r *admissionregistrationv1.ParamRef) *ParamRefD
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ParamRefDie) DieFeedDuck(v any) *ParamRefDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ParamRefDie) DieFeedJSON(j []byte) *ParamRefDie {
 	r := admissionregistrationv1.ParamRef{}
@@ -6842,6 +7211,15 @@ func (d *ParamRefDie) DieRelease() admissionregistrationv1.ParamRef {
 func (d *ParamRefDie) DieReleasePtr() *admissionregistrationv1.ParamRef {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ParamRefDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -7128,6 +7506,15 @@ func (d *ValidatingWebhookConfigurationDie) DieFeedPtr(r *admissionregistrationv
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidatingWebhookConfigurationDie) DieFeedDuck(v any) *ValidatingWebhookConfigurationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidatingWebhookConfigurationDie) DieFeedJSON(j []byte) *ValidatingWebhookConfigurationDie {
 	r := admissionregistrationv1.ValidatingWebhookConfiguration{}
@@ -7188,6 +7575,15 @@ func (d *ValidatingWebhookConfigurationDie) DieReleaseUnstructured() *unstructur
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidatingWebhookConfigurationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -7475,6 +7871,15 @@ func (d *ValidatingWebhookDie) DieFeedPtr(r *admissionregistrationv1.ValidatingW
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ValidatingWebhookDie) DieFeedDuck(v any) *ValidatingWebhookDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ValidatingWebhookDie) DieFeedJSON(j []byte) *ValidatingWebhookDie {
 	r := admissionregistrationv1.ValidatingWebhook{}
@@ -7523,6 +7928,15 @@ func (d *ValidatingWebhookDie) DieRelease() admissionregistrationv1.ValidatingWe
 func (d *ValidatingWebhookDie) DieReleasePtr() *admissionregistrationv1.ValidatingWebhook {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ValidatingWebhookDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/admissionregistration/v1alpha1/zz_generated.die.go
+++ b/apis/admissionregistration/v1alpha1/zz_generated.die.go
@@ -82,6 +82,15 @@ func (d *MutatingAdmissionPolicyDie) DieFeedPtr(r *admissionregistrationv1alpha1
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MutatingAdmissionPolicyDie) DieFeedDuck(v any) *MutatingAdmissionPolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MutatingAdmissionPolicyDie) DieFeedJSON(j []byte) *MutatingAdmissionPolicyDie {
 	r := admissionregistrationv1alpha1.MutatingAdmissionPolicy{}
@@ -142,6 +151,15 @@ func (d *MutatingAdmissionPolicyDie) DieReleaseUnstructured() *unstructured.Unst
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MutatingAdmissionPolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -418,6 +436,15 @@ func (d *MutatingAdmissionPolicySpecDie) DieFeedPtr(r *admissionregistrationv1al
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MutatingAdmissionPolicySpecDie) DieFeedDuck(v any) *MutatingAdmissionPolicySpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MutatingAdmissionPolicySpecDie) DieFeedJSON(j []byte) *MutatingAdmissionPolicySpecDie {
 	r := admissionregistrationv1alpha1.MutatingAdmissionPolicySpec{}
@@ -466,6 +493,15 @@ func (d *MutatingAdmissionPolicySpecDie) DieRelease() admissionregistrationv1alp
 func (d *MutatingAdmissionPolicySpecDie) DieReleasePtr() *admissionregistrationv1alpha1.MutatingAdmissionPolicySpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MutatingAdmissionPolicySpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -907,6 +943,15 @@ func (d *ParamKindDie) DieFeedPtr(r *admissionregistrationv1alpha1.ParamKind) *P
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ParamKindDie) DieFeedDuck(v any) *ParamKindDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ParamKindDie) DieFeedJSON(j []byte) *ParamKindDie {
 	r := admissionregistrationv1alpha1.ParamKind{}
@@ -955,6 +1000,15 @@ func (d *ParamKindDie) DieRelease() admissionregistrationv1alpha1.ParamKind {
 func (d *ParamKindDie) DieReleasePtr() *admissionregistrationv1alpha1.ParamKind {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ParamKindDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1155,6 +1209,15 @@ func (d *MatchResourcesDie) DieFeedPtr(r *admissionregistrationv1alpha1.MatchRes
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MatchResourcesDie) DieFeedDuck(v any) *MatchResourcesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MatchResourcesDie) DieFeedJSON(j []byte) *MatchResourcesDie {
 	r := admissionregistrationv1alpha1.MatchResources{}
@@ -1203,6 +1266,15 @@ func (d *MatchResourcesDie) DieRelease() admissionregistrationv1alpha1.MatchReso
 func (d *MatchResourcesDie) DieReleasePtr() *admissionregistrationv1alpha1.MatchResources {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MatchResourcesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1684,6 +1756,15 @@ func (d *MatchConditionDie) DieFeedPtr(r *admissionregistrationv1alpha1.MatchCon
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MatchConditionDie) DieFeedDuck(v any) *MatchConditionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MatchConditionDie) DieFeedJSON(j []byte) *MatchConditionDie {
 	r := admissionregistrationv1alpha1.MatchCondition{}
@@ -1732,6 +1813,15 @@ func (d *MatchConditionDie) DieRelease() admissionregistrationv1alpha1.MatchCond
 func (d *MatchConditionDie) DieReleasePtr() *admissionregistrationv1alpha1.MatchCondition {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MatchConditionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1912,6 +2002,15 @@ func (d *VariableDie) DieFeedPtr(r *admissionregistrationv1alpha1.Variable) *Var
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VariableDie) DieFeedDuck(v any) *VariableDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VariableDie) DieFeedJSON(j []byte) *VariableDie {
 	r := admissionregistrationv1alpha1.Variable{}
@@ -1960,6 +2059,15 @@ func (d *VariableDie) DieRelease() admissionregistrationv1alpha1.Variable {
 func (d *VariableDie) DieReleasePtr() *admissionregistrationv1alpha1.Variable {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VariableDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2160,6 +2268,15 @@ func (d *MutationDie) DieFeedPtr(r *admissionregistrationv1alpha1.Mutation) *Mut
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MutationDie) DieFeedDuck(v any) *MutationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MutationDie) DieFeedJSON(j []byte) *MutationDie {
 	r := admissionregistrationv1alpha1.Mutation{}
@@ -2208,6 +2325,15 @@ func (d *MutationDie) DieRelease() admissionregistrationv1alpha1.Mutation {
 func (d *MutationDie) DieReleasePtr() *admissionregistrationv1alpha1.Mutation {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MutationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2451,6 +2577,15 @@ func (d *NamedRuleWithOperationsDie) DieFeedPtr(r *admissionregistrationv1alpha1
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NamedRuleWithOperationsDie) DieFeedDuck(v any) *NamedRuleWithOperationsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NamedRuleWithOperationsDie) DieFeedJSON(j []byte) *NamedRuleWithOperationsDie {
 	r := admissionregistrationv1alpha1.NamedRuleWithOperations{}
@@ -2499,6 +2634,15 @@ func (d *NamedRuleWithOperationsDie) DieRelease() admissionregistrationv1alpha1.
 func (d *NamedRuleWithOperationsDie) DieReleasePtr() *admissionregistrationv1alpha1.NamedRuleWithOperations {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NamedRuleWithOperationsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2704,6 +2848,15 @@ func (d *ApplyConfigurationDie) DieFeedPtr(r *admissionregistrationv1alpha1.Appl
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ApplyConfigurationDie) DieFeedDuck(v any) *ApplyConfigurationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ApplyConfigurationDie) DieFeedJSON(j []byte) *ApplyConfigurationDie {
 	r := admissionregistrationv1alpha1.ApplyConfiguration{}
@@ -2752,6 +2905,15 @@ func (d *ApplyConfigurationDie) DieRelease() admissionregistrationv1alpha1.Apply
 func (d *ApplyConfigurationDie) DieReleasePtr() *admissionregistrationv1alpha1.ApplyConfiguration {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ApplyConfigurationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2999,6 +3161,15 @@ func (d *JSONPatchDie) DieFeedPtr(r *admissionregistrationv1alpha1.JSONPatch) *J
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *JSONPatchDie) DieFeedDuck(v any) *JSONPatchDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *JSONPatchDie) DieFeedJSON(j []byte) *JSONPatchDie {
 	r := admissionregistrationv1alpha1.JSONPatch{}
@@ -3047,6 +3218,15 @@ func (d *JSONPatchDie) DieRelease() admissionregistrationv1alpha1.JSONPatch {
 func (d *JSONPatchDie) DieReleasePtr() *admissionregistrationv1alpha1.JSONPatch {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *JSONPatchDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/apiextensions/v1/zz_generated.die.go
+++ b/apis/apiextensions/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *CustomResourceDefinitionDie) DieFeedPtr(r *apiextensionsv1.CustomResour
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceDefinitionDie) DieFeedDuck(v any) *CustomResourceDefinitionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceDefinitionDie) DieFeedJSON(j []byte) *CustomResourceDefinitionDie {
 	r := apiextensionsv1.CustomResourceDefinition{}
@@ -141,6 +150,15 @@ func (d *CustomResourceDefinitionDie) DieReleaseUnstructured() *unstructured.Uns
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceDefinitionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -433,6 +451,15 @@ func (d *CustomResourceDefinitionSpecDie) DieFeedPtr(r *apiextensionsv1.CustomRe
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceDefinitionSpecDie) DieFeedDuck(v any) *CustomResourceDefinitionSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceDefinitionSpecDie) DieFeedJSON(j []byte) *CustomResourceDefinitionSpecDie {
 	r := apiextensionsv1.CustomResourceDefinitionSpec{}
@@ -481,6 +508,15 @@ func (d *CustomResourceDefinitionSpecDie) DieRelease() apiextensionsv1.CustomRes
 func (d *CustomResourceDefinitionSpecDie) DieReleasePtr() *apiextensionsv1.CustomResourceDefinitionSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceDefinitionSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -787,6 +823,15 @@ func (d *CustomResourceDefinitionVersionDie) DieFeedPtr(r *apiextensionsv1.Custo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceDefinitionVersionDie) DieFeedDuck(v any) *CustomResourceDefinitionVersionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceDefinitionVersionDie) DieFeedJSON(j []byte) *CustomResourceDefinitionVersionDie {
 	r := apiextensionsv1.CustomResourceDefinitionVersion{}
@@ -835,6 +880,15 @@ func (d *CustomResourceDefinitionVersionDie) DieRelease() apiextensionsv1.Custom
 func (d *CustomResourceDefinitionVersionDie) DieReleasePtr() *apiextensionsv1.CustomResourceDefinitionVersion {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceDefinitionVersionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1162,6 +1216,15 @@ func (d *CustomResourceValidationDie) DieFeedPtr(r *apiextensionsv1.CustomResour
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceValidationDie) DieFeedDuck(v any) *CustomResourceValidationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceValidationDie) DieFeedJSON(j []byte) *CustomResourceValidationDie {
 	r := apiextensionsv1.CustomResourceValidation{}
@@ -1210,6 +1273,15 @@ func (d *CustomResourceValidationDie) DieRelease() apiextensionsv1.CustomResourc
 func (d *CustomResourceValidationDie) DieReleasePtr() *apiextensionsv1.CustomResourceValidation {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceValidationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1397,6 +1469,15 @@ func (d *CustomResourceSubresourcesDie) DieFeedPtr(r *apiextensionsv1.CustomReso
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceSubresourcesDie) DieFeedDuck(v any) *CustomResourceSubresourcesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceSubresourcesDie) DieFeedJSON(j []byte) *CustomResourceSubresourcesDie {
 	r := apiextensionsv1.CustomResourceSubresources{}
@@ -1445,6 +1526,15 @@ func (d *CustomResourceSubresourcesDie) DieRelease() apiextensionsv1.CustomResou
 func (d *CustomResourceSubresourcesDie) DieReleasePtr() *apiextensionsv1.CustomResourceSubresources {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceSubresourcesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1656,6 +1746,15 @@ func (d *CustomResourceSubresourceScaleDie) DieFeedPtr(r *apiextensionsv1.Custom
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceSubresourceScaleDie) DieFeedDuck(v any) *CustomResourceSubresourceScaleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceSubresourceScaleDie) DieFeedJSON(j []byte) *CustomResourceSubresourceScaleDie {
 	r := apiextensionsv1.CustomResourceSubresourceScale{}
@@ -1704,6 +1803,15 @@ func (d *CustomResourceSubresourceScaleDie) DieRelease() apiextensionsv1.CustomR
 func (d *CustomResourceSubresourceScaleDie) DieReleasePtr() *apiextensionsv1.CustomResourceSubresourceScale {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceSubresourceScaleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1935,6 +2043,15 @@ func (d *CustomResourceColumnDefinitionDie) DieFeedPtr(r *apiextensionsv1.Custom
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceColumnDefinitionDie) DieFeedDuck(v any) *CustomResourceColumnDefinitionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceColumnDefinitionDie) DieFeedJSON(j []byte) *CustomResourceColumnDefinitionDie {
 	r := apiextensionsv1.CustomResourceColumnDefinition{}
@@ -1983,6 +2100,15 @@ func (d *CustomResourceColumnDefinitionDie) DieRelease() apiextensionsv1.CustomR
 func (d *CustomResourceColumnDefinitionDie) DieReleasePtr() *apiextensionsv1.CustomResourceColumnDefinition {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceColumnDefinitionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2217,6 +2343,15 @@ func (d *CustomResourceConversionDie) DieFeedPtr(r *apiextensionsv1.CustomResour
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceConversionDie) DieFeedDuck(v any) *CustomResourceConversionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceConversionDie) DieFeedJSON(j []byte) *CustomResourceConversionDie {
 	r := apiextensionsv1.CustomResourceConversion{}
@@ -2265,6 +2400,15 @@ func (d *CustomResourceConversionDie) DieRelease() apiextensionsv1.CustomResourc
 func (d *CustomResourceConversionDie) DieReleasePtr() *apiextensionsv1.CustomResourceConversion {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceConversionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2476,6 +2620,15 @@ func (d *WebhookConversionDie) DieFeedPtr(r *apiextensionsv1.WebhookConversion) 
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *WebhookConversionDie) DieFeedDuck(v any) *WebhookConversionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *WebhookConversionDie) DieFeedJSON(j []byte) *WebhookConversionDie {
 	r := apiextensionsv1.WebhookConversion{}
@@ -2524,6 +2677,15 @@ func (d *WebhookConversionDie) DieRelease() apiextensionsv1.WebhookConversion {
 func (d *WebhookConversionDie) DieReleasePtr() *apiextensionsv1.WebhookConversion {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *WebhookConversionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2739,6 +2901,15 @@ func (d *WebhookClientConfigDie) DieFeedPtr(r *apiextensionsv1.WebhookClientConf
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *WebhookClientConfigDie) DieFeedDuck(v any) *WebhookClientConfigDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *WebhookClientConfigDie) DieFeedJSON(j []byte) *WebhookClientConfigDie {
 	r := apiextensionsv1.WebhookClientConfig{}
@@ -2787,6 +2958,15 @@ func (d *WebhookClientConfigDie) DieRelease() apiextensionsv1.WebhookClientConfi
 func (d *WebhookClientConfigDie) DieReleasePtr() *apiextensionsv1.WebhookClientConfig {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *WebhookClientConfigDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3047,6 +3227,15 @@ func (d *ServiceReferenceDie) DieFeedPtr(r *apiextensionsv1.ServiceReference) *S
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceReferenceDie) DieFeedDuck(v any) *ServiceReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceReferenceDie) DieFeedJSON(j []byte) *ServiceReferenceDie {
 	r := apiextensionsv1.ServiceReference{}
@@ -3095,6 +3284,15 @@ func (d *ServiceReferenceDie) DieRelease() apiextensionsv1.ServiceReference {
 func (d *ServiceReferenceDie) DieReleasePtr() *apiextensionsv1.ServiceReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3311,6 +3509,15 @@ func (d *SelectableFieldDie) DieFeedPtr(r *apiextensionsv1.SelectableField) *Sel
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SelectableFieldDie) DieFeedDuck(v any) *SelectableFieldDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SelectableFieldDie) DieFeedJSON(j []byte) *SelectableFieldDie {
 	r := apiextensionsv1.SelectableField{}
@@ -3359,6 +3566,15 @@ func (d *SelectableFieldDie) DieRelease() apiextensionsv1.SelectableField {
 func (d *SelectableFieldDie) DieReleasePtr() *apiextensionsv1.SelectableField {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SelectableFieldDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3560,6 +3776,15 @@ func (d *CustomResourceDefinitionStatusDie) DieFeedPtr(r *apiextensionsv1.Custom
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceDefinitionStatusDie) DieFeedDuck(v any) *CustomResourceDefinitionStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceDefinitionStatusDie) DieFeedJSON(j []byte) *CustomResourceDefinitionStatusDie {
 	r := apiextensionsv1.CustomResourceDefinitionStatus{}
@@ -3608,6 +3833,15 @@ func (d *CustomResourceDefinitionStatusDie) DieRelease() apiextensionsv1.CustomR
 func (d *CustomResourceDefinitionStatusDie) DieReleasePtr() *apiextensionsv1.CustomResourceDefinitionStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceDefinitionStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3834,6 +4068,15 @@ func (d *CustomResourceDefinitionNamesDie) DieFeedPtr(r *apiextensionsv1.CustomR
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CustomResourceDefinitionNamesDie) DieFeedDuck(v any) *CustomResourceDefinitionNamesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CustomResourceDefinitionNamesDie) DieFeedJSON(j []byte) *CustomResourceDefinitionNamesDie {
 	r := apiextensionsv1.CustomResourceDefinitionNames{}
@@ -3882,6 +4125,15 @@ func (d *CustomResourceDefinitionNamesDie) DieRelease() apiextensionsv1.CustomRe
 func (d *CustomResourceDefinitionNamesDie) DieReleasePtr() *apiextensionsv1.CustomResourceDefinitionNames {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CustomResourceDefinitionNamesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/apiregistration/v1/zz_generated.die.go
+++ b/apis/apiregistration/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *APIServiceDie) DieFeedPtr(r *apiregistration.APIService) *APIServiceDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *APIServiceDie) DieFeedDuck(v any) *APIServiceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *APIServiceDie) DieFeedJSON(j []byte) *APIServiceDie {
 	r := apiregistration.APIService{}
@@ -141,6 +150,15 @@ func (d *APIServiceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *APIServiceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -433,6 +451,15 @@ func (d *APIServiceSpecDie) DieFeedPtr(r *apiregistration.APIServiceSpec) *APISe
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *APIServiceSpecDie) DieFeedDuck(v any) *APIServiceSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *APIServiceSpecDie) DieFeedJSON(j []byte) *APIServiceSpecDie {
 	r := apiregistration.APIServiceSpec{}
@@ -481,6 +508,15 @@ func (d *APIServiceSpecDie) DieRelease() apiregistration.APIServiceSpec {
 func (d *APIServiceSpecDie) DieReleasePtr() *apiregistration.APIServiceSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *APIServiceSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -765,6 +801,15 @@ func (d *ServiceReferenceDie) DieFeedPtr(r *apiregistration.ServiceReference) *S
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceReferenceDie) DieFeedDuck(v any) *ServiceReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceReferenceDie) DieFeedJSON(j []byte) *ServiceReferenceDie {
 	r := apiregistration.ServiceReference{}
@@ -813,6 +858,15 @@ func (d *ServiceReferenceDie) DieRelease() apiregistration.ServiceReference {
 func (d *ServiceReferenceDie) DieReleasePtr() *apiregistration.ServiceReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1018,6 +1072,15 @@ func (d *APIServiceStatusDie) DieFeedPtr(r *apiregistration.APIServiceStatus) *A
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *APIServiceStatusDie) DieFeedDuck(v any) *APIServiceStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *APIServiceStatusDie) DieFeedJSON(j []byte) *APIServiceStatusDie {
 	r := apiregistration.APIServiceStatus{}
@@ -1066,6 +1129,15 @@ func (d *APIServiceStatusDie) DieRelease() apiregistration.APIServiceStatus {
 func (d *APIServiceStatusDie) DieReleasePtr() *apiregistration.APIServiceStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *APIServiceStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
+++ b/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *FlowSchemaDie) DieFeedPtr(r *flowcontrolv1beta1.FlowSchema) *FlowSchema
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FlowSchemaDie) DieFeedDuck(v any) *FlowSchemaDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FlowSchemaDie) DieFeedJSON(j []byte) *FlowSchemaDie {
 	r := flowcontrolv1beta1.FlowSchema{}
@@ -141,6 +150,15 @@ func (d *FlowSchemaDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FlowSchemaDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -437,6 +455,15 @@ func (d *FlowSchemaSpecDie) DieFeedPtr(r *flowcontrolv1beta1.FlowSchemaSpec) *Fl
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FlowSchemaSpecDie) DieFeedDuck(v any) *FlowSchemaSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FlowSchemaSpecDie) DieFeedJSON(j []byte) *FlowSchemaSpecDie {
 	r := flowcontrolv1beta1.FlowSchemaSpec{}
@@ -485,6 +512,15 @@ func (d *FlowSchemaSpecDie) DieRelease() flowcontrolv1beta1.FlowSchemaSpec {
 func (d *FlowSchemaSpecDie) DieReleasePtr() *flowcontrolv1beta1.FlowSchemaSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FlowSchemaSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -753,6 +789,15 @@ func (d *FlowSchemaStatusDie) DieFeedPtr(r *flowcontrolv1beta1.FlowSchemaStatus)
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FlowSchemaStatusDie) DieFeedDuck(v any) *FlowSchemaStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FlowSchemaStatusDie) DieFeedJSON(j []byte) *FlowSchemaStatusDie {
 	r := flowcontrolv1beta1.FlowSchemaStatus{}
@@ -801,6 +846,15 @@ func (d *FlowSchemaStatusDie) DieRelease() flowcontrolv1beta1.FlowSchemaStatus {
 func (d *FlowSchemaStatusDie) DieReleasePtr() *flowcontrolv1beta1.FlowSchemaStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FlowSchemaStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -988,6 +1042,15 @@ func (d *PriorityLevelConfigurationReferenceDie) DieFeedPtr(r *flowcontrolv1beta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PriorityLevelConfigurationReferenceDie) DieFeedDuck(v any) *PriorityLevelConfigurationReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PriorityLevelConfigurationReferenceDie) DieFeedJSON(j []byte) *PriorityLevelConfigurationReferenceDie {
 	r := flowcontrolv1beta1.PriorityLevelConfigurationReference{}
@@ -1036,6 +1099,15 @@ func (d *PriorityLevelConfigurationReferenceDie) DieRelease() flowcontrolv1beta1
 func (d *PriorityLevelConfigurationReferenceDie) DieReleasePtr() *flowcontrolv1beta1.PriorityLevelConfigurationReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PriorityLevelConfigurationReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1225,6 +1297,15 @@ func (d *FlowDistinguisherMethodDie) DieFeedPtr(r *flowcontrolv1beta1.FlowDistin
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FlowDistinguisherMethodDie) DieFeedDuck(v any) *FlowDistinguisherMethodDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FlowDistinguisherMethodDie) DieFeedJSON(j []byte) *FlowDistinguisherMethodDie {
 	r := flowcontrolv1beta1.FlowDistinguisherMethod{}
@@ -1273,6 +1354,15 @@ func (d *FlowDistinguisherMethodDie) DieRelease() flowcontrolv1beta1.FlowDisting
 func (d *FlowDistinguisherMethodDie) DieReleasePtr() *flowcontrolv1beta1.FlowDistinguisherMethod {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FlowDistinguisherMethodDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1464,6 +1554,15 @@ func (d *PolicyRulesWithSubjectsDie) DieFeedPtr(r *flowcontrolv1beta1.PolicyRule
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PolicyRulesWithSubjectsDie) DieFeedDuck(v any) *PolicyRulesWithSubjectsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PolicyRulesWithSubjectsDie) DieFeedJSON(j []byte) *PolicyRulesWithSubjectsDie {
 	r := flowcontrolv1beta1.PolicyRulesWithSubjects{}
@@ -1512,6 +1611,15 @@ func (d *PolicyRulesWithSubjectsDie) DieRelease() flowcontrolv1beta1.PolicyRules
 func (d *PolicyRulesWithSubjectsDie) DieReleasePtr() *flowcontrolv1beta1.PolicyRulesWithSubjects {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PolicyRulesWithSubjectsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1773,6 +1881,15 @@ func (d *SubjectDie) DieFeedPtr(r *flowcontrolv1beta1.Subject) *SubjectDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SubjectDie) DieFeedDuck(v any) *SubjectDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SubjectDie) DieFeedJSON(j []byte) *SubjectDie {
 	r := flowcontrolv1beta1.Subject{}
@@ -1821,6 +1938,15 @@ func (d *SubjectDie) DieRelease() flowcontrolv1beta1.Subject {
 func (d *SubjectDie) DieReleasePtr() *flowcontrolv1beta1.Subject {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SubjectDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2031,6 +2157,15 @@ func (d *UserSubjectDie) DieFeedPtr(r *flowcontrolv1beta1.UserSubject) *UserSubj
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *UserSubjectDie) DieFeedDuck(v any) *UserSubjectDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *UserSubjectDie) DieFeedJSON(j []byte) *UserSubjectDie {
 	r := flowcontrolv1beta1.UserSubject{}
@@ -2079,6 +2214,15 @@ func (d *UserSubjectDie) DieRelease() flowcontrolv1beta1.UserSubject {
 func (d *UserSubjectDie) DieReleasePtr() *flowcontrolv1beta1.UserSubject {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *UserSubjectDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2268,6 +2412,15 @@ func (d *GroupSubjectDie) DieFeedPtr(r *flowcontrolv1beta1.GroupSubject) *GroupS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GroupSubjectDie) DieFeedDuck(v any) *GroupSubjectDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GroupSubjectDie) DieFeedJSON(j []byte) *GroupSubjectDie {
 	r := flowcontrolv1beta1.GroupSubject{}
@@ -2316,6 +2469,15 @@ func (d *GroupSubjectDie) DieRelease() flowcontrolv1beta1.GroupSubject {
 func (d *GroupSubjectDie) DieReleasePtr() *flowcontrolv1beta1.GroupSubject {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GroupSubjectDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2509,6 +2671,15 @@ func (d *ServiceAccountSubjectDie) DieFeedPtr(r *flowcontrolv1beta1.ServiceAccou
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceAccountSubjectDie) DieFeedDuck(v any) *ServiceAccountSubjectDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceAccountSubjectDie) DieFeedJSON(j []byte) *ServiceAccountSubjectDie {
 	r := flowcontrolv1beta1.ServiceAccountSubject{}
@@ -2557,6 +2728,15 @@ func (d *ServiceAccountSubjectDie) DieRelease() flowcontrolv1beta1.ServiceAccoun
 func (d *ServiceAccountSubjectDie) DieReleasePtr() *flowcontrolv1beta1.ServiceAccountSubject {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceAccountSubjectDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2755,6 +2935,15 @@ func (d *ResourcePolicyRuleDie) DieFeedPtr(r *flowcontrolv1beta1.ResourcePolicyR
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourcePolicyRuleDie) DieFeedDuck(v any) *ResourcePolicyRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourcePolicyRuleDie) DieFeedJSON(j []byte) *ResourcePolicyRuleDie {
 	r := flowcontrolv1beta1.ResourcePolicyRule{}
@@ -2803,6 +2992,15 @@ func (d *ResourcePolicyRuleDie) DieRelease() flowcontrolv1beta1.ResourcePolicyRu
 func (d *ResourcePolicyRuleDie) DieReleasePtr() *flowcontrolv1beta1.ResourcePolicyRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourcePolicyRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3056,6 +3254,15 @@ func (d *NonResourcePolicyRuleDie) DieFeedPtr(r *flowcontrolv1beta1.NonResourceP
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NonResourcePolicyRuleDie) DieFeedDuck(v any) *NonResourcePolicyRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NonResourcePolicyRuleDie) DieFeedJSON(j []byte) *NonResourcePolicyRuleDie {
 	r := flowcontrolv1beta1.NonResourcePolicyRule{}
@@ -3104,6 +3311,15 @@ func (d *NonResourcePolicyRuleDie) DieRelease() flowcontrolv1beta1.NonResourcePo
 func (d *NonResourcePolicyRuleDie) DieReleasePtr() *flowcontrolv1beta1.NonResourcePolicyRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NonResourcePolicyRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3321,6 +3537,15 @@ func (d *PriorityLevelConfigurationDie) DieFeedPtr(r *flowcontrolv1beta1.Priorit
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PriorityLevelConfigurationDie) DieFeedDuck(v any) *PriorityLevelConfigurationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PriorityLevelConfigurationDie) DieFeedJSON(j []byte) *PriorityLevelConfigurationDie {
 	r := flowcontrolv1beta1.PriorityLevelConfiguration{}
@@ -3381,6 +3606,15 @@ func (d *PriorityLevelConfigurationDie) DieReleaseUnstructured() *unstructured.U
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PriorityLevelConfigurationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3677,6 +3911,15 @@ func (d *PriorityLevelConfigurationSpecDie) DieFeedPtr(r *flowcontrolv1beta1.Pri
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PriorityLevelConfigurationSpecDie) DieFeedDuck(v any) *PriorityLevelConfigurationSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PriorityLevelConfigurationSpecDie) DieFeedJSON(j []byte) *PriorityLevelConfigurationSpecDie {
 	r := flowcontrolv1beta1.PriorityLevelConfigurationSpec{}
@@ -3725,6 +3968,15 @@ func (d *PriorityLevelConfigurationSpecDie) DieRelease() flowcontrolv1beta1.Prio
 func (d *PriorityLevelConfigurationSpecDie) DieReleasePtr() *flowcontrolv1beta1.PriorityLevelConfigurationSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PriorityLevelConfigurationSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3984,6 +4236,15 @@ func (d *LimitedPriorityLevelConfigurationDie) DieFeedPtr(r *flowcontrolv1beta1.
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LimitedPriorityLevelConfigurationDie) DieFeedDuck(v any) *LimitedPriorityLevelConfigurationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LimitedPriorityLevelConfigurationDie) DieFeedJSON(j []byte) *LimitedPriorityLevelConfigurationDie {
 	r := flowcontrolv1beta1.LimitedPriorityLevelConfiguration{}
@@ -4032,6 +4293,15 @@ func (d *LimitedPriorityLevelConfigurationDie) DieRelease() flowcontrolv1beta1.L
 func (d *LimitedPriorityLevelConfigurationDie) DieReleasePtr() *flowcontrolv1beta1.LimitedPriorityLevelConfiguration {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LimitedPriorityLevelConfigurationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4309,6 +4579,15 @@ func (d *LimitResponseDie) DieFeedPtr(r *flowcontrolv1beta1.LimitResponse) *Limi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LimitResponseDie) DieFeedDuck(v any) *LimitResponseDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LimitResponseDie) DieFeedJSON(j []byte) *LimitResponseDie {
 	r := flowcontrolv1beta1.LimitResponse{}
@@ -4357,6 +4636,15 @@ func (d *LimitResponseDie) DieRelease() flowcontrolv1beta1.LimitResponse {
 func (d *LimitResponseDie) DieReleasePtr() *flowcontrolv1beta1.LimitResponse {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LimitResponseDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4578,6 +4866,15 @@ func (d *ExemptPriorityLevelConfigurationDie) DieFeedPtr(r *flowcontrolv1beta1.E
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ExemptPriorityLevelConfigurationDie) DieFeedDuck(v any) *ExemptPriorityLevelConfigurationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ExemptPriorityLevelConfigurationDie) DieFeedJSON(j []byte) *ExemptPriorityLevelConfigurationDie {
 	r := flowcontrolv1beta1.ExemptPriorityLevelConfiguration{}
@@ -4626,6 +4923,15 @@ func (d *ExemptPriorityLevelConfigurationDie) DieRelease() flowcontrolv1beta1.Ex
 func (d *ExemptPriorityLevelConfigurationDie) DieReleasePtr() *flowcontrolv1beta1.ExemptPriorityLevelConfiguration {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ExemptPriorityLevelConfigurationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4852,6 +5158,15 @@ func (d *QueuingConfigurationDie) DieFeedPtr(r *flowcontrolv1beta1.QueuingConfig
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *QueuingConfigurationDie) DieFeedDuck(v any) *QueuingConfigurationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *QueuingConfigurationDie) DieFeedJSON(j []byte) *QueuingConfigurationDie {
 	r := flowcontrolv1beta1.QueuingConfiguration{}
@@ -4900,6 +5215,15 @@ func (d *QueuingConfigurationDie) DieRelease() flowcontrolv1beta1.QueuingConfigu
 func (d *QueuingConfigurationDie) DieReleasePtr() *flowcontrolv1beta1.QueuingConfiguration {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *QueuingConfigurationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5137,6 +5461,15 @@ func (d *PriorityLevelConfigurationStatusDie) DieFeedPtr(r *flowcontrolv1beta1.P
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PriorityLevelConfigurationStatusDie) DieFeedDuck(v any) *PriorityLevelConfigurationStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PriorityLevelConfigurationStatusDie) DieFeedJSON(j []byte) *PriorityLevelConfigurationStatusDie {
 	r := flowcontrolv1beta1.PriorityLevelConfigurationStatus{}
@@ -5185,6 +5518,15 @@ func (d *PriorityLevelConfigurationStatusDie) DieRelease() flowcontrolv1beta1.Pr
 func (d *PriorityLevelConfigurationStatusDie) DieReleasePtr() *flowcontrolv1beta1.PriorityLevelConfigurationStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PriorityLevelConfigurationStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/apps/v1/zz_generated.die.go
+++ b/apis/apps/v1/zz_generated.die.go
@@ -84,6 +84,15 @@ func (d *ControllerRevisionDie) DieFeedPtr(r *appsv1.ControllerRevision) *Contro
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ControllerRevisionDie) DieFeedDuck(v any) *ControllerRevisionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ControllerRevisionDie) DieFeedJSON(j []byte) *ControllerRevisionDie {
 	r := appsv1.ControllerRevision{}
@@ -144,6 +153,15 @@ func (d *ControllerRevisionDie) DieReleaseUnstructured() *unstructured.Unstructu
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ControllerRevisionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -421,6 +439,15 @@ func (d *DaemonSetDie) DieFeedPtr(r *appsv1.DaemonSet) *DaemonSetDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DaemonSetDie) DieFeedDuck(v any) *DaemonSetDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DaemonSetDie) DieFeedJSON(j []byte) *DaemonSetDie {
 	r := appsv1.DaemonSet{}
@@ -481,6 +508,15 @@ func (d *DaemonSetDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DaemonSetDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -783,6 +819,15 @@ func (d *DaemonSetSpecDie) DieFeedPtr(r *appsv1.DaemonSetSpec) *DaemonSetSpecDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DaemonSetSpecDie) DieFeedDuck(v any) *DaemonSetSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DaemonSetSpecDie) DieFeedJSON(j []byte) *DaemonSetSpecDie {
 	r := appsv1.DaemonSetSpec{}
@@ -831,6 +876,15 @@ func (d *DaemonSetSpecDie) DieRelease() appsv1.DaemonSetSpec {
 func (d *DaemonSetSpecDie) DieReleasePtr() *appsv1.DaemonSetSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DaemonSetSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1121,6 +1175,15 @@ func (d *DaemonSetUpdateStrategyDie) DieFeedPtr(r *appsv1.DaemonSetUpdateStrateg
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DaemonSetUpdateStrategyDie) DieFeedDuck(v any) *DaemonSetUpdateStrategyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DaemonSetUpdateStrategyDie) DieFeedJSON(j []byte) *DaemonSetUpdateStrategyDie {
 	r := appsv1.DaemonSetUpdateStrategy{}
@@ -1169,6 +1232,15 @@ func (d *DaemonSetUpdateStrategyDie) DieRelease() appsv1.DaemonSetUpdateStrategy
 func (d *DaemonSetUpdateStrategyDie) DieReleasePtr() *appsv1.DaemonSetUpdateStrategy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DaemonSetUpdateStrategyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1371,6 +1443,15 @@ func (d *RollingUpdateDaemonSetDie) DieFeedPtr(r *appsv1.RollingUpdateDaemonSet)
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RollingUpdateDaemonSetDie) DieFeedDuck(v any) *RollingUpdateDaemonSetDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RollingUpdateDaemonSetDie) DieFeedJSON(j []byte) *RollingUpdateDaemonSetDie {
 	r := appsv1.RollingUpdateDaemonSet{}
@@ -1419,6 +1500,15 @@ func (d *RollingUpdateDaemonSetDie) DieRelease() appsv1.RollingUpdateDaemonSet {
 func (d *RollingUpdateDaemonSetDie) DieReleasePtr() *appsv1.RollingUpdateDaemonSet {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RollingUpdateDaemonSetDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1833,6 +1923,15 @@ func (d *DaemonSetStatusDie) DieFeedPtr(r *appsv1.DaemonSetStatus) *DaemonSetSta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DaemonSetStatusDie) DieFeedDuck(v any) *DaemonSetStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DaemonSetStatusDie) DieFeedJSON(j []byte) *DaemonSetStatusDie {
 	r := appsv1.DaemonSetStatus{}
@@ -1881,6 +1980,15 @@ func (d *DaemonSetStatusDie) DieRelease() appsv1.DaemonSetStatus {
 func (d *DaemonSetStatusDie) DieReleasePtr() *appsv1.DaemonSetStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DaemonSetStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2160,6 +2268,15 @@ func (d *DeploymentDie) DieFeedPtr(r *appsv1.Deployment) *DeploymentDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DeploymentDie) DieFeedDuck(v any) *DeploymentDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DeploymentDie) DieFeedJSON(j []byte) *DeploymentDie {
 	r := appsv1.Deployment{}
@@ -2220,6 +2337,15 @@ func (d *DeploymentDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DeploymentDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2512,6 +2638,15 @@ func (d *DeploymentSpecDie) DieFeedPtr(r *appsv1.DeploymentSpec) *DeploymentSpec
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DeploymentSpecDie) DieFeedDuck(v any) *DeploymentSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DeploymentSpecDie) DieFeedJSON(j []byte) *DeploymentSpecDie {
 	r := appsv1.DeploymentSpec{}
@@ -2560,6 +2695,15 @@ func (d *DeploymentSpecDie) DieRelease() appsv1.DeploymentSpec {
 func (d *DeploymentSpecDie) DieReleasePtr() *appsv1.DeploymentSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DeploymentSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2859,6 +3003,15 @@ func (d *DeploymentStrategyDie) DieFeedPtr(r *appsv1.DeploymentStrategy) *Deploy
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DeploymentStrategyDie) DieFeedDuck(v any) *DeploymentStrategyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DeploymentStrategyDie) DieFeedJSON(j []byte) *DeploymentStrategyDie {
 	r := appsv1.DeploymentStrategy{}
@@ -2907,6 +3060,15 @@ func (d *DeploymentStrategyDie) DieRelease() appsv1.DeploymentStrategy {
 func (d *DeploymentStrategyDie) DieReleasePtr() *appsv1.DeploymentStrategy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DeploymentStrategyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3109,6 +3271,15 @@ func (d *RollingUpdateDeploymentDie) DieFeedPtr(r *appsv1.RollingUpdateDeploymen
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RollingUpdateDeploymentDie) DieFeedDuck(v any) *RollingUpdateDeploymentDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RollingUpdateDeploymentDie) DieFeedJSON(j []byte) *RollingUpdateDeploymentDie {
 	r := appsv1.RollingUpdateDeployment{}
@@ -3157,6 +3328,15 @@ func (d *RollingUpdateDeploymentDie) DieRelease() appsv1.RollingUpdateDeployment
 func (d *RollingUpdateDeploymentDie) DieReleasePtr() *appsv1.RollingUpdateDeployment {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RollingUpdateDeploymentDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3505,6 +3685,15 @@ func (d *DeploymentStatusDie) DieFeedPtr(r *appsv1.DeploymentStatus) *Deployment
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DeploymentStatusDie) DieFeedDuck(v any) *DeploymentStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DeploymentStatusDie) DieFeedJSON(j []byte) *DeploymentStatusDie {
 	r := appsv1.DeploymentStatus{}
@@ -3553,6 +3742,15 @@ func (d *DeploymentStatusDie) DieRelease() appsv1.DeploymentStatus {
 func (d *DeploymentStatusDie) DieReleasePtr() *appsv1.DeploymentStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DeploymentStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3800,6 +3998,15 @@ func (d *ReplicaSetDie) DieFeedPtr(r *appsv1.ReplicaSet) *ReplicaSetDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ReplicaSetDie) DieFeedDuck(v any) *ReplicaSetDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ReplicaSetDie) DieFeedJSON(j []byte) *ReplicaSetDie {
 	r := appsv1.ReplicaSet{}
@@ -3860,6 +4067,15 @@ func (d *ReplicaSetDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ReplicaSetDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4162,6 +4378,15 @@ func (d *ReplicaSetSpecDie) DieFeedPtr(r *appsv1.ReplicaSetSpec) *ReplicaSetSpec
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ReplicaSetSpecDie) DieFeedDuck(v any) *ReplicaSetSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ReplicaSetSpecDie) DieFeedJSON(j []byte) *ReplicaSetSpecDie {
 	r := appsv1.ReplicaSetSpec{}
@@ -4210,6 +4435,15 @@ func (d *ReplicaSetSpecDie) DieRelease() appsv1.ReplicaSetSpec {
 func (d *ReplicaSetSpecDie) DieReleasePtr() *appsv1.ReplicaSetSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ReplicaSetSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4470,6 +4704,15 @@ func (d *ReplicaSetStatusDie) DieFeedPtr(r *appsv1.ReplicaSetStatus) *ReplicaSet
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ReplicaSetStatusDie) DieFeedDuck(v any) *ReplicaSetStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ReplicaSetStatusDie) DieFeedJSON(j []byte) *ReplicaSetStatusDie {
 	r := appsv1.ReplicaSetStatus{}
@@ -4518,6 +4761,15 @@ func (d *ReplicaSetStatusDie) DieRelease() appsv1.ReplicaSetStatus {
 func (d *ReplicaSetStatusDie) DieReleasePtr() *appsv1.ReplicaSetStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ReplicaSetStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4745,6 +4997,15 @@ func (d *StatefulSetDie) DieFeedPtr(r *appsv1.StatefulSet) *StatefulSetDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatefulSetDie) DieFeedDuck(v any) *StatefulSetDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatefulSetDie) DieFeedJSON(j []byte) *StatefulSetDie {
 	r := appsv1.StatefulSet{}
@@ -4805,6 +5066,15 @@ func (d *StatefulSetDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatefulSetDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5099,6 +5369,15 @@ func (d *StatefulSetSpecDie) DieFeedPtr(r *appsv1.StatefulSetSpec) *StatefulSetS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatefulSetSpecDie) DieFeedDuck(v any) *StatefulSetSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatefulSetSpecDie) DieFeedJSON(j []byte) *StatefulSetSpecDie {
 	r := appsv1.StatefulSetSpec{}
@@ -5147,6 +5426,15 @@ func (d *StatefulSetSpecDie) DieRelease() appsv1.StatefulSetSpec {
 func (d *StatefulSetSpecDie) DieReleasePtr() *appsv1.StatefulSetSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatefulSetSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5603,6 +5891,15 @@ func (d *StatefulSetUpdateStrategyDie) DieFeedPtr(r *appsv1.StatefulSetUpdateStr
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatefulSetUpdateStrategyDie) DieFeedDuck(v any) *StatefulSetUpdateStrategyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatefulSetUpdateStrategyDie) DieFeedJSON(j []byte) *StatefulSetUpdateStrategyDie {
 	r := appsv1.StatefulSetUpdateStrategy{}
@@ -5651,6 +5948,15 @@ func (d *StatefulSetUpdateStrategyDie) DieRelease() appsv1.StatefulSetUpdateStra
 func (d *StatefulSetUpdateStrategyDie) DieReleasePtr() *appsv1.StatefulSetUpdateStrategy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatefulSetUpdateStrategyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5847,6 +6153,15 @@ func (d *RollingUpdateStatefulSetStrategyDie) DieFeedPtr(r *appsv1.RollingUpdate
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RollingUpdateStatefulSetStrategyDie) DieFeedDuck(v any) *RollingUpdateStatefulSetStrategyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RollingUpdateStatefulSetStrategyDie) DieFeedJSON(j []byte) *RollingUpdateStatefulSetStrategyDie {
 	r := appsv1.RollingUpdateStatefulSetStrategy{}
@@ -5895,6 +6210,15 @@ func (d *RollingUpdateStatefulSetStrategyDie) DieRelease() appsv1.RollingUpdateS
 func (d *RollingUpdateStatefulSetStrategyDie) DieReleasePtr() *appsv1.RollingUpdateStatefulSetStrategy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RollingUpdateStatefulSetStrategyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6151,6 +6475,15 @@ func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieFeedPtr(r *appsv
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieFeedDuck(v any) *StatefulSetPersistentVolumeClaimRetentionPolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieFeedJSON(j []byte) *StatefulSetPersistentVolumeClaimRetentionPolicyDie {
 	r := appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{}
@@ -6199,6 +6532,15 @@ func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieRelease() appsv1
 func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieReleasePtr() *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6407,6 +6749,15 @@ func (d *StatefulSetOrdinalsDie) DieFeedPtr(r *appsv1.StatefulSetOrdinals) *Stat
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatefulSetOrdinalsDie) DieFeedDuck(v any) *StatefulSetOrdinalsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatefulSetOrdinalsDie) DieFeedJSON(j []byte) *StatefulSetOrdinalsDie {
 	r := appsv1.StatefulSetOrdinals{}
@@ -6455,6 +6806,15 @@ func (d *StatefulSetOrdinalsDie) DieRelease() appsv1.StatefulSetOrdinals {
 func (d *StatefulSetOrdinalsDie) DieReleasePtr() *appsv1.StatefulSetOrdinals {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatefulSetOrdinalsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6656,6 +7016,15 @@ func (d *StatefulSetStatusDie) DieFeedPtr(r *appsv1.StatefulSetStatus) *Stateful
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatefulSetStatusDie) DieFeedDuck(v any) *StatefulSetStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatefulSetStatusDie) DieFeedJSON(j []byte) *StatefulSetStatusDie {
 	r := appsv1.StatefulSetStatus{}
@@ -6704,6 +7073,15 @@ func (d *StatefulSetStatusDie) DieRelease() appsv1.StatefulSetStatus {
 func (d *StatefulSetStatusDie) DieReleasePtr() *appsv1.StatefulSetStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatefulSetStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/authentication/v1/zz_generated.die.go
+++ b/apis/authentication/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *SelfSubjectReviewDie) DieFeedPtr(r *authenticationv1.SelfSubjectReview)
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SelfSubjectReviewDie) DieFeedDuck(v any) *SelfSubjectReviewDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SelfSubjectReviewDie) DieFeedJSON(j []byte) *SelfSubjectReviewDie {
 	r := authenticationv1.SelfSubjectReview{}
@@ -141,6 +150,15 @@ func (d *SelfSubjectReviewDie) DieReleaseUnstructured() *unstructured.Unstructur
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SelfSubjectReviewDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -417,6 +435,15 @@ func (d *SelfSubjectReviewStatusDie) DieFeedPtr(r *authenticationv1.SelfSubjectR
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SelfSubjectReviewStatusDie) DieFeedDuck(v any) *SelfSubjectReviewStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SelfSubjectReviewStatusDie) DieFeedJSON(j []byte) *SelfSubjectReviewStatusDie {
 	r := authenticationv1.SelfSubjectReviewStatus{}
@@ -465,6 +492,15 @@ func (d *SelfSubjectReviewStatusDie) DieRelease() authenticationv1.SelfSubjectRe
 func (d *SelfSubjectReviewStatusDie) DieReleasePtr() *authenticationv1.SelfSubjectReviewStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SelfSubjectReviewStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -663,6 +699,15 @@ func (d *UserInfoDie) DieFeedPtr(r *authenticationv1.UserInfo) *UserInfoDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *UserInfoDie) DieFeedDuck(v any) *UserInfoDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *UserInfoDie) DieFeedJSON(j []byte) *UserInfoDie {
 	r := authenticationv1.UserInfo{}
@@ -711,6 +756,15 @@ func (d *UserInfoDie) DieRelease() authenticationv1.UserInfo {
 func (d *UserInfoDie) DieReleasePtr() *authenticationv1.UserInfo {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *UserInfoDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -919,6 +973,15 @@ func (d *TokenReviewDie) DieFeedPtr(r *authenticationv1.TokenReview) *TokenRevie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TokenReviewDie) DieFeedDuck(v any) *TokenReviewDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TokenReviewDie) DieFeedJSON(j []byte) *TokenReviewDie {
 	r := authenticationv1.TokenReview{}
@@ -979,6 +1042,15 @@ func (d *TokenReviewDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TokenReviewDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1253,6 +1325,15 @@ func (d *TokenRequestSpecDie) DieFeedPtr(r *authenticationv1.TokenRequestSpec) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TokenRequestSpecDie) DieFeedDuck(v any) *TokenRequestSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TokenRequestSpecDie) DieFeedJSON(j []byte) *TokenRequestSpecDie {
 	r := authenticationv1.TokenRequestSpec{}
@@ -1301,6 +1382,15 @@ func (d *TokenRequestSpecDie) DieRelease() authenticationv1.TokenRequestSpec {
 func (d *TokenRequestSpecDie) DieReleasePtr() *authenticationv1.TokenRequestSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TokenRequestSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1543,6 +1633,15 @@ func (d *BoundObjectReferenceDie) DieFeedPtr(r *authenticationv1.BoundObjectRefe
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *BoundObjectReferenceDie) DieFeedDuck(v any) *BoundObjectReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *BoundObjectReferenceDie) DieFeedJSON(j []byte) *BoundObjectReferenceDie {
 	r := authenticationv1.BoundObjectReference{}
@@ -1591,6 +1690,15 @@ func (d *BoundObjectReferenceDie) DieRelease() authenticationv1.BoundObjectRefer
 func (d *BoundObjectReferenceDie) DieReleasePtr() *authenticationv1.BoundObjectReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *BoundObjectReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1799,6 +1907,15 @@ func (d *TokenRequestStatusDie) DieFeedPtr(r *authenticationv1.TokenRequestStatu
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TokenRequestStatusDie) DieFeedDuck(v any) *TokenRequestStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TokenRequestStatusDie) DieFeedJSON(j []byte) *TokenRequestStatusDie {
 	r := authenticationv1.TokenRequestStatus{}
@@ -1847,6 +1964,15 @@ func (d *TokenRequestStatusDie) DieRelease() authenticationv1.TokenRequestStatus
 func (d *TokenRequestStatusDie) DieReleasePtr() *authenticationv1.TokenRequestStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TokenRequestStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/authorization/rbac/v1/zz_generated.die.go
+++ b/apis/authorization/rbac/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *ClusterRoleDie) DieFeedPtr(r *rbacv1.ClusterRole) *ClusterRoleDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ClusterRoleDie) DieFeedDuck(v any) *ClusterRoleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ClusterRoleDie) DieFeedJSON(j []byte) *ClusterRoleDie {
 	r := rbacv1.ClusterRole{}
@@ -141,6 +150,15 @@ func (d *ClusterRoleDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ClusterRoleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -446,6 +464,15 @@ func (d *AggregationRuleDie) DieFeedPtr(r *rbacv1.AggregationRule) *AggregationR
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AggregationRuleDie) DieFeedDuck(v any) *AggregationRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AggregationRuleDie) DieFeedJSON(j []byte) *AggregationRuleDie {
 	r := rbacv1.AggregationRule{}
@@ -494,6 +521,15 @@ func (d *AggregationRuleDie) DieRelease() rbacv1.AggregationRule {
 func (d *AggregationRuleDie) DieReleasePtr() *rbacv1.AggregationRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AggregationRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -700,6 +736,15 @@ func (d *ClusterRoleBindingDie) DieFeedPtr(r *rbacv1.ClusterRoleBinding) *Cluste
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ClusterRoleBindingDie) DieFeedDuck(v any) *ClusterRoleBindingDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ClusterRoleBindingDie) DieFeedJSON(j []byte) *ClusterRoleBindingDie {
 	r := rbacv1.ClusterRoleBinding{}
@@ -760,6 +805,15 @@ func (d *ClusterRoleBindingDie) DieReleaseUnstructured() *unstructured.Unstructu
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ClusterRoleBindingDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1068,6 +1122,15 @@ func (d *RoleDie) DieFeedPtr(r *rbacv1.Role) *RoleDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RoleDie) DieFeedDuck(v any) *RoleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RoleDie) DieFeedJSON(j []byte) *RoleDie {
 	r := rbacv1.Role{}
@@ -1128,6 +1191,15 @@ func (d *RoleDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RoleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1407,6 +1479,15 @@ func (d *PolicyRuleDie) DieFeedPtr(r *rbacv1.PolicyRule) *PolicyRuleDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PolicyRuleDie) DieFeedDuck(v any) *PolicyRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PolicyRuleDie) DieFeedJSON(j []byte) *PolicyRuleDie {
 	r := rbacv1.PolicyRule{}
@@ -1455,6 +1536,15 @@ func (d *PolicyRuleDie) DieRelease() rbacv1.PolicyRule {
 func (d *PolicyRuleDie) DieReleasePtr() *rbacv1.PolicyRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PolicyRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1679,6 +1769,15 @@ func (d *RoleBindingDie) DieFeedPtr(r *rbacv1.RoleBinding) *RoleBindingDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RoleBindingDie) DieFeedDuck(v any) *RoleBindingDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RoleBindingDie) DieFeedJSON(j []byte) *RoleBindingDie {
 	r := rbacv1.RoleBinding{}
@@ -1739,6 +1838,15 @@ func (d *RoleBindingDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RoleBindingDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2044,6 +2152,15 @@ func (d *SubjectDie) DieFeedPtr(r *rbacv1.Subject) *SubjectDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SubjectDie) DieFeedDuck(v any) *SubjectDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SubjectDie) DieFeedJSON(j []byte) *SubjectDie {
 	r := rbacv1.Subject{}
@@ -2092,6 +2209,15 @@ func (d *SubjectDie) DieRelease() rbacv1.Subject {
 func (d *SubjectDie) DieReleasePtr() *rbacv1.Subject {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SubjectDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2308,6 +2434,15 @@ func (d *RoleRefDie) DieFeedPtr(r *rbacv1.RoleRef) *RoleRefDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RoleRefDie) DieFeedDuck(v any) *RoleRefDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RoleRefDie) DieFeedJSON(j []byte) *RoleRefDie {
 	r := rbacv1.RoleRef{}
@@ -2356,6 +2491,15 @@ func (d *RoleRefDie) DieRelease() rbacv1.RoleRef {
 func (d *RoleRefDie) DieReleasePtr() *rbacv1.RoleRef {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RoleRefDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/authorization/v1/zz_generated.die.go
+++ b/apis/authorization/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *LocalSubjectAccessReviewDie) DieFeedPtr(r *authorizationv1.LocalSubject
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LocalSubjectAccessReviewDie) DieFeedDuck(v any) *LocalSubjectAccessReviewDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LocalSubjectAccessReviewDie) DieFeedJSON(j []byte) *LocalSubjectAccessReviewDie {
 	r := authorizationv1.LocalSubjectAccessReview{}
@@ -141,6 +150,15 @@ func (d *LocalSubjectAccessReviewDie) DieReleaseUnstructured() *unstructured.Uns
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LocalSubjectAccessReviewDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -420,6 +438,15 @@ func (d *SelfSubjectAccessReviewDie) DieFeedPtr(r *authorizationv1.SelfSubjectAc
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SelfSubjectAccessReviewDie) DieFeedDuck(v any) *SelfSubjectAccessReviewDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SelfSubjectAccessReviewDie) DieFeedJSON(j []byte) *SelfSubjectAccessReviewDie {
 	r := authorizationv1.SelfSubjectAccessReview{}
@@ -480,6 +507,15 @@ func (d *SelfSubjectAccessReviewDie) DieReleaseUnstructured() *unstructured.Unst
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SelfSubjectAccessReviewDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -772,6 +808,15 @@ func (d *SelfSubjectAccessReviewSpecDie) DieFeedPtr(r *authorizationv1.SelfSubje
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SelfSubjectAccessReviewSpecDie) DieFeedDuck(v any) *SelfSubjectAccessReviewSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SelfSubjectAccessReviewSpecDie) DieFeedJSON(j []byte) *SelfSubjectAccessReviewSpecDie {
 	r := authorizationv1.SelfSubjectAccessReviewSpec{}
@@ -820,6 +865,15 @@ func (d *SelfSubjectAccessReviewSpecDie) DieRelease() authorizationv1.SelfSubjec
 func (d *SelfSubjectAccessReviewSpecDie) DieReleasePtr() *authorizationv1.SelfSubjectAccessReviewSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SelfSubjectAccessReviewSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1039,6 +1093,15 @@ func (d *SelfSubjectRulesReviewDie) DieFeedPtr(r *authorizationv1.SelfSubjectRul
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SelfSubjectRulesReviewDie) DieFeedDuck(v any) *SelfSubjectRulesReviewDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SelfSubjectRulesReviewDie) DieFeedJSON(j []byte) *SelfSubjectRulesReviewDie {
 	r := authorizationv1.SelfSubjectRulesReview{}
@@ -1099,6 +1162,15 @@ func (d *SelfSubjectRulesReviewDie) DieReleaseUnstructured() *unstructured.Unstr
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SelfSubjectRulesReviewDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1391,6 +1463,15 @@ func (d *SelfSubjectRulesReviewSpecDie) DieFeedPtr(r *authorizationv1.SelfSubjec
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SelfSubjectRulesReviewSpecDie) DieFeedDuck(v any) *SelfSubjectRulesReviewSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SelfSubjectRulesReviewSpecDie) DieFeedJSON(j []byte) *SelfSubjectRulesReviewSpecDie {
 	r := authorizationv1.SelfSubjectRulesReviewSpec{}
@@ -1439,6 +1520,15 @@ func (d *SelfSubjectRulesReviewSpecDie) DieRelease() authorizationv1.SelfSubject
 func (d *SelfSubjectRulesReviewSpecDie) DieReleasePtr() *authorizationv1.SelfSubjectRulesReviewSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SelfSubjectRulesReviewSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1626,6 +1716,15 @@ func (d *SubjectRulesReviewStatusDie) DieFeedPtr(r *authorizationv1.SubjectRules
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SubjectRulesReviewStatusDie) DieFeedDuck(v any) *SubjectRulesReviewStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SubjectRulesReviewStatusDie) DieFeedJSON(j []byte) *SubjectRulesReviewStatusDie {
 	r := authorizationv1.SubjectRulesReviewStatus{}
@@ -1674,6 +1773,15 @@ func (d *SubjectRulesReviewStatusDie) DieRelease() authorizationv1.SubjectRulesR
 func (d *SubjectRulesReviewStatusDie) DieReleasePtr() *authorizationv1.SubjectRulesReviewStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SubjectRulesReviewStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1920,6 +2028,15 @@ func (d *ResourceRuleDie) DieFeedPtr(r *authorizationv1.ResourceRule) *ResourceR
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceRuleDie) DieFeedDuck(v any) *ResourceRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceRuleDie) DieFeedJSON(j []byte) *ResourceRuleDie {
 	r := authorizationv1.ResourceRule{}
@@ -1968,6 +2085,15 @@ func (d *ResourceRuleDie) DieRelease() authorizationv1.ResourceRule {
 func (d *ResourceRuleDie) DieReleasePtr() *authorizationv1.ResourceRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2180,6 +2306,15 @@ func (d *NonResourceRuleDie) DieFeedPtr(r *authorizationv1.NonResourceRule) *Non
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NonResourceRuleDie) DieFeedDuck(v any) *NonResourceRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NonResourceRuleDie) DieFeedJSON(j []byte) *NonResourceRuleDie {
 	r := authorizationv1.NonResourceRule{}
@@ -2228,6 +2363,15 @@ func (d *NonResourceRuleDie) DieRelease() authorizationv1.NonResourceRule {
 func (d *NonResourceRuleDie) DieReleasePtr() *authorizationv1.NonResourceRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NonResourceRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2427,6 +2571,15 @@ func (d *SubjectAccessReviewDie) DieFeedPtr(r *authorizationv1.SubjectAccessRevi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SubjectAccessReviewDie) DieFeedDuck(v any) *SubjectAccessReviewDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SubjectAccessReviewDie) DieFeedJSON(j []byte) *SubjectAccessReviewDie {
 	r := authorizationv1.SubjectAccessReview{}
@@ -2487,6 +2640,15 @@ func (d *SubjectAccessReviewDie) DieReleaseUnstructured() *unstructured.Unstruct
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SubjectAccessReviewDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2779,6 +2941,15 @@ func (d *SubjectAccessReviewSpecDie) DieFeedPtr(r *authorizationv1.SubjectAccess
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SubjectAccessReviewSpecDie) DieFeedDuck(v any) *SubjectAccessReviewSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SubjectAccessReviewSpecDie) DieFeedJSON(j []byte) *SubjectAccessReviewSpecDie {
 	r := authorizationv1.SubjectAccessReviewSpec{}
@@ -2827,6 +2998,15 @@ func (d *SubjectAccessReviewSpecDie) DieRelease() authorizationv1.SubjectAccessR
 func (d *SubjectAccessReviewSpecDie) DieReleasePtr() *authorizationv1.SubjectAccessReviewSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SubjectAccessReviewSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3066,6 +3246,15 @@ func (d *ResourceAttributesDie) DieFeedPtr(r *authorizationv1.ResourceAttributes
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceAttributesDie) DieFeedDuck(v any) *ResourceAttributesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceAttributesDie) DieFeedJSON(j []byte) *ResourceAttributesDie {
 	r := authorizationv1.ResourceAttributes{}
@@ -3114,6 +3303,15 @@ func (d *ResourceAttributesDie) DieRelease() authorizationv1.ResourceAttributes 
 func (d *ResourceAttributesDie) DieReleasePtr() *authorizationv1.ResourceAttributes {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceAttributesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3401,6 +3599,15 @@ func (d *NonResourceAttributesDie) DieFeedPtr(r *authorizationv1.NonResourceAttr
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NonResourceAttributesDie) DieFeedDuck(v any) *NonResourceAttributesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NonResourceAttributesDie) DieFeedJSON(j []byte) *NonResourceAttributesDie {
 	r := authorizationv1.NonResourceAttributes{}
@@ -3449,6 +3656,15 @@ func (d *NonResourceAttributesDie) DieRelease() authorizationv1.NonResourceAttri
 func (d *NonResourceAttributesDie) DieReleasePtr() *authorizationv1.NonResourceAttributes {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NonResourceAttributesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3643,6 +3859,15 @@ func (d *SubjectAccessReviewStatusDie) DieFeedPtr(r *authorizationv1.SubjectAcce
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SubjectAccessReviewStatusDie) DieFeedDuck(v any) *SubjectAccessReviewStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SubjectAccessReviewStatusDie) DieFeedJSON(j []byte) *SubjectAccessReviewStatusDie {
 	r := authorizationv1.SubjectAccessReviewStatus{}
@@ -3691,6 +3916,15 @@ func (d *SubjectAccessReviewStatusDie) DieRelease() authorizationv1.SubjectAcces
 func (d *SubjectAccessReviewStatusDie) DieReleasePtr() *authorizationv1.SubjectAccessReviewStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SubjectAccessReviewStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3909,6 +4143,15 @@ func (d *FieldSelectorAttributesDie) DieFeedPtr(r *authorizationv1.FieldSelector
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FieldSelectorAttributesDie) DieFeedDuck(v any) *FieldSelectorAttributesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FieldSelectorAttributesDie) DieFeedJSON(j []byte) *FieldSelectorAttributesDie {
 	r := authorizationv1.FieldSelectorAttributes{}
@@ -3957,6 +4200,15 @@ func (d *FieldSelectorAttributesDie) DieRelease() authorizationv1.FieldSelectorA
 func (d *FieldSelectorAttributesDie) DieReleasePtr() *authorizationv1.FieldSelectorAttributes {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FieldSelectorAttributesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4183,6 +4435,15 @@ func (d *LabelSelectorAttributesDie) DieFeedPtr(r *authorizationv1.LabelSelector
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LabelSelectorAttributesDie) DieFeedDuck(v any) *LabelSelectorAttributesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LabelSelectorAttributesDie) DieFeedJSON(j []byte) *LabelSelectorAttributesDie {
 	r := authorizationv1.LabelSelectorAttributes{}
@@ -4231,6 +4492,15 @@ func (d *LabelSelectorAttributesDie) DieRelease() authorizationv1.LabelSelectorA
 func (d *LabelSelectorAttributesDie) DieReleasePtr() *authorizationv1.LabelSelectorAttributes {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LabelSelectorAttributesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/autoscaling/v1/zz_generated.die.go
+++ b/apis/autoscaling/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *HorizontalPodAutoscalerDie) DieFeedPtr(r *autoscalingv1.HorizontalPodAu
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HorizontalPodAutoscalerDie) DieFeedDuck(v any) *HorizontalPodAutoscalerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HorizontalPodAutoscalerDie) DieFeedJSON(j []byte) *HorizontalPodAutoscalerDie {
 	r := autoscalingv1.HorizontalPodAutoscaler{}
@@ -141,6 +150,15 @@ func (d *HorizontalPodAutoscalerDie) DieReleaseUnstructured() *unstructured.Unst
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HorizontalPodAutoscalerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -433,6 +451,15 @@ func (d *HorizontalPodAutoscalerSpecDie) DieFeedPtr(r *autoscalingv1.HorizontalP
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HorizontalPodAutoscalerSpecDie) DieFeedDuck(v any) *HorizontalPodAutoscalerSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HorizontalPodAutoscalerSpecDie) DieFeedJSON(j []byte) *HorizontalPodAutoscalerSpecDie {
 	r := autoscalingv1.HorizontalPodAutoscalerSpec{}
@@ -481,6 +508,15 @@ func (d *HorizontalPodAutoscalerSpecDie) DieRelease() autoscalingv1.HorizontalPo
 func (d *HorizontalPodAutoscalerSpecDie) DieReleasePtr() *autoscalingv1.HorizontalPodAutoscalerSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HorizontalPodAutoscalerSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -714,6 +750,15 @@ func (d *CrossVersionObjectReferenceDie) DieFeedPtr(r *autoscalingv1.CrossVersio
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CrossVersionObjectReferenceDie) DieFeedDuck(v any) *CrossVersionObjectReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CrossVersionObjectReferenceDie) DieFeedJSON(j []byte) *CrossVersionObjectReferenceDie {
 	r := autoscalingv1.CrossVersionObjectReference{}
@@ -762,6 +807,15 @@ func (d *CrossVersionObjectReferenceDie) DieRelease() autoscalingv1.CrossVersion
 func (d *CrossVersionObjectReferenceDie) DieReleasePtr() *autoscalingv1.CrossVersionObjectReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CrossVersionObjectReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -963,6 +1017,15 @@ func (d *HorizontalPodAutoscalerStatusDie) DieFeedPtr(r *autoscalingv1.Horizonta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HorizontalPodAutoscalerStatusDie) DieFeedDuck(v any) *HorizontalPodAutoscalerStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HorizontalPodAutoscalerStatusDie) DieFeedJSON(j []byte) *HorizontalPodAutoscalerStatusDie {
 	r := autoscalingv1.HorizontalPodAutoscalerStatus{}
@@ -1011,6 +1074,15 @@ func (d *HorizontalPodAutoscalerStatusDie) DieRelease() autoscalingv1.Horizontal
 func (d *HorizontalPodAutoscalerStatusDie) DieReleasePtr() *autoscalingv1.HorizontalPodAutoscalerStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HorizontalPodAutoscalerStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/autoscaling/v2/zz_generated.die.go
+++ b/apis/autoscaling/v2/zz_generated.die.go
@@ -83,6 +83,15 @@ func (d *HorizontalPodAutoscalerDie) DieFeedPtr(r *autoscalingv2.HorizontalPodAu
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HorizontalPodAutoscalerDie) DieFeedDuck(v any) *HorizontalPodAutoscalerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HorizontalPodAutoscalerDie) DieFeedJSON(j []byte) *HorizontalPodAutoscalerDie {
 	r := autoscalingv2.HorizontalPodAutoscaler{}
@@ -143,6 +152,15 @@ func (d *HorizontalPodAutoscalerDie) DieReleaseUnstructured() *unstructured.Unst
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HorizontalPodAutoscalerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -437,6 +455,15 @@ func (d *HorizontalPodAutoscalerSpecDie) DieFeedPtr(r *autoscalingv2.HorizontalP
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HorizontalPodAutoscalerSpecDie) DieFeedDuck(v any) *HorizontalPodAutoscalerSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HorizontalPodAutoscalerSpecDie) DieFeedJSON(j []byte) *HorizontalPodAutoscalerSpecDie {
 	r := autoscalingv2.HorizontalPodAutoscalerSpec{}
@@ -485,6 +512,15 @@ func (d *HorizontalPodAutoscalerSpecDie) DieRelease() autoscalingv2.HorizontalPo
 func (d *HorizontalPodAutoscalerSpecDie) DieReleasePtr() *autoscalingv2.HorizontalPodAutoscalerSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HorizontalPodAutoscalerSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -784,6 +820,15 @@ func (d *CrossVersionObjectReferenceDie) DieFeedPtr(r *autoscalingv2.CrossVersio
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CrossVersionObjectReferenceDie) DieFeedDuck(v any) *CrossVersionObjectReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CrossVersionObjectReferenceDie) DieFeedJSON(j []byte) *CrossVersionObjectReferenceDie {
 	r := autoscalingv2.CrossVersionObjectReference{}
@@ -832,6 +877,15 @@ func (d *CrossVersionObjectReferenceDie) DieRelease() autoscalingv2.CrossVersion
 func (d *CrossVersionObjectReferenceDie) DieReleasePtr() *autoscalingv2.CrossVersionObjectReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CrossVersionObjectReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1033,6 +1087,15 @@ func (d *MetricSpecDie) DieFeedPtr(r *autoscalingv2.MetricSpec) *MetricSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MetricSpecDie) DieFeedDuck(v any) *MetricSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MetricSpecDie) DieFeedJSON(j []byte) *MetricSpecDie {
 	r := autoscalingv2.MetricSpec{}
@@ -1081,6 +1144,15 @@ func (d *MetricSpecDie) DieRelease() autoscalingv2.MetricSpec {
 func (d *MetricSpecDie) DieReleasePtr() *autoscalingv2.MetricSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MetricSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1420,6 +1492,15 @@ func (d *ObjectMetricSourceDie) DieFeedPtr(r *autoscalingv2.ObjectMetricSource) 
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ObjectMetricSourceDie) DieFeedDuck(v any) *ObjectMetricSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ObjectMetricSourceDie) DieFeedJSON(j []byte) *ObjectMetricSourceDie {
 	r := autoscalingv2.ObjectMetricSource{}
@@ -1468,6 +1549,15 @@ func (d *ObjectMetricSourceDie) DieRelease() autoscalingv2.ObjectMetricSource {
 func (d *ObjectMetricSourceDie) DieReleasePtr() *autoscalingv2.ObjectMetricSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ObjectMetricSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1702,6 +1792,15 @@ func (d *MetricTargetDie) DieFeedPtr(r *autoscalingv2.MetricTarget) *MetricTarge
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MetricTargetDie) DieFeedDuck(v any) *MetricTargetDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MetricTargetDie) DieFeedJSON(j []byte) *MetricTargetDie {
 	r := autoscalingv2.MetricTarget{}
@@ -1750,6 +1849,15 @@ func (d *MetricTargetDie) DieRelease() autoscalingv2.MetricTarget {
 func (d *MetricTargetDie) DieReleasePtr() *autoscalingv2.MetricTarget {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MetricTargetDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1984,6 +2092,15 @@ func (d *MetricIdentifierDie) DieFeedPtr(r *autoscalingv2.MetricIdentifier) *Met
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MetricIdentifierDie) DieFeedDuck(v any) *MetricIdentifierDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MetricIdentifierDie) DieFeedJSON(j []byte) *MetricIdentifierDie {
 	r := autoscalingv2.MetricIdentifier{}
@@ -2032,6 +2149,15 @@ func (d *MetricIdentifierDie) DieRelease() autoscalingv2.MetricIdentifier {
 func (d *MetricIdentifierDie) DieReleasePtr() *autoscalingv2.MetricIdentifier {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MetricIdentifierDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2245,6 +2371,15 @@ func (d *PodsMetricSourceDie) DieFeedPtr(r *autoscalingv2.PodsMetricSource) *Pod
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodsMetricSourceDie) DieFeedDuck(v any) *PodsMetricSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodsMetricSourceDie) DieFeedJSON(j []byte) *PodsMetricSourceDie {
 	r := autoscalingv2.PodsMetricSource{}
@@ -2293,6 +2428,15 @@ func (d *PodsMetricSourceDie) DieRelease() autoscalingv2.PodsMetricSource {
 func (d *PodsMetricSourceDie) DieReleasePtr() *autoscalingv2.PodsMetricSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodsMetricSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2509,6 +2653,15 @@ func (d *ResourceMetricSourceDie) DieFeedPtr(r *autoscalingv2.ResourceMetricSour
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceMetricSourceDie) DieFeedDuck(v any) *ResourceMetricSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceMetricSourceDie) DieFeedJSON(j []byte) *ResourceMetricSourceDie {
 	r := autoscalingv2.ResourceMetricSource{}
@@ -2557,6 +2710,15 @@ func (d *ResourceMetricSourceDie) DieRelease() autoscalingv2.ResourceMetricSourc
 func (d *ResourceMetricSourceDie) DieReleasePtr() *autoscalingv2.ResourceMetricSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceMetricSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2762,6 +2924,15 @@ func (d *ContainerResourceMetricSourceDie) DieFeedPtr(r *autoscalingv2.Container
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerResourceMetricSourceDie) DieFeedDuck(v any) *ContainerResourceMetricSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerResourceMetricSourceDie) DieFeedJSON(j []byte) *ContainerResourceMetricSourceDie {
 	r := autoscalingv2.ContainerResourceMetricSource{}
@@ -2810,6 +2981,15 @@ func (d *ContainerResourceMetricSourceDie) DieRelease() autoscalingv2.ContainerR
 func (d *ContainerResourceMetricSourceDie) DieReleasePtr() *autoscalingv2.ContainerResourceMetricSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerResourceMetricSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3022,6 +3202,15 @@ func (d *ExternalMetricSourceDie) DieFeedPtr(r *autoscalingv2.ExternalMetricSour
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ExternalMetricSourceDie) DieFeedDuck(v any) *ExternalMetricSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ExternalMetricSourceDie) DieFeedJSON(j []byte) *ExternalMetricSourceDie {
 	r := autoscalingv2.ExternalMetricSource{}
@@ -3070,6 +3259,15 @@ func (d *ExternalMetricSourceDie) DieRelease() autoscalingv2.ExternalMetricSourc
 func (d *ExternalMetricSourceDie) DieReleasePtr() *autoscalingv2.ExternalMetricSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ExternalMetricSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3286,6 +3484,15 @@ func (d *HorizontalPodAutoscalerBehaviorDie) DieFeedPtr(r *autoscalingv2.Horizon
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HorizontalPodAutoscalerBehaviorDie) DieFeedDuck(v any) *HorizontalPodAutoscalerBehaviorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HorizontalPodAutoscalerBehaviorDie) DieFeedJSON(j []byte) *HorizontalPodAutoscalerBehaviorDie {
 	r := autoscalingv2.HorizontalPodAutoscalerBehavior{}
@@ -3334,6 +3541,15 @@ func (d *HorizontalPodAutoscalerBehaviorDie) DieRelease() autoscalingv2.Horizont
 func (d *HorizontalPodAutoscalerBehaviorDie) DieReleasePtr() *autoscalingv2.HorizontalPodAutoscalerBehavior {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HorizontalPodAutoscalerBehaviorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3578,6 +3794,15 @@ func (d *HPAScalingRulesDie) DieFeedPtr(r *autoscalingv2.HPAScalingRules) *HPASc
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HPAScalingRulesDie) DieFeedDuck(v any) *HPAScalingRulesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HPAScalingRulesDie) DieFeedJSON(j []byte) *HPAScalingRulesDie {
 	r := autoscalingv2.HPAScalingRules{}
@@ -3626,6 +3851,15 @@ func (d *HPAScalingRulesDie) DieRelease() autoscalingv2.HPAScalingRules {
 func (d *HPAScalingRulesDie) DieReleasePtr() *autoscalingv2.HPAScalingRules {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HPAScalingRulesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3855,6 +4089,15 @@ func (d *HPAScalingPolicyDie) DieFeedPtr(r *autoscalingv2.HPAScalingPolicy) *HPA
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HPAScalingPolicyDie) DieFeedDuck(v any) *HPAScalingPolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HPAScalingPolicyDie) DieFeedJSON(j []byte) *HPAScalingPolicyDie {
 	r := autoscalingv2.HPAScalingPolicy{}
@@ -3903,6 +4146,15 @@ func (d *HPAScalingPolicyDie) DieRelease() autoscalingv2.HPAScalingPolicy {
 func (d *HPAScalingPolicyDie) DieReleasePtr() *autoscalingv2.HPAScalingPolicy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HPAScalingPolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4108,6 +4360,15 @@ func (d *HorizontalPodAutoscalerStatusDie) DieFeedPtr(r *autoscalingv2.Horizonta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HorizontalPodAutoscalerStatusDie) DieFeedDuck(v any) *HorizontalPodAutoscalerStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HorizontalPodAutoscalerStatusDie) DieFeedJSON(j []byte) *HorizontalPodAutoscalerStatusDie {
 	r := autoscalingv2.HorizontalPodAutoscalerStatus{}
@@ -4156,6 +4417,15 @@ func (d *HorizontalPodAutoscalerStatusDie) DieRelease() autoscalingv2.Horizontal
 func (d *HorizontalPodAutoscalerStatusDie) DieReleasePtr() *autoscalingv2.HorizontalPodAutoscalerStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HorizontalPodAutoscalerStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4398,6 +4668,15 @@ func (d *MetricStatusDie) DieFeedPtr(r *autoscalingv2.MetricStatus) *MetricStatu
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MetricStatusDie) DieFeedDuck(v any) *MetricStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MetricStatusDie) DieFeedJSON(j []byte) *MetricStatusDie {
 	r := autoscalingv2.MetricStatus{}
@@ -4446,6 +4725,15 @@ func (d *MetricStatusDie) DieRelease() autoscalingv2.MetricStatus {
 func (d *MetricStatusDie) DieReleasePtr() *autoscalingv2.MetricStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MetricStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4785,6 +5073,15 @@ func (d *ObjectMetricStatusDie) DieFeedPtr(r *autoscalingv2.ObjectMetricStatus) 
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ObjectMetricStatusDie) DieFeedDuck(v any) *ObjectMetricStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ObjectMetricStatusDie) DieFeedJSON(j []byte) *ObjectMetricStatusDie {
 	r := autoscalingv2.ObjectMetricStatus{}
@@ -4833,6 +5130,15 @@ func (d *ObjectMetricStatusDie) DieRelease() autoscalingv2.ObjectMetricStatus {
 func (d *ObjectMetricStatusDie) DieReleasePtr() *autoscalingv2.ObjectMetricStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ObjectMetricStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5067,6 +5373,15 @@ func (d *MetricValueStatusDie) DieFeedPtr(r *autoscalingv2.MetricValueStatus) *M
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *MetricValueStatusDie) DieFeedDuck(v any) *MetricValueStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *MetricValueStatusDie) DieFeedJSON(j []byte) *MetricValueStatusDie {
 	r := autoscalingv2.MetricValueStatus{}
@@ -5115,6 +5430,15 @@ func (d *MetricValueStatusDie) DieRelease() autoscalingv2.MetricValueStatus {
 func (d *MetricValueStatusDie) DieReleasePtr() *autoscalingv2.MetricValueStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *MetricValueStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5340,6 +5664,15 @@ func (d *PodsMetricStatusDie) DieFeedPtr(r *autoscalingv2.PodsMetricStatus) *Pod
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodsMetricStatusDie) DieFeedDuck(v any) *PodsMetricStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodsMetricStatusDie) DieFeedJSON(j []byte) *PodsMetricStatusDie {
 	r := autoscalingv2.PodsMetricStatus{}
@@ -5388,6 +5721,15 @@ func (d *PodsMetricStatusDie) DieRelease() autoscalingv2.PodsMetricStatus {
 func (d *PodsMetricStatusDie) DieReleasePtr() *autoscalingv2.PodsMetricStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodsMetricStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5604,6 +5946,15 @@ func (d *ResourceMetricStatusDie) DieFeedPtr(r *autoscalingv2.ResourceMetricStat
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceMetricStatusDie) DieFeedDuck(v any) *ResourceMetricStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceMetricStatusDie) DieFeedJSON(j []byte) *ResourceMetricStatusDie {
 	r := autoscalingv2.ResourceMetricStatus{}
@@ -5652,6 +6003,15 @@ func (d *ResourceMetricStatusDie) DieRelease() autoscalingv2.ResourceMetricStatu
 func (d *ResourceMetricStatusDie) DieReleasePtr() *autoscalingv2.ResourceMetricStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceMetricStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5857,6 +6217,15 @@ func (d *ContainerResourceMetricStatusDie) DieFeedPtr(r *autoscalingv2.Container
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerResourceMetricStatusDie) DieFeedDuck(v any) *ContainerResourceMetricStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerResourceMetricStatusDie) DieFeedJSON(j []byte) *ContainerResourceMetricStatusDie {
 	r := autoscalingv2.ContainerResourceMetricStatus{}
@@ -5905,6 +6274,15 @@ func (d *ContainerResourceMetricStatusDie) DieRelease() autoscalingv2.ContainerR
 func (d *ContainerResourceMetricStatusDie) DieReleasePtr() *autoscalingv2.ContainerResourceMetricStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerResourceMetricStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6117,6 +6495,15 @@ func (d *ExternalMetricStatusDie) DieFeedPtr(r *autoscalingv2.ExternalMetricStat
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ExternalMetricStatusDie) DieFeedDuck(v any) *ExternalMetricStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ExternalMetricStatusDie) DieFeedJSON(j []byte) *ExternalMetricStatusDie {
 	r := autoscalingv2.ExternalMetricStatus{}
@@ -6165,6 +6552,15 @@ func (d *ExternalMetricStatusDie) DieRelease() autoscalingv2.ExternalMetricStatu
 func (d *ExternalMetricStatusDie) DieReleasePtr() *autoscalingv2.ExternalMetricStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ExternalMetricStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/batch/v1/zz_generated.die.go
+++ b/apis/batch/v1/zz_generated.die.go
@@ -83,6 +83,15 @@ func (d *CronJobDie) DieFeedPtr(r *batchv1.CronJob) *CronJobDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CronJobDie) DieFeedDuck(v any) *CronJobDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CronJobDie) DieFeedJSON(j []byte) *CronJobDie {
 	r := batchv1.CronJob{}
@@ -143,6 +152,15 @@ func (d *CronJobDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CronJobDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -439,6 +457,15 @@ func (d *CronJobSpecDie) DieFeedPtr(r *batchv1.CronJobSpec) *CronJobSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CronJobSpecDie) DieFeedDuck(v any) *CronJobSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CronJobSpecDie) DieFeedJSON(j []byte) *CronJobSpecDie {
 	r := batchv1.CronJobSpec{}
@@ -487,6 +514,15 @@ func (d *CronJobSpecDie) DieRelease() batchv1.CronJobSpec {
 func (d *CronJobSpecDie) DieReleasePtr() *batchv1.CronJobSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CronJobSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -755,6 +791,15 @@ func (d *CronJobStatusDie) DieFeedPtr(r *batchv1.CronJobStatus) *CronJobStatusDi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CronJobStatusDie) DieFeedDuck(v any) *CronJobStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CronJobStatusDie) DieFeedJSON(j []byte) *CronJobStatusDie {
 	r := batchv1.CronJobStatus{}
@@ -803,6 +848,15 @@ func (d *CronJobStatusDie) DieRelease() batchv1.CronJobStatus {
 func (d *CronJobStatusDie) DieReleasePtr() *batchv1.CronJobStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CronJobStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1007,6 +1061,15 @@ func (d *JobDie) DieFeedPtr(r *batchv1.Job) *JobDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *JobDie) DieFeedDuck(v any) *JobDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *JobDie) DieFeedJSON(j []byte) *JobDie {
 	r := batchv1.Job{}
@@ -1067,6 +1130,15 @@ func (d *JobDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *JobDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1363,6 +1435,15 @@ func (d *JobSpecDie) DieFeedPtr(r *batchv1.JobSpec) *JobSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *JobSpecDie) DieFeedDuck(v any) *JobSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *JobSpecDie) DieFeedJSON(j []byte) *JobSpecDie {
 	r := batchv1.JobSpec{}
@@ -1411,6 +1492,15 @@ func (d *JobSpecDie) DieRelease() batchv1.JobSpec {
 func (d *JobSpecDie) DieReleasePtr() *batchv1.JobSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *JobSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1987,6 +2077,15 @@ func (d *PodFailurePolicyDie) DieFeedPtr(r *batchv1.PodFailurePolicy) *PodFailur
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodFailurePolicyDie) DieFeedDuck(v any) *PodFailurePolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodFailurePolicyDie) DieFeedJSON(j []byte) *PodFailurePolicyDie {
 	r := batchv1.PodFailurePolicy{}
@@ -2035,6 +2134,15 @@ func (d *PodFailurePolicyDie) DieRelease() batchv1.PodFailurePolicy {
 func (d *PodFailurePolicyDie) DieReleasePtr() *batchv1.PodFailurePolicy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodFailurePolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2250,6 +2358,15 @@ func (d *PodFailurePolicyRuleDie) DieFeedPtr(r *batchv1.PodFailurePolicyRule) *P
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodFailurePolicyRuleDie) DieFeedDuck(v any) *PodFailurePolicyRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodFailurePolicyRuleDie) DieFeedJSON(j []byte) *PodFailurePolicyRuleDie {
 	r := batchv1.PodFailurePolicyRule{}
@@ -2298,6 +2415,15 @@ func (d *PodFailurePolicyRuleDie) DieRelease() batchv1.PodFailurePolicyRule {
 func (d *PodFailurePolicyRuleDie) DieReleasePtr() *batchv1.PodFailurePolicyRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodFailurePolicyRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2556,6 +2682,15 @@ func (d *PodFailurePolicyOnExitCodesRequirementDie) DieFeedPtr(r *batchv1.PodFai
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodFailurePolicyOnExitCodesRequirementDie) DieFeedDuck(v any) *PodFailurePolicyOnExitCodesRequirementDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodFailurePolicyOnExitCodesRequirementDie) DieFeedJSON(j []byte) *PodFailurePolicyOnExitCodesRequirementDie {
 	r := batchv1.PodFailurePolicyOnExitCodesRequirement{}
@@ -2604,6 +2739,15 @@ func (d *PodFailurePolicyOnExitCodesRequirementDie) DieRelease() batchv1.PodFail
 func (d *PodFailurePolicyOnExitCodesRequirementDie) DieReleasePtr() *batchv1.PodFailurePolicyOnExitCodesRequirement {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodFailurePolicyOnExitCodesRequirementDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2839,6 +2983,15 @@ func (d *PodFailurePolicyOnPodConditionsPatternDie) DieFeedPtr(r *batchv1.PodFai
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodFailurePolicyOnPodConditionsPatternDie) DieFeedDuck(v any) *PodFailurePolicyOnPodConditionsPatternDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodFailurePolicyOnPodConditionsPatternDie) DieFeedJSON(j []byte) *PodFailurePolicyOnPodConditionsPatternDie {
 	r := batchv1.PodFailurePolicyOnPodConditionsPattern{}
@@ -2887,6 +3040,15 @@ func (d *PodFailurePolicyOnPodConditionsPatternDie) DieRelease() batchv1.PodFail
 func (d *PodFailurePolicyOnPodConditionsPatternDie) DieReleasePtr() *batchv1.PodFailurePolicyOnPodConditionsPattern {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodFailurePolicyOnPodConditionsPatternDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3087,6 +3249,15 @@ func (d *SuccessPolicyDie) DieFeedPtr(r *batchv1.SuccessPolicy) *SuccessPolicyDi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SuccessPolicyDie) DieFeedDuck(v any) *SuccessPolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SuccessPolicyDie) DieFeedJSON(j []byte) *SuccessPolicyDie {
 	r := batchv1.SuccessPolicy{}
@@ -3135,6 +3306,15 @@ func (d *SuccessPolicyDie) DieRelease() batchv1.SuccessPolicy {
 func (d *SuccessPolicyDie) DieReleasePtr() *batchv1.SuccessPolicy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SuccessPolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3354,6 +3534,15 @@ func (d *SuccessPolicyRuleDie) DieFeedPtr(r *batchv1.SuccessPolicyRule) *Success
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SuccessPolicyRuleDie) DieFeedDuck(v any) *SuccessPolicyRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SuccessPolicyRuleDie) DieFeedJSON(j []byte) *SuccessPolicyRuleDie {
 	r := batchv1.SuccessPolicyRule{}
@@ -3402,6 +3591,15 @@ func (d *SuccessPolicyRuleDie) DieRelease() batchv1.SuccessPolicyRule {
 func (d *SuccessPolicyRuleDie) DieReleasePtr() *batchv1.SuccessPolicyRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SuccessPolicyRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3634,6 +3832,15 @@ func (d *JobStatusDie) DieFeedPtr(r *batchv1.JobStatus) *JobStatusDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *JobStatusDie) DieFeedDuck(v any) *JobStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *JobStatusDie) DieFeedJSON(j []byte) *JobStatusDie {
 	r := batchv1.JobStatus{}
@@ -3682,6 +3889,15 @@ func (d *JobStatusDie) DieRelease() batchv1.JobStatus {
 func (d *JobStatusDie) DieReleasePtr() *batchv1.JobStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *JobStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4084,6 +4300,15 @@ func (d *UncountedTerminatedPodsDie) DieFeedPtr(r *batchv1.UncountedTerminatedPo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *UncountedTerminatedPodsDie) DieFeedDuck(v any) *UncountedTerminatedPodsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *UncountedTerminatedPodsDie) DieFeedJSON(j []byte) *UncountedTerminatedPodsDie {
 	r := batchv1.UncountedTerminatedPods{}
@@ -4132,6 +4357,15 @@ func (d *UncountedTerminatedPodsDie) DieRelease() batchv1.UncountedTerminatedPod
 func (d *UncountedTerminatedPodsDie) DieReleasePtr() *batchv1.UncountedTerminatedPods {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *UncountedTerminatedPodsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/certificates/v1/zz_generated.die.go
+++ b/apis/certificates/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *CertificateSigningRequestDie) DieFeedPtr(r *certificatesv1.CertificateS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CertificateSigningRequestDie) DieFeedDuck(v any) *CertificateSigningRequestDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CertificateSigningRequestDie) DieFeedJSON(j []byte) *CertificateSigningRequestDie {
 	r := certificatesv1.CertificateSigningRequest{}
@@ -141,6 +150,15 @@ func (d *CertificateSigningRequestDie) DieReleaseUnstructured() *unstructured.Un
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CertificateSigningRequestDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -439,6 +457,15 @@ func (d *CertificateSigningRequestSpecDie) DieFeedPtr(r *certificatesv1.Certific
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CertificateSigningRequestSpecDie) DieFeedDuck(v any) *CertificateSigningRequestSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CertificateSigningRequestSpecDie) DieFeedJSON(j []byte) *CertificateSigningRequestSpecDie {
 	r := certificatesv1.CertificateSigningRequestSpec{}
@@ -487,6 +514,15 @@ func (d *CertificateSigningRequestSpecDie) DieRelease() certificatesv1.Certifica
 func (d *CertificateSigningRequestSpecDie) DieReleasePtr() *certificatesv1.CertificateSigningRequestSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CertificateSigningRequestSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -802,6 +838,15 @@ func (d *CertificateSigningRequestStatusDie) DieFeedPtr(r *certificatesv1.Certif
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CertificateSigningRequestStatusDie) DieFeedDuck(v any) *CertificateSigningRequestStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CertificateSigningRequestStatusDie) DieFeedJSON(j []byte) *CertificateSigningRequestStatusDie {
 	r := certificatesv1.CertificateSigningRequestStatus{}
@@ -850,6 +895,15 @@ func (d *CertificateSigningRequestStatusDie) DieRelease() certificatesv1.Certifi
 func (d *CertificateSigningRequestStatusDie) DieReleasePtr() *certificatesv1.CertificateSigningRequestStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CertificateSigningRequestStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/coordination/v1/zz_generated.die.go
+++ b/apis/coordination/v1/zz_generated.die.go
@@ -81,6 +81,15 @@ func (d *LeaseDie) DieFeedPtr(r *coordinationv1.Lease) *LeaseDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LeaseDie) DieFeedDuck(v any) *LeaseDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LeaseDie) DieFeedJSON(j []byte) *LeaseDie {
 	r := coordinationv1.Lease{}
@@ -141,6 +150,15 @@ func (d *LeaseDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LeaseDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -419,6 +437,15 @@ func (d *LeaseSpecDie) DieFeedPtr(r *coordinationv1.LeaseSpec) *LeaseSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LeaseSpecDie) DieFeedDuck(v any) *LeaseSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LeaseSpecDie) DieFeedJSON(j []byte) *LeaseSpecDie {
 	r := coordinationv1.LeaseSpec{}
@@ -467,6 +494,15 @@ func (d *LeaseSpecDie) DieRelease() coordinationv1.LeaseSpec {
 func (d *LeaseSpecDie) DieReleasePtr() *coordinationv1.LeaseSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LeaseSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/core/v1/zz_generated.die.go
+++ b/apis/core/v1/zz_generated.die.go
@@ -83,6 +83,15 @@ func (d *BindingDie) DieFeedPtr(r *corev1.Binding) *BindingDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *BindingDie) DieFeedDuck(v any) *BindingDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *BindingDie) DieFeedJSON(j []byte) *BindingDie {
 	r := corev1.Binding{}
@@ -143,6 +152,15 @@ func (d *BindingDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *BindingDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -421,6 +439,15 @@ func (d *ObjectReferenceDie) DieFeedPtr(r *corev1.ObjectReference) *ObjectRefere
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ObjectReferenceDie) DieFeedDuck(v any) *ObjectReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ObjectReferenceDie) DieFeedJSON(j []byte) *ObjectReferenceDie {
 	r := corev1.ObjectReference{}
@@ -469,6 +496,15 @@ func (d *ObjectReferenceDie) DieRelease() corev1.ObjectReference {
 func (d *ObjectReferenceDie) DieReleasePtr() *corev1.ObjectReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ObjectReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -722,6 +758,15 @@ func (d *LocalObjectReferenceDie) DieFeedPtr(r *corev1.LocalObjectReference) *Lo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LocalObjectReferenceDie) DieFeedDuck(v any) *LocalObjectReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LocalObjectReferenceDie) DieFeedJSON(j []byte) *LocalObjectReferenceDie {
 	r := corev1.LocalObjectReference{}
@@ -770,6 +815,15 @@ func (d *LocalObjectReferenceDie) DieRelease() corev1.LocalObjectReference {
 func (d *LocalObjectReferenceDie) DieReleasePtr() *corev1.LocalObjectReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LocalObjectReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -967,6 +1021,15 @@ func (d *TypedLocalObjectReferenceDie) DieFeedPtr(r *corev1.TypedLocalObjectRefe
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TypedLocalObjectReferenceDie) DieFeedDuck(v any) *TypedLocalObjectReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TypedLocalObjectReferenceDie) DieFeedJSON(j []byte) *TypedLocalObjectReferenceDie {
 	r := corev1.TypedLocalObjectReference{}
@@ -1015,6 +1078,15 @@ func (d *TypedLocalObjectReferenceDie) DieRelease() corev1.TypedLocalObjectRefer
 func (d *TypedLocalObjectReferenceDie) DieReleasePtr() *corev1.TypedLocalObjectReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TypedLocalObjectReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1220,6 +1292,15 @@ func (d *TypedObjectReferenceDie) DieFeedPtr(r *corev1.TypedObjectReference) *Ty
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TypedObjectReferenceDie) DieFeedDuck(v any) *TypedObjectReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TypedObjectReferenceDie) DieFeedJSON(j []byte) *TypedObjectReferenceDie {
 	r := corev1.TypedObjectReference{}
@@ -1268,6 +1349,15 @@ func (d *TypedObjectReferenceDie) DieRelease() corev1.TypedObjectReference {
 func (d *TypedObjectReferenceDie) DieReleasePtr() *corev1.TypedObjectReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TypedObjectReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1484,6 +1574,15 @@ func (d *SecretReferenceDie) DieFeedPtr(r *corev1.SecretReference) *SecretRefere
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SecretReferenceDie) DieFeedDuck(v any) *SecretReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SecretReferenceDie) DieFeedJSON(j []byte) *SecretReferenceDie {
 	r := corev1.SecretReference{}
@@ -1532,6 +1631,15 @@ func (d *SecretReferenceDie) DieRelease() corev1.SecretReference {
 func (d *SecretReferenceDie) DieReleasePtr() *corev1.SecretReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SecretReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1726,6 +1834,15 @@ func (d *TopologySelectorTermDie) DieFeedPtr(r *corev1.TopologySelectorTerm) *To
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TopologySelectorTermDie) DieFeedDuck(v any) *TopologySelectorTermDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TopologySelectorTermDie) DieFeedJSON(j []byte) *TopologySelectorTermDie {
 	r := corev1.TopologySelectorTerm{}
@@ -1774,6 +1891,15 @@ func (d *TopologySelectorTermDie) DieRelease() corev1.TopologySelectorTerm {
 func (d *TopologySelectorTermDie) DieReleasePtr() *corev1.TopologySelectorTerm {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TopologySelectorTermDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1973,6 +2099,15 @@ func (d *TopologySelectorLabelRequirementDie) DieFeedPtr(r *corev1.TopologySelec
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TopologySelectorLabelRequirementDie) DieFeedDuck(v any) *TopologySelectorLabelRequirementDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TopologySelectorLabelRequirementDie) DieFeedJSON(j []byte) *TopologySelectorLabelRequirementDie {
 	r := corev1.TopologySelectorLabelRequirement{}
@@ -2021,6 +2156,15 @@ func (d *TopologySelectorLabelRequirementDie) DieRelease() corev1.TopologySelect
 func (d *TopologySelectorLabelRequirementDie) DieReleasePtr() *corev1.TopologySelectorLabelRequirement {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TopologySelectorLabelRequirementDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2220,6 +2364,15 @@ func (d *ComponentStatusDie) DieFeedPtr(r *corev1.ComponentStatus) *ComponentSta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ComponentStatusDie) DieFeedDuck(v any) *ComponentStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ComponentStatusDie) DieFeedJSON(j []byte) *ComponentStatusDie {
 	r := corev1.ComponentStatus{}
@@ -2280,6 +2433,15 @@ func (d *ComponentStatusDie) DieReleaseUnstructured() *unstructured.Unstructured
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ComponentStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2550,6 +2712,15 @@ func (d *ConfigMapDie) DieFeedPtr(r *corev1.ConfigMap) *ConfigMapDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ConfigMapDie) DieFeedDuck(v any) *ConfigMapDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ConfigMapDie) DieFeedJSON(j []byte) *ConfigMapDie {
 	r := corev1.ConfigMap{}
@@ -2610,6 +2781,15 @@ func (d *ConfigMapDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ConfigMapDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2883,6 +3063,15 @@ func (d *ContainerDie) DieFeedPtr(r *corev1.Container) *ContainerDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerDie) DieFeedDuck(v any) *ContainerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerDie) DieFeedJSON(j []byte) *ContainerDie {
 	r := corev1.Container{}
@@ -2931,6 +3120,15 @@ func (d *ContainerDie) DieRelease() corev1.Container {
 func (d *ContainerDie) DieReleasePtr() *corev1.Container {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3699,6 +3897,15 @@ func (d *ContainerPortDie) DieFeedPtr(r *corev1.ContainerPort) *ContainerPortDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerPortDie) DieFeedDuck(v any) *ContainerPortDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerPortDie) DieFeedJSON(j []byte) *ContainerPortDie {
 	r := corev1.ContainerPort{}
@@ -3747,6 +3954,15 @@ func (d *ContainerPortDie) DieRelease() corev1.ContainerPort {
 func (d *ContainerPortDie) DieReleasePtr() *corev1.ContainerPort {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerPortDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3976,6 +4192,15 @@ func (d *EnvFromSourceDie) DieFeedPtr(r *corev1.EnvFromSource) *EnvFromSourceDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EnvFromSourceDie) DieFeedDuck(v any) *EnvFromSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EnvFromSourceDie) DieFeedJSON(j []byte) *EnvFromSourceDie {
 	r := corev1.EnvFromSource{}
@@ -4024,6 +4249,15 @@ func (d *EnvFromSourceDie) DieRelease() corev1.EnvFromSource {
 func (d *EnvFromSourceDie) DieReleasePtr() *corev1.EnvFromSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EnvFromSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4247,6 +4481,15 @@ func (d *ConfigMapEnvSourceDie) DieFeedPtr(r *corev1.ConfigMapEnvSource) *Config
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ConfigMapEnvSourceDie) DieFeedDuck(v any) *ConfigMapEnvSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ConfigMapEnvSourceDie) DieFeedJSON(j []byte) *ConfigMapEnvSourceDie {
 	r := corev1.ConfigMapEnvSource{}
@@ -4295,6 +4538,15 @@ func (d *ConfigMapEnvSourceDie) DieRelease() corev1.ConfigMapEnvSource {
 func (d *ConfigMapEnvSourceDie) DieReleasePtr() *corev1.ConfigMapEnvSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ConfigMapEnvSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4489,6 +4741,15 @@ func (d *SecretEnvSourceDie) DieFeedPtr(r *corev1.SecretEnvSource) *SecretEnvSou
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SecretEnvSourceDie) DieFeedDuck(v any) *SecretEnvSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SecretEnvSourceDie) DieFeedJSON(j []byte) *SecretEnvSourceDie {
 	r := corev1.SecretEnvSource{}
@@ -4537,6 +4798,15 @@ func (d *SecretEnvSourceDie) DieRelease() corev1.SecretEnvSource {
 func (d *SecretEnvSourceDie) DieReleasePtr() *corev1.SecretEnvSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SecretEnvSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4731,6 +5001,15 @@ func (d *EnvVarDie) DieFeedPtr(r *corev1.EnvVar) *EnvVarDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EnvVarDie) DieFeedDuck(v any) *EnvVarDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EnvVarDie) DieFeedJSON(j []byte) *EnvVarDie {
 	r := corev1.EnvVar{}
@@ -4779,6 +5058,15 @@ func (d *EnvVarDie) DieRelease() corev1.EnvVar {
 func (d *EnvVarDie) DieReleasePtr() *corev1.EnvVar {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EnvVarDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5007,6 +5295,15 @@ func (d *EnvVarSourceDie) DieFeedPtr(r *corev1.EnvVarSource) *EnvVarSourceDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EnvVarSourceDie) DieFeedDuck(v any) *EnvVarSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EnvVarSourceDie) DieFeedJSON(j []byte) *EnvVarSourceDie {
 	r := corev1.EnvVarSource{}
@@ -5055,6 +5352,15 @@ func (d *EnvVarSourceDie) DieRelease() corev1.EnvVarSource {
 func (d *EnvVarSourceDie) DieReleasePtr() *corev1.EnvVarSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EnvVarSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5315,6 +5621,15 @@ func (d *ObjectFieldSelectorDie) DieFeedPtr(r *corev1.ObjectFieldSelector) *Obje
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ObjectFieldSelectorDie) DieFeedDuck(v any) *ObjectFieldSelectorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ObjectFieldSelectorDie) DieFeedJSON(j []byte) *ObjectFieldSelectorDie {
 	r := corev1.ObjectFieldSelector{}
@@ -5363,6 +5678,15 @@ func (d *ObjectFieldSelectorDie) DieRelease() corev1.ObjectFieldSelector {
 func (d *ObjectFieldSelectorDie) DieReleasePtr() *corev1.ObjectFieldSelector {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ObjectFieldSelectorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5557,6 +5881,15 @@ func (d *ResourceFieldSelectorDie) DieFeedPtr(r *corev1.ResourceFieldSelector) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceFieldSelectorDie) DieFeedDuck(v any) *ResourceFieldSelectorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceFieldSelectorDie) DieFeedJSON(j []byte) *ResourceFieldSelectorDie {
 	r := corev1.ResourceFieldSelector{}
@@ -5605,6 +5938,15 @@ func (d *ResourceFieldSelectorDie) DieRelease() corev1.ResourceFieldSelector {
 func (d *ResourceFieldSelectorDie) DieReleasePtr() *corev1.ResourceFieldSelector {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceFieldSelectorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5814,6 +6156,15 @@ func (d *ConfigMapKeySelectorDie) DieFeedPtr(r *corev1.ConfigMapKeySelector) *Co
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ConfigMapKeySelectorDie) DieFeedDuck(v any) *ConfigMapKeySelectorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ConfigMapKeySelectorDie) DieFeedJSON(j []byte) *ConfigMapKeySelectorDie {
 	r := corev1.ConfigMapKeySelector{}
@@ -5862,6 +6213,15 @@ func (d *ConfigMapKeySelectorDie) DieRelease() corev1.ConfigMapKeySelector {
 func (d *ConfigMapKeySelectorDie) DieReleasePtr() *corev1.ConfigMapKeySelector {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ConfigMapKeySelectorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6063,6 +6423,15 @@ func (d *SecretKeySelectorDie) DieFeedPtr(r *corev1.SecretKeySelector) *SecretKe
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SecretKeySelectorDie) DieFeedDuck(v any) *SecretKeySelectorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SecretKeySelectorDie) DieFeedJSON(j []byte) *SecretKeySelectorDie {
 	r := corev1.SecretKeySelector{}
@@ -6111,6 +6480,15 @@ func (d *SecretKeySelectorDie) DieRelease() corev1.SecretKeySelector {
 func (d *SecretKeySelectorDie) DieReleasePtr() *corev1.SecretKeySelector {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SecretKeySelectorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6312,6 +6690,15 @@ func (d *ResourceRequirementsDie) DieFeedPtr(r *corev1.ResourceRequirements) *Re
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceRequirementsDie) DieFeedDuck(v any) *ResourceRequirementsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceRequirementsDie) DieFeedJSON(j []byte) *ResourceRequirementsDie {
 	r := corev1.ResourceRequirements{}
@@ -6360,6 +6747,15 @@ func (d *ResourceRequirementsDie) DieRelease() corev1.ResourceRequirements {
 func (d *ResourceRequirementsDie) DieReleasePtr() *corev1.ResourceRequirements {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceRequirementsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6681,6 +7077,15 @@ func (d *ResourceClaimDie) DieFeedPtr(r *corev1.ResourceClaim) *ResourceClaimDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceClaimDie) DieFeedDuck(v any) *ResourceClaimDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceClaimDie) DieFeedJSON(j []byte) *ResourceClaimDie {
 	r := corev1.ResourceClaim{}
@@ -6729,6 +7134,15 @@ func (d *ResourceClaimDie) DieRelease() corev1.ResourceClaim {
 func (d *ResourceClaimDie) DieReleasePtr() *corev1.ResourceClaim {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceClaimDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6931,6 +7345,15 @@ func (d *ContainerResizePolicyDie) DieFeedPtr(r *corev1.ContainerResizePolicy) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerResizePolicyDie) DieFeedDuck(v any) *ContainerResizePolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerResizePolicyDie) DieFeedJSON(j []byte) *ContainerResizePolicyDie {
 	r := corev1.ContainerResizePolicy{}
@@ -6979,6 +7402,15 @@ func (d *ContainerResizePolicyDie) DieRelease() corev1.ContainerResizePolicy {
 func (d *ContainerResizePolicyDie) DieReleasePtr() *corev1.ContainerResizePolicy {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerResizePolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -7177,6 +7609,15 @@ func (d *VolumeMountDie) DieFeedPtr(r *corev1.VolumeMount) *VolumeMountDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeMountDie) DieFeedDuck(v any) *VolumeMountDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeMountDie) DieFeedJSON(j []byte) *VolumeMountDie {
 	r := corev1.VolumeMount{}
@@ -7225,6 +7666,15 @@ func (d *VolumeMountDie) DieRelease() corev1.VolumeMount {
 func (d *VolumeMountDie) DieReleasePtr() *corev1.VolumeMount {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeMountDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -7498,6 +7948,15 @@ func (d *VolumeDeviceDie) DieFeedPtr(r *corev1.VolumeDevice) *VolumeDeviceDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeDeviceDie) DieFeedDuck(v any) *VolumeDeviceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeDeviceDie) DieFeedJSON(j []byte) *VolumeDeviceDie {
 	r := corev1.VolumeDevice{}
@@ -7546,6 +8005,15 @@ func (d *VolumeDeviceDie) DieRelease() corev1.VolumeDevice {
 func (d *VolumeDeviceDie) DieReleasePtr() *corev1.VolumeDevice {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeDeviceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -7740,6 +8208,15 @@ func (d *ProbeDie) DieFeedPtr(r *corev1.Probe) *ProbeDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ProbeDie) DieFeedDuck(v any) *ProbeDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ProbeDie) DieFeedJSON(j []byte) *ProbeDie {
 	r := corev1.Probe{}
@@ -7788,6 +8265,15 @@ func (d *ProbeDie) DieRelease() corev1.Probe {
 func (d *ProbeDie) DieReleasePtr() *corev1.Probe {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ProbeDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -8058,6 +8544,15 @@ func (d *LifecycleDie) DieFeedPtr(r *corev1.Lifecycle) *LifecycleDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LifecycleDie) DieFeedDuck(v any) *LifecycleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LifecycleDie) DieFeedJSON(j []byte) *LifecycleDie {
 	r := corev1.Lifecycle{}
@@ -8106,6 +8601,15 @@ func (d *LifecycleDie) DieRelease() corev1.Lifecycle {
 func (d *LifecycleDie) DieReleasePtr() *corev1.Lifecycle {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LifecycleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -8366,6 +8870,15 @@ func (d *LifecycleHandlerDie) DieFeedPtr(r *corev1.LifecycleHandler) *LifecycleH
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LifecycleHandlerDie) DieFeedDuck(v any) *LifecycleHandlerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LifecycleHandlerDie) DieFeedJSON(j []byte) *LifecycleHandlerDie {
 	r := corev1.LifecycleHandler{}
@@ -8414,6 +8927,15 @@ func (d *LifecycleHandlerDie) DieRelease() corev1.LifecycleHandler {
 func (d *LifecycleHandlerDie) DieReleasePtr() *corev1.LifecycleHandler {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LifecycleHandlerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -8674,6 +9196,15 @@ func (d *ProbeHandlerDie) DieFeedPtr(r *corev1.ProbeHandler) *ProbeHandlerDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ProbeHandlerDie) DieFeedDuck(v any) *ProbeHandlerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ProbeHandlerDie) DieFeedJSON(j []byte) *ProbeHandlerDie {
 	r := corev1.ProbeHandler{}
@@ -8722,6 +9253,15 @@ func (d *ProbeHandlerDie) DieRelease() corev1.ProbeHandler {
 func (d *ProbeHandlerDie) DieReleasePtr() *corev1.ProbeHandler {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ProbeHandlerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -8974,6 +9514,15 @@ func (d *ExecActionDie) DieFeedPtr(r *corev1.ExecAction) *ExecActionDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ExecActionDie) DieFeedDuck(v any) *ExecActionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ExecActionDie) DieFeedJSON(j []byte) *ExecActionDie {
 	r := corev1.ExecAction{}
@@ -9022,6 +9571,15 @@ func (d *ExecActionDie) DieRelease() corev1.ExecAction {
 func (d *ExecActionDie) DieReleasePtr() *corev1.ExecAction {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ExecActionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -9217,6 +9775,15 @@ func (d *HTTPGetActionDie) DieFeedPtr(r *corev1.HTTPGetAction) *HTTPGetActionDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HTTPGetActionDie) DieFeedDuck(v any) *HTTPGetActionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HTTPGetActionDie) DieFeedJSON(j []byte) *HTTPGetActionDie {
 	r := corev1.HTTPGetAction{}
@@ -9265,6 +9832,15 @@ func (d *HTTPGetActionDie) DieRelease() corev1.HTTPGetAction {
 func (d *HTTPGetActionDie) DieReleasePtr() *corev1.HTTPGetAction {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HTTPGetActionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -9528,6 +10104,15 @@ func (d *HTTPHeaderDie) DieFeedPtr(r *corev1.HTTPHeader) *HTTPHeaderDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HTTPHeaderDie) DieFeedDuck(v any) *HTTPHeaderDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HTTPHeaderDie) DieFeedJSON(j []byte) *HTTPHeaderDie {
 	r := corev1.HTTPHeader{}
@@ -9576,6 +10161,15 @@ func (d *HTTPHeaderDie) DieRelease() corev1.HTTPHeader {
 func (d *HTTPHeaderDie) DieReleasePtr() *corev1.HTTPHeader {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HTTPHeaderDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -9772,6 +10366,15 @@ func (d *TCPSocketActionDie) DieFeedPtr(r *corev1.TCPSocketAction) *TCPSocketAct
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TCPSocketActionDie) DieFeedDuck(v any) *TCPSocketActionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TCPSocketActionDie) DieFeedJSON(j []byte) *TCPSocketActionDie {
 	r := corev1.TCPSocketAction{}
@@ -9820,6 +10423,15 @@ func (d *TCPSocketActionDie) DieRelease() corev1.TCPSocketAction {
 func (d *TCPSocketActionDie) DieReleasePtr() *corev1.TCPSocketAction {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TCPSocketActionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -10046,6 +10658,15 @@ func (d *GRPCActionDie) DieFeedPtr(r *corev1.GRPCAction) *GRPCActionDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GRPCActionDie) DieFeedDuck(v any) *GRPCActionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GRPCActionDie) DieFeedJSON(j []byte) *GRPCActionDie {
 	r := corev1.GRPCAction{}
@@ -10094,6 +10715,15 @@ func (d *GRPCActionDie) DieRelease() corev1.GRPCAction {
 func (d *GRPCActionDie) DieReleasePtr() *corev1.GRPCAction {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GRPCActionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -10292,6 +10922,15 @@ func (d *SleepActionDie) DieFeedPtr(r *corev1.SleepAction) *SleepActionDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SleepActionDie) DieFeedDuck(v any) *SleepActionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SleepActionDie) DieFeedJSON(j []byte) *SleepActionDie {
 	r := corev1.SleepAction{}
@@ -10340,6 +10979,15 @@ func (d *SleepActionDie) DieRelease() corev1.SleepAction {
 func (d *SleepActionDie) DieReleasePtr() *corev1.SleepAction {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SleepActionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -10527,6 +11175,15 @@ func (d *SecurityContextDie) DieFeedPtr(r *corev1.SecurityContext) *SecurityCont
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SecurityContextDie) DieFeedDuck(v any) *SecurityContextDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SecurityContextDie) DieFeedJSON(j []byte) *SecurityContextDie {
 	r := corev1.SecurityContext{}
@@ -10575,6 +11232,15 @@ func (d *SecurityContextDie) DieRelease() corev1.SecurityContext {
 func (d *SecurityContextDie) DieReleasePtr() *corev1.SecurityContext {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SecurityContextDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -11006,6 +11672,15 @@ func (d *CapabilitiesDie) DieFeedPtr(r *corev1.Capabilities) *CapabilitiesDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CapabilitiesDie) DieFeedDuck(v any) *CapabilitiesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CapabilitiesDie) DieFeedJSON(j []byte) *CapabilitiesDie {
 	r := corev1.Capabilities{}
@@ -11054,6 +11729,15 @@ func (d *CapabilitiesDie) DieRelease() corev1.Capabilities {
 func (d *CapabilitiesDie) DieReleasePtr() *corev1.Capabilities {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CapabilitiesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -11248,6 +11932,15 @@ func (d *SELinuxOptionsDie) DieFeedPtr(r *corev1.SELinuxOptions) *SELinuxOptions
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SELinuxOptionsDie) DieFeedDuck(v any) *SELinuxOptionsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SELinuxOptionsDie) DieFeedJSON(j []byte) *SELinuxOptionsDie {
 	r := corev1.SELinuxOptions{}
@@ -11296,6 +11989,15 @@ func (d *SELinuxOptionsDie) DieRelease() corev1.SELinuxOptions {
 func (d *SELinuxOptionsDie) DieReleasePtr() *corev1.SELinuxOptions {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SELinuxOptionsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -11504,6 +12206,15 @@ func (d *WindowsSecurityContextOptionsDie) DieFeedPtr(r *corev1.WindowsSecurityC
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *WindowsSecurityContextOptionsDie) DieFeedDuck(v any) *WindowsSecurityContextOptionsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *WindowsSecurityContextOptionsDie) DieFeedJSON(j []byte) *WindowsSecurityContextOptionsDie {
 	r := corev1.WindowsSecurityContextOptions{}
@@ -11552,6 +12263,15 @@ func (d *WindowsSecurityContextOptionsDie) DieRelease() corev1.WindowsSecurityCo
 func (d *WindowsSecurityContextOptionsDie) DieReleasePtr() *corev1.WindowsSecurityContextOptions {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *WindowsSecurityContextOptionsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -11776,6 +12496,15 @@ func (d *SeccompProfileDie) DieFeedPtr(r *corev1.SeccompProfile) *SeccompProfile
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SeccompProfileDie) DieFeedDuck(v any) *SeccompProfileDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SeccompProfileDie) DieFeedJSON(j []byte) *SeccompProfileDie {
 	r := corev1.SeccompProfile{}
@@ -11824,6 +12553,15 @@ func (d *SeccompProfileDie) DieRelease() corev1.SeccompProfile {
 func (d *SeccompProfileDie) DieReleasePtr() *corev1.SeccompProfile {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SeccompProfileDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -12032,6 +12770,15 @@ func (d *AppArmorProfileDie) DieFeedPtr(r *corev1.AppArmorProfile) *AppArmorProf
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AppArmorProfileDie) DieFeedDuck(v any) *AppArmorProfileDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AppArmorProfileDie) DieFeedJSON(j []byte) *AppArmorProfileDie {
 	r := corev1.AppArmorProfile{}
@@ -12080,6 +12827,15 @@ func (d *AppArmorProfileDie) DieRelease() corev1.AppArmorProfile {
 func (d *AppArmorProfileDie) DieReleasePtr() *corev1.AppArmorProfile {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AppArmorProfileDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -12288,6 +13044,15 @@ func (d *ContainerStatusDie) DieFeedPtr(r *corev1.ContainerStatus) *ContainerSta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerStatusDie) DieFeedDuck(v any) *ContainerStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerStatusDie) DieFeedJSON(j []byte) *ContainerStatusDie {
 	r := corev1.ContainerStatus{}
@@ -12336,6 +13101,15 @@ func (d *ContainerStatusDie) DieRelease() corev1.ContainerStatus {
 func (d *ContainerStatusDie) DieReleasePtr() *corev1.ContainerStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -12794,6 +13568,15 @@ func (d *ContainerUserDie) DieFeedPtr(r *corev1.ContainerUser) *ContainerUserDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerUserDie) DieFeedDuck(v any) *ContainerUserDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerUserDie) DieFeedJSON(j []byte) *ContainerUserDie {
 	r := corev1.ContainerUser{}
@@ -12842,6 +13625,15 @@ func (d *ContainerUserDie) DieRelease() corev1.ContainerUser {
 func (d *ContainerUserDie) DieReleasePtr() *corev1.ContainerUser {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerUserDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -13044,6 +13836,15 @@ func (d *LinuxContainerUserDie) DieFeedPtr(r *corev1.LinuxContainerUser) *LinuxC
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LinuxContainerUserDie) DieFeedDuck(v any) *LinuxContainerUserDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LinuxContainerUserDie) DieFeedJSON(j []byte) *LinuxContainerUserDie {
 	r := corev1.LinuxContainerUser{}
@@ -13092,6 +13893,15 @@ func (d *LinuxContainerUserDie) DieRelease() corev1.LinuxContainerUser {
 func (d *LinuxContainerUserDie) DieReleasePtr() *corev1.LinuxContainerUser {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LinuxContainerUserDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -13293,6 +14103,15 @@ func (d *ResourceStatusDie) DieFeedPtr(r *corev1.ResourceStatus) *ResourceStatus
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceStatusDie) DieFeedDuck(v any) *ResourceStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceStatusDie) DieFeedJSON(j []byte) *ResourceStatusDie {
 	r := corev1.ResourceStatus{}
@@ -13341,6 +14160,15 @@ func (d *ResourceStatusDie) DieRelease() corev1.ResourceStatus {
 func (d *ResourceStatusDie) DieReleasePtr() *corev1.ResourceStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -13571,6 +14399,15 @@ func (d *ResourceHealthDie) DieFeedPtr(r *corev1.ResourceHealth) *ResourceHealth
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceHealthDie) DieFeedDuck(v any) *ResourceHealthDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceHealthDie) DieFeedJSON(j []byte) *ResourceHealthDie {
 	r := corev1.ResourceHealth{}
@@ -13619,6 +14456,15 @@ func (d *ResourceHealthDie) DieRelease() corev1.ResourceHealth {
 func (d *ResourceHealthDie) DieReleasePtr() *corev1.ResourceHealth {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceHealthDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -13829,6 +14675,15 @@ func (d *ContainerStateDie) DieFeedPtr(r *corev1.ContainerState) *ContainerState
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerStateDie) DieFeedDuck(v any) *ContainerStateDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerStateDie) DieFeedJSON(j []byte) *ContainerStateDie {
 	r := corev1.ContainerState{}
@@ -13877,6 +14732,15 @@ func (d *ContainerStateDie) DieRelease() corev1.ContainerState {
 func (d *ContainerStateDie) DieReleasePtr() *corev1.ContainerState {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerStateDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -14111,6 +14975,15 @@ func (d *ContainerStateWaitingDie) DieFeedPtr(r *corev1.ContainerStateWaiting) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerStateWaitingDie) DieFeedDuck(v any) *ContainerStateWaitingDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerStateWaitingDie) DieFeedJSON(j []byte) *ContainerStateWaitingDie {
 	r := corev1.ContainerStateWaiting{}
@@ -14159,6 +15032,15 @@ func (d *ContainerStateWaitingDie) DieRelease() corev1.ContainerStateWaiting {
 func (d *ContainerStateWaitingDie) DieReleasePtr() *corev1.ContainerStateWaiting {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerStateWaitingDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -14353,6 +15235,15 @@ func (d *ContainerStateRunningDie) DieFeedPtr(r *corev1.ContainerStateRunning) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerStateRunningDie) DieFeedDuck(v any) *ContainerStateRunningDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerStateRunningDie) DieFeedJSON(j []byte) *ContainerStateRunningDie {
 	r := corev1.ContainerStateRunning{}
@@ -14401,6 +15292,15 @@ func (d *ContainerStateRunningDie) DieRelease() corev1.ContainerStateRunning {
 func (d *ContainerStateRunningDie) DieReleasePtr() *corev1.ContainerStateRunning {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerStateRunningDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -14588,6 +15488,15 @@ func (d *ContainerStateTerminatedDie) DieFeedPtr(r *corev1.ContainerStateTermina
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerStateTerminatedDie) DieFeedDuck(v any) *ContainerStateTerminatedDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerStateTerminatedDie) DieFeedJSON(j []byte) *ContainerStateTerminatedDie {
 	r := corev1.ContainerStateTerminated{}
@@ -14636,6 +15545,15 @@ func (d *ContainerStateTerminatedDie) DieRelease() corev1.ContainerStateTerminat
 func (d *ContainerStateTerminatedDie) DieReleasePtr() *corev1.ContainerStateTerminated {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerStateTerminatedDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -14865,6 +15783,15 @@ func (d *VolumeMountStatusDie) DieFeedPtr(r *corev1.VolumeMountStatus) *VolumeMo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeMountStatusDie) DieFeedDuck(v any) *VolumeMountStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeMountStatusDie) DieFeedJSON(j []byte) *VolumeMountStatusDie {
 	r := corev1.VolumeMountStatus{}
@@ -14913,6 +15840,15 @@ func (d *VolumeMountStatusDie) DieRelease() corev1.VolumeMountStatus {
 func (d *VolumeMountStatusDie) DieReleasePtr() *corev1.VolumeMountStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeMountStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -15128,6 +16064,15 @@ func (d *EndpointsDie) DieFeedPtr(r *corev1.Endpoints) *EndpointsDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointsDie) DieFeedDuck(v any) *EndpointsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointsDie) DieFeedJSON(j []byte) *EndpointsDie {
 	r := corev1.Endpoints{}
@@ -15188,6 +16133,15 @@ func (d *EndpointsDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -15491,6 +16445,15 @@ func (d *EndpointSubsetDie) DieFeedPtr(r *corev1.EndpointSubset) *EndpointSubset
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointSubsetDie) DieFeedDuck(v any) *EndpointSubsetDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointSubsetDie) DieFeedJSON(j []byte) *EndpointSubsetDie {
 	r := corev1.EndpointSubset{}
@@ -15539,6 +16502,15 @@ func (d *EndpointSubsetDie) DieRelease() corev1.EndpointSubset {
 func (d *EndpointSubsetDie) DieReleasePtr() *corev1.EndpointSubset {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointSubsetDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -15788,6 +16760,15 @@ func (d *EndpointAddressDie) DieFeedPtr(r *corev1.EndpointAddress) *EndpointAddr
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointAddressDie) DieFeedDuck(v any) *EndpointAddressDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointAddressDie) DieFeedJSON(j []byte) *EndpointAddressDie {
 	r := corev1.EndpointAddress{}
@@ -15836,6 +16817,15 @@ func (d *EndpointAddressDie) DieRelease() corev1.EndpointAddress {
 func (d *EndpointAddressDie) DieReleasePtr() *corev1.EndpointAddress {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointAddressDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -16059,6 +17049,15 @@ func (d *EndpointPortDie) DieFeedPtr(r *corev1.EndpointPort) *EndpointPortDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointPortDie) DieFeedDuck(v any) *EndpointPortDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointPortDie) DieFeedJSON(j []byte) *EndpointPortDie {
 	r := corev1.EndpointPort{}
@@ -16107,6 +17106,15 @@ func (d *EndpointPortDie) DieRelease() corev1.EndpointPort {
 func (d *EndpointPortDie) DieReleasePtr() *corev1.EndpointPort {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointPortDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -16350,6 +17358,15 @@ func (d *EventDie) DieFeedPtr(r *corev1.Event) *EventDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EventDie) DieFeedDuck(v any) *EventDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EventDie) DieFeedJSON(j []byte) *EventDie {
 	r := corev1.Event{}
@@ -16410,6 +17427,15 @@ func (d *EventDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EventDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -16818,6 +17844,15 @@ func (d *EventSourceDie) DieFeedPtr(r *corev1.EventSource) *EventSourceDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EventSourceDie) DieFeedDuck(v any) *EventSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EventSourceDie) DieFeedJSON(j []byte) *EventSourceDie {
 	r := corev1.EventSource{}
@@ -16866,6 +17901,15 @@ func (d *EventSourceDie) DieRelease() corev1.EventSource {
 func (d *EventSourceDie) DieReleasePtr() *corev1.EventSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EventSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -17060,6 +18104,15 @@ func (d *EventSeriesDie) DieFeedPtr(r *corev1.EventSeries) *EventSeriesDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EventSeriesDie) DieFeedDuck(v any) *EventSeriesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EventSeriesDie) DieFeedJSON(j []byte) *EventSeriesDie {
 	r := corev1.EventSeries{}
@@ -17108,6 +18161,15 @@ func (d *EventSeriesDie) DieRelease() corev1.EventSeries {
 func (d *EventSeriesDie) DieReleasePtr() *corev1.EventSeries {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EventSeriesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -17305,6 +18367,15 @@ func (d *LimitRangeDie) DieFeedPtr(r *corev1.LimitRange) *LimitRangeDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LimitRangeDie) DieFeedDuck(v any) *LimitRangeDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LimitRangeDie) DieFeedJSON(j []byte) *LimitRangeDie {
 	r := corev1.LimitRange{}
@@ -17365,6 +18436,15 @@ func (d *LimitRangeDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LimitRangeDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -17643,6 +18723,15 @@ func (d *LimitRangeSpecDie) DieFeedPtr(r *corev1.LimitRangeSpec) *LimitRangeSpec
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LimitRangeSpecDie) DieFeedDuck(v any) *LimitRangeSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LimitRangeSpecDie) DieFeedJSON(j []byte) *LimitRangeSpecDie {
 	r := corev1.LimitRangeSpec{}
@@ -17691,6 +18780,15 @@ func (d *LimitRangeSpecDie) DieRelease() corev1.LimitRangeSpec {
 func (d *LimitRangeSpecDie) DieReleasePtr() *corev1.LimitRangeSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LimitRangeSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -17890,6 +18988,15 @@ func (d *LimitRangeItemDie) DieFeedPtr(r *corev1.LimitRangeItem) *LimitRangeItem
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LimitRangeItemDie) DieFeedDuck(v any) *LimitRangeItemDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LimitRangeItemDie) DieFeedJSON(j []byte) *LimitRangeItemDie {
 	r := corev1.LimitRangeItem{}
@@ -17938,6 +19045,15 @@ func (d *LimitRangeItemDie) DieRelease() corev1.LimitRangeItem {
 func (d *LimitRangeItemDie) DieReleasePtr() *corev1.LimitRangeItem {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LimitRangeItemDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -18263,6 +19379,15 @@ func (d *NamespaceDie) DieFeedPtr(r *corev1.Namespace) *NamespaceDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NamespaceDie) DieFeedDuck(v any) *NamespaceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NamespaceDie) DieFeedJSON(j []byte) *NamespaceDie {
 	r := corev1.Namespace{}
@@ -18323,6 +19448,15 @@ func (d *NamespaceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NamespaceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -18619,6 +19753,15 @@ func (d *NamespaceSpecDie) DieFeedPtr(r *corev1.NamespaceSpec) *NamespaceSpecDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NamespaceSpecDie) DieFeedDuck(v any) *NamespaceSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NamespaceSpecDie) DieFeedJSON(j []byte) *NamespaceSpecDie {
 	r := corev1.NamespaceSpec{}
@@ -18667,6 +19810,15 @@ func (d *NamespaceSpecDie) DieRelease() corev1.NamespaceSpec {
 func (d *NamespaceSpecDie) DieReleasePtr() *corev1.NamespaceSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NamespaceSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -18856,6 +20008,15 @@ func (d *NamespaceStatusDie) DieFeedPtr(r *corev1.NamespaceStatus) *NamespaceSta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NamespaceStatusDie) DieFeedDuck(v any) *NamespaceStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NamespaceStatusDie) DieFeedJSON(j []byte) *NamespaceStatusDie {
 	r := corev1.NamespaceStatus{}
@@ -18904,6 +20065,15 @@ func (d *NamespaceStatusDie) DieRelease() corev1.NamespaceStatus {
 func (d *NamespaceStatusDie) DieReleasePtr() *corev1.NamespaceStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NamespaceStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -19103,6 +20273,15 @@ func (d *NodeDie) DieFeedPtr(r *corev1.Node) *NodeDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeDie) DieFeedDuck(v any) *NodeDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeDie) DieFeedJSON(j []byte) *NodeDie {
 	r := corev1.Node{}
@@ -19163,6 +20342,15 @@ func (d *NodeDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -19463,6 +20651,15 @@ func (d *NodeSpecDie) DieFeedPtr(r *corev1.NodeSpec) *NodeSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeSpecDie) DieFeedDuck(v any) *NodeSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeSpecDie) DieFeedJSON(j []byte) *NodeSpecDie {
 	r := corev1.NodeSpec{}
@@ -19511,6 +20708,15 @@ func (d *NodeSpecDie) DieRelease() corev1.NodeSpec {
 func (d *NodeSpecDie) DieReleasePtr() *corev1.NodeSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -19779,6 +20985,15 @@ func (d *TaintDie) DieFeedPtr(r *corev1.Taint) *TaintDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TaintDie) DieFeedDuck(v any) *TaintDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TaintDie) DieFeedJSON(j []byte) *TaintDie {
 	r := corev1.Taint{}
@@ -19827,6 +21042,15 @@ func (d *TaintDie) DieRelease() corev1.Taint {
 func (d *TaintDie) DieReleasePtr() *corev1.Taint {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TaintDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -20041,6 +21265,15 @@ func (d *NodeConfigSourceDie) DieFeedPtr(r *corev1.NodeConfigSource) *NodeConfig
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeConfigSourceDie) DieFeedDuck(v any) *NodeConfigSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeConfigSourceDie) DieFeedJSON(j []byte) *NodeConfigSourceDie {
 	r := corev1.NodeConfigSource{}
@@ -20089,6 +21322,15 @@ func (d *NodeConfigSourceDie) DieRelease() corev1.NodeConfigSource {
 func (d *NodeConfigSourceDie) DieReleasePtr() *corev1.NodeConfigSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeConfigSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -20287,6 +21529,15 @@ func (d *ConfigMapNodeConfigSourceDie) DieFeedPtr(r *corev1.ConfigMapNodeConfigS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ConfigMapNodeConfigSourceDie) DieFeedDuck(v any) *ConfigMapNodeConfigSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ConfigMapNodeConfigSourceDie) DieFeedJSON(j []byte) *ConfigMapNodeConfigSourceDie {
 	r := corev1.ConfigMapNodeConfigSource{}
@@ -20335,6 +21586,15 @@ func (d *ConfigMapNodeConfigSourceDie) DieRelease() corev1.ConfigMapNodeConfigSo
 func (d *ConfigMapNodeConfigSourceDie) DieReleasePtr() *corev1.ConfigMapNodeConfigSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ConfigMapNodeConfigSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -20560,6 +21820,15 @@ func (d *NodeStatusDie) DieFeedPtr(r *corev1.NodeStatus) *NodeStatusDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeStatusDie) DieFeedDuck(v any) *NodeStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeStatusDie) DieFeedJSON(j []byte) *NodeStatusDie {
 	r := corev1.NodeStatus{}
@@ -20608,6 +21877,15 @@ func (d *NodeStatusDie) DieRelease() corev1.NodeStatus {
 func (d *NodeStatusDie) DieReleasePtr() *corev1.NodeStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -21077,6 +22355,15 @@ func (d *NodeAddressDie) DieFeedPtr(r *corev1.NodeAddress) *NodeAddressDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeAddressDie) DieFeedDuck(v any) *NodeAddressDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeAddressDie) DieFeedJSON(j []byte) *NodeAddressDie {
 	r := corev1.NodeAddress{}
@@ -21125,6 +22412,15 @@ func (d *NodeAddressDie) DieRelease() corev1.NodeAddress {
 func (d *NodeAddressDie) DieReleasePtr() *corev1.NodeAddress {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeAddressDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -21319,6 +22615,15 @@ func (d *NodeDaemonEndpointsDie) DieFeedPtr(r *corev1.NodeDaemonEndpoints) *Node
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeDaemonEndpointsDie) DieFeedDuck(v any) *NodeDaemonEndpointsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeDaemonEndpointsDie) DieFeedJSON(j []byte) *NodeDaemonEndpointsDie {
 	r := corev1.NodeDaemonEndpoints{}
@@ -21367,6 +22672,15 @@ func (d *NodeDaemonEndpointsDie) DieRelease() corev1.NodeDaemonEndpoints {
 func (d *NodeDaemonEndpointsDie) DieReleasePtr() *corev1.NodeDaemonEndpoints {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeDaemonEndpointsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -21565,6 +22879,15 @@ func (d *DaemonEndpointDie) DieFeedPtr(r *corev1.DaemonEndpoint) *DaemonEndpoint
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DaemonEndpointDie) DieFeedDuck(v any) *DaemonEndpointDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DaemonEndpointDie) DieFeedJSON(j []byte) *DaemonEndpointDie {
 	r := corev1.DaemonEndpoint{}
@@ -21613,6 +22936,15 @@ func (d *DaemonEndpointDie) DieRelease() corev1.DaemonEndpoint {
 func (d *DaemonEndpointDie) DieReleasePtr() *corev1.DaemonEndpoint {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DaemonEndpointDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -21800,6 +23132,15 @@ func (d *NodeSystemInfoDie) DieFeedPtr(r *corev1.NodeSystemInfo) *NodeSystemInfo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeSystemInfoDie) DieFeedDuck(v any) *NodeSystemInfoDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeSystemInfoDie) DieFeedJSON(j []byte) *NodeSystemInfoDie {
 	r := corev1.NodeSystemInfo{}
@@ -21848,6 +23189,15 @@ func (d *NodeSystemInfoDie) DieRelease() corev1.NodeSystemInfo {
 func (d *NodeSystemInfoDie) DieReleasePtr() *corev1.NodeSystemInfo {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeSystemInfoDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -22106,6 +23456,15 @@ func (d *ContainerImageDie) DieFeedPtr(r *corev1.ContainerImage) *ContainerImage
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ContainerImageDie) DieFeedDuck(v any) *ContainerImageDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ContainerImageDie) DieFeedJSON(j []byte) *ContainerImageDie {
 	r := corev1.ContainerImage{}
@@ -22154,6 +23513,15 @@ func (d *ContainerImageDie) DieRelease() corev1.ContainerImage {
 func (d *ContainerImageDie) DieReleasePtr() *corev1.ContainerImage {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ContainerImageDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -22350,6 +23718,15 @@ func (d *AttachedVolumeDie) DieFeedPtr(r *corev1.AttachedVolume) *AttachedVolume
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AttachedVolumeDie) DieFeedDuck(v any) *AttachedVolumeDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AttachedVolumeDie) DieFeedJSON(j []byte) *AttachedVolumeDie {
 	r := corev1.AttachedVolume{}
@@ -22398,6 +23775,15 @@ func (d *AttachedVolumeDie) DieRelease() corev1.AttachedVolume {
 func (d *AttachedVolumeDie) DieReleasePtr() *corev1.AttachedVolume {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AttachedVolumeDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -22592,6 +23978,15 @@ func (d *NodeConfigStatusDie) DieFeedPtr(r *corev1.NodeConfigStatus) *NodeConfig
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeConfigStatusDie) DieFeedDuck(v any) *NodeConfigStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeConfigStatusDie) DieFeedJSON(j []byte) *NodeConfigStatusDie {
 	r := corev1.NodeConfigStatus{}
@@ -22640,6 +24035,15 @@ func (d *NodeConfigStatusDie) DieRelease() corev1.NodeConfigStatus {
 func (d *NodeConfigStatusDie) DieReleasePtr() *corev1.NodeConfigStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeConfigStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -22983,6 +24387,15 @@ func (d *NodeRuntimeHandlerDie) DieFeedPtr(r *corev1.NodeRuntimeHandler) *NodeRu
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeRuntimeHandlerDie) DieFeedDuck(v any) *NodeRuntimeHandlerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeRuntimeHandlerDie) DieFeedJSON(j []byte) *NodeRuntimeHandlerDie {
 	r := corev1.NodeRuntimeHandler{}
@@ -23031,6 +24444,15 @@ func (d *NodeRuntimeHandlerDie) DieRelease() corev1.NodeRuntimeHandler {
 func (d *NodeRuntimeHandlerDie) DieReleasePtr() *corev1.NodeRuntimeHandler {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeRuntimeHandlerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -23238,6 +24660,15 @@ func (d *NodeRuntimeHandlerFeaturesDie) DieFeedPtr(r *corev1.NodeRuntimeHandlerF
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeRuntimeHandlerFeaturesDie) DieFeedDuck(v any) *NodeRuntimeHandlerFeaturesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeRuntimeHandlerFeaturesDie) DieFeedJSON(j []byte) *NodeRuntimeHandlerFeaturesDie {
 	r := corev1.NodeRuntimeHandlerFeatures{}
@@ -23286,6 +24717,15 @@ func (d *NodeRuntimeHandlerFeaturesDie) DieRelease() corev1.NodeRuntimeHandlerFe
 func (d *NodeRuntimeHandlerFeaturesDie) DieReleasePtr() *corev1.NodeRuntimeHandlerFeatures {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeRuntimeHandlerFeaturesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -23480,6 +24920,15 @@ func (d *NodeFeaturesDie) DieFeedPtr(r *corev1.NodeFeatures) *NodeFeaturesDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeFeaturesDie) DieFeedDuck(v any) *NodeFeaturesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeFeaturesDie) DieFeedJSON(j []byte) *NodeFeaturesDie {
 	r := corev1.NodeFeatures{}
@@ -23528,6 +24977,15 @@ func (d *NodeFeaturesDie) DieRelease() corev1.NodeFeatures {
 func (d *NodeFeaturesDie) DieReleasePtr() *corev1.NodeFeatures {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeFeaturesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -23718,6 +25176,15 @@ func (d *PersistentVolumeDie) DieFeedPtr(r *corev1.PersistentVolume) *Persistent
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeDie) DieFeedDuck(v any) *PersistentVolumeDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeDie) DieFeedJSON(j []byte) *PersistentVolumeDie {
 	r := corev1.PersistentVolume{}
@@ -23778,6 +25245,15 @@ func (d *PersistentVolumeDie) DieReleaseUnstructured() *unstructured.Unstructure
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -24080,6 +25556,15 @@ func (d *PersistentVolumeSpecDie) DieFeedPtr(r *corev1.PersistentVolumeSpec) *Pe
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeSpecDie) DieFeedDuck(v any) *PersistentVolumeSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeSpecDie) DieFeedJSON(j []byte) *PersistentVolumeSpecDie {
 	r := corev1.PersistentVolumeSpec{}
@@ -24128,6 +25613,15 @@ func (d *PersistentVolumeSpecDie) DieRelease() corev1.PersistentVolumeSpec {
 func (d *PersistentVolumeSpecDie) DieReleasePtr() *corev1.PersistentVolumeSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -24455,6 +25949,15 @@ func (d *PersistentVolumeStatusDie) DieFeedPtr(r *corev1.PersistentVolumeStatus)
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeStatusDie) DieFeedDuck(v any) *PersistentVolumeStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeStatusDie) DieFeedJSON(j []byte) *PersistentVolumeStatusDie {
 	r := corev1.PersistentVolumeStatus{}
@@ -24503,6 +26006,15 @@ func (d *PersistentVolumeStatusDie) DieRelease() corev1.PersistentVolumeStatus {
 func (d *PersistentVolumeStatusDie) DieReleasePtr() *corev1.PersistentVolumeStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -24717,6 +26229,15 @@ func (d *GlusterfsPersistentVolumeSourceDie) DieFeedPtr(r *corev1.GlusterfsPersi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GlusterfsPersistentVolumeSourceDie) DieFeedDuck(v any) *GlusterfsPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GlusterfsPersistentVolumeSourceDie) DieFeedJSON(j []byte) *GlusterfsPersistentVolumeSourceDie {
 	r := corev1.GlusterfsPersistentVolumeSource{}
@@ -24765,6 +26286,15 @@ func (d *GlusterfsPersistentVolumeSourceDie) DieRelease() corev1.GlusterfsPersis
 func (d *GlusterfsPersistentVolumeSourceDie) DieReleasePtr() *corev1.GlusterfsPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GlusterfsPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -24985,6 +26515,15 @@ func (d *RBDPersistentVolumeSourceDie) DieFeedPtr(r *corev1.RBDPersistentVolumeS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RBDPersistentVolumeSourceDie) DieFeedDuck(v any) *RBDPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RBDPersistentVolumeSourceDie) DieFeedJSON(j []byte) *RBDPersistentVolumeSourceDie {
 	r := corev1.RBDPersistentVolumeSource{}
@@ -25033,6 +26572,15 @@ func (d *RBDPersistentVolumeSourceDie) DieRelease() corev1.RBDPersistentVolumeSo
 func (d *RBDPersistentVolumeSourceDie) DieReleasePtr() *corev1.RBDPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RBDPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -25320,6 +26868,15 @@ func (d *ISCSIPersistentVolumeSourceDie) DieFeedPtr(r *corev1.ISCSIPersistentVol
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ISCSIPersistentVolumeSourceDie) DieFeedDuck(v any) *ISCSIPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ISCSIPersistentVolumeSourceDie) DieFeedJSON(j []byte) *ISCSIPersistentVolumeSourceDie {
 	r := corev1.ISCSIPersistentVolumeSource{}
@@ -25368,6 +26925,15 @@ func (d *ISCSIPersistentVolumeSourceDie) DieRelease() corev1.ISCSIPersistentVolu
 func (d *ISCSIPersistentVolumeSourceDie) DieReleasePtr() *corev1.ISCSIPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ISCSIPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -25656,6 +27222,15 @@ func (d *CinderPersistentVolumeSourceDie) DieFeedPtr(r *corev1.CinderPersistentV
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CinderPersistentVolumeSourceDie) DieFeedDuck(v any) *CinderPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CinderPersistentVolumeSourceDie) DieFeedJSON(j []byte) *CinderPersistentVolumeSourceDie {
 	r := corev1.CinderPersistentVolumeSource{}
@@ -25704,6 +27279,15 @@ func (d *CinderPersistentVolumeSourceDie) DieRelease() corev1.CinderPersistentVo
 func (d *CinderPersistentVolumeSourceDie) DieReleasePtr() *corev1.CinderPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CinderPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -25939,6 +27523,15 @@ func (d *CephFSPersistentVolumeSourceDie) DieFeedPtr(r *corev1.CephFSPersistentV
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CephFSPersistentVolumeSourceDie) DieFeedDuck(v any) *CephFSPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CephFSPersistentVolumeSourceDie) DieFeedJSON(j []byte) *CephFSPersistentVolumeSourceDie {
 	r := corev1.CephFSPersistentVolumeSource{}
@@ -25987,6 +27580,15 @@ func (d *CephFSPersistentVolumeSourceDie) DieRelease() corev1.CephFSPersistentVo
 func (d *CephFSPersistentVolumeSourceDie) DieReleasePtr() *corev1.CephFSPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CephFSPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -26234,6 +27836,15 @@ func (d *FlexPersistentVolumeSourceDie) DieFeedPtr(r *corev1.FlexPersistentVolum
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FlexPersistentVolumeSourceDie) DieFeedDuck(v any) *FlexPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FlexPersistentVolumeSourceDie) DieFeedJSON(j []byte) *FlexPersistentVolumeSourceDie {
 	r := corev1.FlexPersistentVolumeSource{}
@@ -26282,6 +27893,15 @@ func (d *FlexPersistentVolumeSourceDie) DieRelease() corev1.FlexPersistentVolume
 func (d *FlexPersistentVolumeSourceDie) DieReleasePtr() *corev1.FlexPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FlexPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -26530,6 +28150,15 @@ func (d *AzureFilePersistentVolumeSourceDie) DieFeedPtr(r *corev1.AzureFilePersi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AzureFilePersistentVolumeSourceDie) DieFeedDuck(v any) *AzureFilePersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AzureFilePersistentVolumeSourceDie) DieFeedJSON(j []byte) *AzureFilePersistentVolumeSourceDie {
 	r := corev1.AzureFilePersistentVolumeSource{}
@@ -26578,6 +28207,15 @@ func (d *AzureFilePersistentVolumeSourceDie) DieRelease() corev1.AzureFilePersis
 func (d *AzureFilePersistentVolumeSourceDie) DieReleasePtr() *corev1.AzureFilePersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AzureFilePersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -26790,6 +28428,15 @@ func (d *ScaleIOPersistentVolumeSourceDie) DieFeedPtr(r *corev1.ScaleIOPersisten
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ScaleIOPersistentVolumeSourceDie) DieFeedDuck(v any) *ScaleIOPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ScaleIOPersistentVolumeSourceDie) DieFeedJSON(j []byte) *ScaleIOPersistentVolumeSourceDie {
 	r := corev1.ScaleIOPersistentVolumeSource{}
@@ -26838,6 +28485,15 @@ func (d *ScaleIOPersistentVolumeSourceDie) DieRelease() corev1.ScaleIOPersistent
 func (d *ScaleIOPersistentVolumeSourceDie) DieReleasePtr() *corev1.ScaleIOPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ScaleIOPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -27115,6 +28771,15 @@ func (d *LocalVolumeSourceDie) DieFeedPtr(r *corev1.LocalVolumeSource) *LocalVol
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LocalVolumeSourceDie) DieFeedDuck(v any) *LocalVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LocalVolumeSourceDie) DieFeedJSON(j []byte) *LocalVolumeSourceDie {
 	r := corev1.LocalVolumeSource{}
@@ -27163,6 +28828,15 @@ func (d *LocalVolumeSourceDie) DieRelease() corev1.LocalVolumeSource {
 func (d *LocalVolumeSourceDie) DieReleasePtr() *corev1.LocalVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LocalVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -27365,6 +29039,15 @@ func (d *StorageOSPersistentVolumeSourceDie) DieFeedPtr(r *corev1.StorageOSPersi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StorageOSPersistentVolumeSourceDie) DieFeedDuck(v any) *StorageOSPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StorageOSPersistentVolumeSourceDie) DieFeedJSON(j []byte) *StorageOSPersistentVolumeSourceDie {
 	r := corev1.StorageOSPersistentVolumeSource{}
@@ -27413,6 +29096,15 @@ func (d *StorageOSPersistentVolumeSourceDie) DieRelease() corev1.StorageOSPersis
 func (d *StorageOSPersistentVolumeSourceDie) DieReleasePtr() *corev1.StorageOSPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StorageOSPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -27661,6 +29353,15 @@ func (d *CSIPersistentVolumeSourceDie) DieFeedPtr(r *corev1.CSIPersistentVolumeS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSIPersistentVolumeSourceDie) DieFeedDuck(v any) *CSIPersistentVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSIPersistentVolumeSourceDie) DieFeedJSON(j []byte) *CSIPersistentVolumeSourceDie {
 	r := corev1.CSIPersistentVolumeSource{}
@@ -27709,6 +29410,15 @@ func (d *CSIPersistentVolumeSourceDie) DieRelease() corev1.CSIPersistentVolumeSo
 func (d *CSIPersistentVolumeSourceDie) DieReleasePtr() *corev1.CSIPersistentVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSIPersistentVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -28104,6 +29814,15 @@ func (d *VolumeNodeAffinityDie) DieFeedPtr(r *corev1.VolumeNodeAffinity) *Volume
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeNodeAffinityDie) DieFeedDuck(v any) *VolumeNodeAffinityDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeNodeAffinityDie) DieFeedJSON(j []byte) *VolumeNodeAffinityDie {
 	r := corev1.VolumeNodeAffinity{}
@@ -28152,6 +29871,15 @@ func (d *VolumeNodeAffinityDie) DieRelease() corev1.VolumeNodeAffinity {
 func (d *VolumeNodeAffinityDie) DieReleasePtr() *corev1.VolumeNodeAffinity {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeNodeAffinityDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -28350,6 +30078,15 @@ func (d *NodeSelectorDie) DieFeedPtr(r *corev1.NodeSelector) *NodeSelectorDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeSelectorDie) DieFeedDuck(v any) *NodeSelectorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeSelectorDie) DieFeedJSON(j []byte) *NodeSelectorDie {
 	r := corev1.NodeSelector{}
@@ -28398,6 +30135,15 @@ func (d *NodeSelectorDie) DieRelease() corev1.NodeSelector {
 func (d *NodeSelectorDie) DieReleasePtr() *corev1.NodeSelector {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeSelectorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -28597,6 +30343,15 @@ func (d *NodeSelectorTermDie) DieFeedPtr(r *corev1.NodeSelectorTerm) *NodeSelect
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeSelectorTermDie) DieFeedDuck(v any) *NodeSelectorTermDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeSelectorTermDie) DieFeedJSON(j []byte) *NodeSelectorTermDie {
 	r := corev1.NodeSelectorTerm{}
@@ -28645,6 +30400,15 @@ func (d *NodeSelectorTermDie) DieRelease() corev1.NodeSelectorTerm {
 func (d *NodeSelectorTermDie) DieReleasePtr() *corev1.NodeSelectorTerm {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeSelectorTermDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -28879,6 +30643,15 @@ func (d *NodeSelectorRequirementDie) DieFeedPtr(r *corev1.NodeSelectorRequiremen
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NodeSelectorRequirementDie) DieFeedDuck(v any) *NodeSelectorRequirementDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NodeSelectorRequirementDie) DieFeedJSON(j []byte) *NodeSelectorRequirementDie {
 	r := corev1.NodeSelectorRequirement{}
@@ -28927,6 +30700,15 @@ func (d *NodeSelectorRequirementDie) DieRelease() corev1.NodeSelectorRequirement
 func (d *NodeSelectorRequirementDie) DieReleasePtr() *corev1.NodeSelectorRequirement {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NodeSelectorRequirementDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -29141,6 +30923,15 @@ func (d *PersistentVolumeClaimDie) DieFeedPtr(r *corev1.PersistentVolumeClaim) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeClaimDie) DieFeedDuck(v any) *PersistentVolumeClaimDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeClaimDie) DieFeedJSON(j []byte) *PersistentVolumeClaimDie {
 	r := corev1.PersistentVolumeClaim{}
@@ -29201,6 +30992,15 @@ func (d *PersistentVolumeClaimDie) DieReleaseUnstructured() *unstructured.Unstru
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeClaimDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -29499,6 +31299,15 @@ func (d *PersistentVolumeClaimSpecDie) DieFeedPtr(r *corev1.PersistentVolumeClai
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeClaimSpecDie) DieFeedDuck(v any) *PersistentVolumeClaimSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeClaimSpecDie) DieFeedJSON(j []byte) *PersistentVolumeClaimSpecDie {
 	r := corev1.PersistentVolumeClaimSpec{}
@@ -29547,6 +31356,15 @@ func (d *PersistentVolumeClaimSpecDie) DieRelease() corev1.PersistentVolumeClaim
 func (d *PersistentVolumeClaimSpecDie) DieReleasePtr() *corev1.PersistentVolumeClaimSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeClaimSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -29994,6 +31812,15 @@ func (d *VolumeResourceRequirementsDie) DieFeedPtr(r *corev1.VolumeResourceRequi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeResourceRequirementsDie) DieFeedDuck(v any) *VolumeResourceRequirementsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeResourceRequirementsDie) DieFeedJSON(j []byte) *VolumeResourceRequirementsDie {
 	r := corev1.VolumeResourceRequirements{}
@@ -30042,6 +31869,15 @@ func (d *VolumeResourceRequirementsDie) DieRelease() corev1.VolumeResourceRequir
 func (d *VolumeResourceRequirementsDie) DieReleasePtr() *corev1.VolumeResourceRequirements {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeResourceRequirementsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -30300,6 +32136,15 @@ func (d *PersistentVolumeClaimStatusDie) DieFeedPtr(r *corev1.PersistentVolumeCl
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeClaimStatusDie) DieFeedDuck(v any) *PersistentVolumeClaimStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeClaimStatusDie) DieFeedJSON(j []byte) *PersistentVolumeClaimStatusDie {
 	r := corev1.PersistentVolumeClaimStatus{}
@@ -30348,6 +32193,15 @@ func (d *PersistentVolumeClaimStatusDie) DieRelease() corev1.PersistentVolumeCla
 func (d *PersistentVolumeClaimStatusDie) DieReleasePtr() *corev1.PersistentVolumeClaimStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeClaimStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -30752,6 +32606,15 @@ func (d *ModifyVolumeStatusDie) DieFeedPtr(r *corev1.ModifyVolumeStatus) *Modify
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ModifyVolumeStatusDie) DieFeedDuck(v any) *ModifyVolumeStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ModifyVolumeStatusDie) DieFeedJSON(j []byte) *ModifyVolumeStatusDie {
 	r := corev1.ModifyVolumeStatus{}
@@ -30800,6 +32663,15 @@ func (d *ModifyVolumeStatusDie) DieRelease() corev1.ModifyVolumeStatus {
 func (d *ModifyVolumeStatusDie) DieReleasePtr() *corev1.ModifyVolumeStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ModifyVolumeStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -31012,6 +32884,15 @@ func (d *PersistentVolumeClaimTemplateDie) DieFeedPtr(r *corev1.PersistentVolume
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeClaimTemplateDie) DieFeedDuck(v any) *PersistentVolumeClaimTemplateDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeClaimTemplateDie) DieFeedJSON(j []byte) *PersistentVolumeClaimTemplateDie {
 	r := corev1.PersistentVolumeClaimTemplate{}
@@ -31060,6 +32941,15 @@ func (d *PersistentVolumeClaimTemplateDie) DieRelease() corev1.PersistentVolumeC
 func (d *PersistentVolumeClaimTemplateDie) DieReleasePtr() *corev1.PersistentVolumeClaimTemplate {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeClaimTemplateDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -31299,6 +33189,15 @@ func (d *PodDie) DieFeedPtr(r *corev1.Pod) *PodDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodDie) DieFeedDuck(v any) *PodDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodDie) DieFeedJSON(j []byte) *PodDie {
 	r := corev1.Pod{}
@@ -31359,6 +33258,15 @@ func (d *PodDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -31661,6 +33569,15 @@ func (d *PodSpecDie) DieFeedPtr(r *corev1.PodSpec) *PodSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodSpecDie) DieFeedDuck(v any) *PodSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodSpecDie) DieFeedJSON(j []byte) *PodSpecDie {
 	r := corev1.PodSpec{}
@@ -31709,6 +33626,15 @@ func (d *PodSpecDie) DieRelease() corev1.PodSpec {
 func (d *PodSpecDie) DieReleasePtr() *corev1.PodSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -32833,6 +34759,15 @@ func (d *PodSchedulingGateDie) DieFeedPtr(r *corev1.PodSchedulingGate) *PodSched
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodSchedulingGateDie) DieFeedDuck(v any) *PodSchedulingGateDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodSchedulingGateDie) DieFeedJSON(j []byte) *PodSchedulingGateDie {
 	r := corev1.PodSchedulingGate{}
@@ -32881,6 +34816,15 @@ func (d *PodSchedulingGateDie) DieRelease() corev1.PodSchedulingGate {
 func (d *PodSchedulingGateDie) DieReleasePtr() *corev1.PodSchedulingGate {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodSchedulingGateDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -33070,6 +35014,15 @@ func (d *PodResourceClaimDie) DieFeedPtr(r *corev1.PodResourceClaim) *PodResourc
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodResourceClaimDie) DieFeedDuck(v any) *PodResourceClaimDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodResourceClaimDie) DieFeedJSON(j []byte) *PodResourceClaimDie {
 	r := corev1.PodResourceClaim{}
@@ -33118,6 +35071,15 @@ func (d *PodResourceClaimDie) DieRelease() corev1.PodResourceClaim {
 func (d *PodResourceClaimDie) DieReleasePtr() *corev1.PodResourceClaim {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodResourceClaimDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -33349,6 +35311,15 @@ func (d *PodSecurityContextDie) DieFeedPtr(r *corev1.PodSecurityContext) *PodSec
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodSecurityContextDie) DieFeedDuck(v any) *PodSecurityContextDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodSecurityContextDie) DieFeedJSON(j []byte) *PodSecurityContextDie {
 	r := corev1.PodSecurityContext{}
@@ -33397,6 +35368,15 @@ func (d *PodSecurityContextDie) DieRelease() corev1.PodSecurityContext {
 func (d *PodSecurityContextDie) DieReleasePtr() *corev1.PodSecurityContext {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodSecurityContextDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -33888,6 +35868,15 @@ func (d *SysctlDie) DieFeedPtr(r *corev1.Sysctl) *SysctlDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SysctlDie) DieFeedDuck(v any) *SysctlDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SysctlDie) DieFeedJSON(j []byte) *SysctlDie {
 	r := corev1.Sysctl{}
@@ -33936,6 +35925,15 @@ func (d *SysctlDie) DieRelease() corev1.Sysctl {
 func (d *SysctlDie) DieReleasePtr() *corev1.Sysctl {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SysctlDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -34130,6 +36128,15 @@ func (d *TolerationDie) DieFeedPtr(r *corev1.Toleration) *TolerationDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TolerationDie) DieFeedDuck(v any) *TolerationDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TolerationDie) DieFeedJSON(j []byte) *TolerationDie {
 	r := corev1.Toleration{}
@@ -34178,6 +36185,15 @@ func (d *TolerationDie) DieRelease() corev1.Toleration {
 func (d *TolerationDie) DieReleasePtr() *corev1.Toleration {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TolerationDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -34411,6 +36427,15 @@ func (d *HostAliasDie) DieFeedPtr(r *corev1.HostAlias) *HostAliasDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HostAliasDie) DieFeedDuck(v any) *HostAliasDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HostAliasDie) DieFeedJSON(j []byte) *HostAliasDie {
 	r := corev1.HostAlias{}
@@ -34459,6 +36484,15 @@ func (d *HostAliasDie) DieRelease() corev1.HostAlias {
 func (d *HostAliasDie) DieReleasePtr() *corev1.HostAlias {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HostAliasDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -34653,6 +36687,15 @@ func (d *PodDNSConfigDie) DieFeedPtr(r *corev1.PodDNSConfig) *PodDNSConfigDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodDNSConfigDie) DieFeedDuck(v any) *PodDNSConfigDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodDNSConfigDie) DieFeedJSON(j []byte) *PodDNSConfigDie {
 	r := corev1.PodDNSConfig{}
@@ -34701,6 +36744,15 @@ func (d *PodDNSConfigDie) DieRelease() corev1.PodDNSConfig {
 func (d *PodDNSConfigDie) DieReleasePtr() *corev1.PodDNSConfig {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodDNSConfigDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -34934,6 +36986,15 @@ func (d *PodDNSConfigOptionDie) DieFeedPtr(r *corev1.PodDNSConfigOption) *PodDNS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodDNSConfigOptionDie) DieFeedDuck(v any) *PodDNSConfigOptionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodDNSConfigOptionDie) DieFeedJSON(j []byte) *PodDNSConfigOptionDie {
 	r := corev1.PodDNSConfigOption{}
@@ -34982,6 +37043,15 @@ func (d *PodDNSConfigOptionDie) DieRelease() corev1.PodDNSConfigOption {
 func (d *PodDNSConfigOptionDie) DieReleasePtr() *corev1.PodDNSConfigOption {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodDNSConfigOptionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -35178,6 +37248,15 @@ func (d *PodReadinessGateDie) DieFeedPtr(r *corev1.PodReadinessGate) *PodReadine
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodReadinessGateDie) DieFeedDuck(v any) *PodReadinessGateDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodReadinessGateDie) DieFeedJSON(j []byte) *PodReadinessGateDie {
 	r := corev1.PodReadinessGate{}
@@ -35226,6 +37305,15 @@ func (d *PodReadinessGateDie) DieRelease() corev1.PodReadinessGate {
 func (d *PodReadinessGateDie) DieReleasePtr() *corev1.PodReadinessGate {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodReadinessGateDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -35413,6 +37501,15 @@ func (d *TopologySpreadConstraintDie) DieFeedPtr(r *corev1.TopologySpreadConstra
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TopologySpreadConstraintDie) DieFeedDuck(v any) *TopologySpreadConstraintDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TopologySpreadConstraintDie) DieFeedJSON(j []byte) *TopologySpreadConstraintDie {
 	r := corev1.TopologySpreadConstraint{}
@@ -35461,6 +37558,15 @@ func (d *TopologySpreadConstraintDie) DieRelease() corev1.TopologySpreadConstrai
 func (d *TopologySpreadConstraintDie) DieReleasePtr() *corev1.TopologySpreadConstraint {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TopologySpreadConstraintDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -35872,6 +37978,15 @@ func (d *PodOSDie) DieFeedPtr(r *corev1.PodOS) *PodOSDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodOSDie) DieFeedDuck(v any) *PodOSDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodOSDie) DieFeedJSON(j []byte) *PodOSDie {
 	r := corev1.PodOS{}
@@ -35920,6 +38035,15 @@ func (d *PodOSDie) DieRelease() corev1.PodOS {
 func (d *PodOSDie) DieReleasePtr() *corev1.PodOS {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodOSDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -36113,6 +38237,15 @@ func (d *PodStatusDie) DieFeedPtr(r *corev1.PodStatus) *PodStatusDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodStatusDie) DieFeedDuck(v any) *PodStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodStatusDie) DieFeedJSON(j []byte) *PodStatusDie {
 	r := corev1.PodStatus{}
@@ -36161,6 +38294,15 @@ func (d *PodStatusDie) DieRelease() corev1.PodStatus {
 func (d *PodStatusDie) DieReleasePtr() *corev1.PodStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -36680,6 +38822,15 @@ func (d *PodTemplateDie) DieFeedPtr(r *corev1.PodTemplate) *PodTemplateDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodTemplateDie) DieFeedDuck(v any) *PodTemplateDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodTemplateDie) DieFeedJSON(j []byte) *PodTemplateDie {
 	r := corev1.PodTemplate{}
@@ -36740,6 +38891,15 @@ func (d *PodTemplateDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodTemplateDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -37014,6 +39174,15 @@ func (d *PodTemplateSpecDie) DieFeedPtr(r *corev1.PodTemplateSpec) *PodTemplateS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodTemplateSpecDie) DieFeedDuck(v any) *PodTemplateSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodTemplateSpecDie) DieFeedJSON(j []byte) *PodTemplateSpecDie {
 	r := corev1.PodTemplateSpec{}
@@ -37062,6 +39231,15 @@ func (d *PodTemplateSpecDie) DieRelease() corev1.PodTemplateSpec {
 func (d *PodTemplateSpecDie) DieReleasePtr() *corev1.PodTemplateSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodTemplateSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -37289,6 +39467,15 @@ func (d *ReplicationControllerDie) DieFeedPtr(r *corev1.ReplicationController) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ReplicationControllerDie) DieFeedDuck(v any) *ReplicationControllerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ReplicationControllerDie) DieFeedJSON(j []byte) *ReplicationControllerDie {
 	r := corev1.ReplicationController{}
@@ -37349,6 +39536,15 @@ func (d *ReplicationControllerDie) DieReleaseUnstructured() *unstructured.Unstru
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ReplicationControllerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -37651,6 +39847,15 @@ func (d *ReplicationControllerSpecDie) DieFeedPtr(r *corev1.ReplicationControlle
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ReplicationControllerSpecDie) DieFeedDuck(v any) *ReplicationControllerSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ReplicationControllerSpecDie) DieFeedJSON(j []byte) *ReplicationControllerSpecDie {
 	r := corev1.ReplicationControllerSpec{}
@@ -37699,6 +39904,15 @@ func (d *ReplicationControllerSpecDie) DieRelease() corev1.ReplicationController
 func (d *ReplicationControllerSpecDie) DieReleasePtr() *corev1.ReplicationControllerSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ReplicationControllerSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -37948,6 +40162,15 @@ func (d *ReplicationControllerStatusDie) DieFeedPtr(r *corev1.ReplicationControl
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ReplicationControllerStatusDie) DieFeedDuck(v any) *ReplicationControllerStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ReplicationControllerStatusDie) DieFeedJSON(j []byte) *ReplicationControllerStatusDie {
 	r := corev1.ReplicationControllerStatus{}
@@ -37996,6 +40219,15 @@ func (d *ReplicationControllerStatusDie) DieRelease() corev1.ReplicationControll
 func (d *ReplicationControllerStatusDie) DieReleasePtr() *corev1.ReplicationControllerStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ReplicationControllerStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -38223,6 +40455,15 @@ func (d *ResourceQuotaDie) DieFeedPtr(r *corev1.ResourceQuota) *ResourceQuotaDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceQuotaDie) DieFeedDuck(v any) *ResourceQuotaDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceQuotaDie) DieFeedJSON(j []byte) *ResourceQuotaDie {
 	r := corev1.ResourceQuota{}
@@ -38283,6 +40524,15 @@ func (d *ResourceQuotaDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceQuotaDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -38579,6 +40829,15 @@ func (d *ResourceQuotaSpecDie) DieFeedPtr(r *corev1.ResourceQuotaSpec) *Resource
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceQuotaSpecDie) DieFeedDuck(v any) *ResourceQuotaSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceQuotaSpecDie) DieFeedJSON(j []byte) *ResourceQuotaSpecDie {
 	r := corev1.ResourceQuotaSpec{}
@@ -38627,6 +40886,15 @@ func (d *ResourceQuotaSpecDie) DieRelease() corev1.ResourceQuotaSpec {
 func (d *ResourceQuotaSpecDie) DieReleasePtr() *corev1.ResourceQuotaSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceQuotaSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -38875,6 +41143,15 @@ func (d *ScopeSelectorDie) DieFeedPtr(r *corev1.ScopeSelector) *ScopeSelectorDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ScopeSelectorDie) DieFeedDuck(v any) *ScopeSelectorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ScopeSelectorDie) DieFeedJSON(j []byte) *ScopeSelectorDie {
 	r := corev1.ScopeSelector{}
@@ -38923,6 +41200,15 @@ func (d *ScopeSelectorDie) DieRelease() corev1.ScopeSelector {
 func (d *ScopeSelectorDie) DieReleasePtr() *corev1.ScopeSelector {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ScopeSelectorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -39130,6 +41416,15 @@ func (d *ScopedResourceSelectorRequirementDie) DieFeedPtr(r *corev1.ScopedResour
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ScopedResourceSelectorRequirementDie) DieFeedDuck(v any) *ScopedResourceSelectorRequirementDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ScopedResourceSelectorRequirementDie) DieFeedJSON(j []byte) *ScopedResourceSelectorRequirementDie {
 	r := corev1.ScopedResourceSelectorRequirement{}
@@ -39178,6 +41473,15 @@ func (d *ScopedResourceSelectorRequirementDie) DieRelease() corev1.ScopedResourc
 func (d *ScopedResourceSelectorRequirementDie) DieReleasePtr() *corev1.ScopedResourceSelectorRequirement {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ScopedResourceSelectorRequirementDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -39387,6 +41691,15 @@ func (d *ResourceQuotaStatusDie) DieFeedPtr(r *corev1.ResourceQuotaStatus) *Reso
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ResourceQuotaStatusDie) DieFeedDuck(v any) *ResourceQuotaStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ResourceQuotaStatusDie) DieFeedJSON(j []byte) *ResourceQuotaStatusDie {
 	r := corev1.ResourceQuotaStatus{}
@@ -39435,6 +41748,15 @@ func (d *ResourceQuotaStatusDie) DieRelease() corev1.ResourceQuotaStatus {
 func (d *ResourceQuotaStatusDie) DieReleasePtr() *corev1.ResourceQuotaStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ResourceQuotaStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -39678,6 +42000,15 @@ func (d *SecretDie) DieFeedPtr(r *corev1.Secret) *SecretDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SecretDie) DieFeedDuck(v any) *SecretDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SecretDie) DieFeedJSON(j []byte) *SecretDie {
 	r := corev1.Secret{}
@@ -39738,6 +42069,15 @@ func (d *SecretDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SecretDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -40023,6 +42363,15 @@ func (d *ServiceDie) DieFeedPtr(r *corev1.Service) *ServiceDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceDie) DieFeedDuck(v any) *ServiceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceDie) DieFeedJSON(j []byte) *ServiceDie {
 	r := corev1.Service{}
@@ -40083,6 +42432,15 @@ func (d *ServiceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -40383,6 +42741,15 @@ func (d *ServiceSpecDie) DieFeedPtr(r *corev1.ServiceSpec) *ServiceSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceSpecDie) DieFeedDuck(v any) *ServiceSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceSpecDie) DieFeedJSON(j []byte) *ServiceSpecDie {
 	r := corev1.ServiceSpec{}
@@ -40431,6 +42798,15 @@ func (d *ServiceSpecDie) DieRelease() corev1.ServiceSpec {
 func (d *ServiceSpecDie) DieReleasePtr() *corev1.ServiceSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -41064,6 +43440,15 @@ func (d *ServicePortDie) DieFeedPtr(r *corev1.ServicePort) *ServicePortDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServicePortDie) DieFeedDuck(v any) *ServicePortDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServicePortDie) DieFeedJSON(j []byte) *ServicePortDie {
 	r := corev1.ServicePort{}
@@ -41112,6 +43497,15 @@ func (d *ServicePortDie) DieRelease() corev1.ServicePort {
 func (d *ServicePortDie) DieReleasePtr() *corev1.ServicePort {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServicePortDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -41444,6 +43838,15 @@ func (d *SessionAffinityConfigDie) DieFeedPtr(r *corev1.SessionAffinityConfig) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SessionAffinityConfigDie) DieFeedDuck(v any) *SessionAffinityConfigDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SessionAffinityConfigDie) DieFeedJSON(j []byte) *SessionAffinityConfigDie {
 	r := corev1.SessionAffinityConfig{}
@@ -41492,6 +43895,15 @@ func (d *SessionAffinityConfigDie) DieRelease() corev1.SessionAffinityConfig {
 func (d *SessionAffinityConfigDie) DieReleasePtr() *corev1.SessionAffinityConfig {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SessionAffinityConfigDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -41690,6 +44102,15 @@ func (d *ClientIPConfigDie) DieFeedPtr(r *corev1.ClientIPConfig) *ClientIPConfig
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ClientIPConfigDie) DieFeedDuck(v any) *ClientIPConfigDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ClientIPConfigDie) DieFeedJSON(j []byte) *ClientIPConfigDie {
 	r := corev1.ClientIPConfig{}
@@ -41738,6 +44159,15 @@ func (d *ClientIPConfigDie) DieRelease() corev1.ClientIPConfig {
 func (d *ClientIPConfigDie) DieReleasePtr() *corev1.ClientIPConfig {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ClientIPConfigDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -41929,6 +44359,15 @@ func (d *ServiceStatusDie) DieFeedPtr(r *corev1.ServiceStatus) *ServiceStatusDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceStatusDie) DieFeedDuck(v any) *ServiceStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceStatusDie) DieFeedJSON(j []byte) *ServiceStatusDie {
 	r := corev1.ServiceStatus{}
@@ -41977,6 +44416,15 @@ func (d *ServiceStatusDie) DieRelease() corev1.ServiceStatus {
 func (d *ServiceStatusDie) DieReleasePtr() *corev1.ServiceStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -42186,6 +44634,15 @@ func (d *LoadBalancerStatusDie) DieFeedPtr(r *corev1.LoadBalancerStatus) *LoadBa
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LoadBalancerStatusDie) DieFeedDuck(v any) *LoadBalancerStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LoadBalancerStatusDie) DieFeedJSON(j []byte) *LoadBalancerStatusDie {
 	r := corev1.LoadBalancerStatus{}
@@ -42234,6 +44691,15 @@ func (d *LoadBalancerStatusDie) DieRelease() corev1.LoadBalancerStatus {
 func (d *LoadBalancerStatusDie) DieReleasePtr() *corev1.LoadBalancerStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LoadBalancerStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -42437,6 +44903,15 @@ func (d *LoadBalancerIngressDie) DieFeedPtr(r *corev1.LoadBalancerIngress) *Load
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LoadBalancerIngressDie) DieFeedDuck(v any) *LoadBalancerIngressDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LoadBalancerIngressDie) DieFeedJSON(j []byte) *LoadBalancerIngressDie {
 	r := corev1.LoadBalancerIngress{}
@@ -42485,6 +44960,15 @@ func (d *LoadBalancerIngressDie) DieRelease() corev1.LoadBalancerIngress {
 func (d *LoadBalancerIngressDie) DieReleasePtr() *corev1.LoadBalancerIngress {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LoadBalancerIngressDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -42723,6 +45207,15 @@ func (d *PortStatusDie) DieFeedPtr(r *corev1.PortStatus) *PortStatusDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PortStatusDie) DieFeedDuck(v any) *PortStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PortStatusDie) DieFeedJSON(j []byte) *PortStatusDie {
 	r := corev1.PortStatus{}
@@ -42771,6 +45264,15 @@ func (d *PortStatusDie) DieRelease() corev1.PortStatus {
 func (d *PortStatusDie) DieReleasePtr() *corev1.PortStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PortStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -42991,6 +45493,15 @@ func (d *ServiceAccountDie) DieFeedPtr(r *corev1.ServiceAccount) *ServiceAccount
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceAccountDie) DieFeedDuck(v any) *ServiceAccountDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceAccountDie) DieFeedJSON(j []byte) *ServiceAccountDie {
 	r := corev1.ServiceAccount{}
@@ -43051,6 +45562,15 @@ func (d *ServiceAccountDie) DieReleaseUnstructured() *unstructured.Unstructured 
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceAccountDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -43394,6 +45914,15 @@ func (d *VolumeDie) DieFeedPtr(r *corev1.Volume) *VolumeDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeDie) DieFeedDuck(v any) *VolumeDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeDie) DieFeedJSON(j []byte) *VolumeDie {
 	r := corev1.Volume{}
@@ -43442,6 +45971,15 @@ func (d *VolumeDie) DieRelease() corev1.Volume {
 func (d *VolumeDie) DieReleasePtr() *corev1.Volume {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -43644,6 +46182,15 @@ func (d *HostPathVolumeSourceDie) DieFeedPtr(r *corev1.HostPathVolumeSource) *Ho
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HostPathVolumeSourceDie) DieFeedDuck(v any) *HostPathVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HostPathVolumeSourceDie) DieFeedJSON(j []byte) *HostPathVolumeSourceDie {
 	r := corev1.HostPathVolumeSource{}
@@ -43692,6 +46239,15 @@ func (d *HostPathVolumeSourceDie) DieRelease() corev1.HostPathVolumeSource {
 func (d *HostPathVolumeSourceDie) DieReleasePtr() *corev1.HostPathVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HostPathVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -43894,6 +46450,15 @@ func (d *EmptyDirVolumeSourceDie) DieFeedPtr(r *corev1.EmptyDirVolumeSource) *Em
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EmptyDirVolumeSourceDie) DieFeedDuck(v any) *EmptyDirVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EmptyDirVolumeSourceDie) DieFeedJSON(j []byte) *EmptyDirVolumeSourceDie {
 	r := corev1.EmptyDirVolumeSource{}
@@ -43942,6 +46507,15 @@ func (d *EmptyDirVolumeSourceDie) DieRelease() corev1.EmptyDirVolumeSource {
 func (d *EmptyDirVolumeSourceDie) DieReleasePtr() *corev1.EmptyDirVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EmptyDirVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -44170,6 +46744,15 @@ func (d *GCEPersistentDiskVolumeSourceDie) DieFeedPtr(r *corev1.GCEPersistentDis
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GCEPersistentDiskVolumeSourceDie) DieFeedDuck(v any) *GCEPersistentDiskVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GCEPersistentDiskVolumeSourceDie) DieFeedJSON(j []byte) *GCEPersistentDiskVolumeSourceDie {
 	r := corev1.GCEPersistentDiskVolumeSource{}
@@ -44218,6 +46801,15 @@ func (d *GCEPersistentDiskVolumeSourceDie) DieRelease() corev1.GCEPersistentDisk
 func (d *GCEPersistentDiskVolumeSourceDie) DieReleasePtr() *corev1.GCEPersistentDiskVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GCEPersistentDiskVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -44448,6 +47040,15 @@ func (d *AWSElasticBlockStoreVolumeSourceDie) DieFeedPtr(r *corev1.AWSElasticBlo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AWSElasticBlockStoreVolumeSourceDie) DieFeedDuck(v any) *AWSElasticBlockStoreVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AWSElasticBlockStoreVolumeSourceDie) DieFeedJSON(j []byte) *AWSElasticBlockStoreVolumeSourceDie {
 	r := corev1.AWSElasticBlockStoreVolumeSource{}
@@ -44496,6 +47097,15 @@ func (d *AWSElasticBlockStoreVolumeSourceDie) DieRelease() corev1.AWSElasticBloc
 func (d *AWSElasticBlockStoreVolumeSourceDie) DieReleasePtr() *corev1.AWSElasticBlockStoreVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AWSElasticBlockStoreVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -44722,6 +47332,15 @@ func (d *GitRepoVolumeSourceDie) DieFeedPtr(r *corev1.GitRepoVolumeSource) *GitR
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GitRepoVolumeSourceDie) DieFeedDuck(v any) *GitRepoVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GitRepoVolumeSourceDie) DieFeedJSON(j []byte) *GitRepoVolumeSourceDie {
 	r := corev1.GitRepoVolumeSource{}
@@ -44770,6 +47389,15 @@ func (d *GitRepoVolumeSourceDie) DieRelease() corev1.GitRepoVolumeSource {
 func (d *GitRepoVolumeSourceDie) DieReleasePtr() *corev1.GitRepoVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GitRepoVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -44977,6 +47605,15 @@ func (d *SecretVolumeSourceDie) DieFeedPtr(r *corev1.SecretVolumeSource) *Secret
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SecretVolumeSourceDie) DieFeedDuck(v any) *SecretVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SecretVolumeSourceDie) DieFeedJSON(j []byte) *SecretVolumeSourceDie {
 	r := corev1.SecretVolumeSource{}
@@ -45025,6 +47662,15 @@ func (d *SecretVolumeSourceDie) DieRelease() corev1.SecretVolumeSource {
 func (d *SecretVolumeSourceDie) DieReleasePtr() *corev1.SecretVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SecretVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -45291,6 +47937,15 @@ func (d *NFSVolumeSourceDie) DieFeedPtr(r *corev1.NFSVolumeSource) *NFSVolumeSou
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NFSVolumeSourceDie) DieFeedDuck(v any) *NFSVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NFSVolumeSourceDie) DieFeedJSON(j []byte) *NFSVolumeSourceDie {
 	r := corev1.NFSVolumeSource{}
@@ -45339,6 +47994,15 @@ func (d *NFSVolumeSourceDie) DieRelease() corev1.NFSVolumeSource {
 func (d *NFSVolumeSourceDie) DieReleasePtr() *corev1.NFSVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NFSVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -45548,6 +48212,15 @@ func (d *ISCSIVolumeSourceDie) DieFeedPtr(r *corev1.ISCSIVolumeSource) *ISCSIVol
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ISCSIVolumeSourceDie) DieFeedDuck(v any) *ISCSIVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ISCSIVolumeSourceDie) DieFeedJSON(j []byte) *ISCSIVolumeSourceDie {
 	r := corev1.ISCSIVolumeSource{}
@@ -45596,6 +48269,15 @@ func (d *ISCSIVolumeSourceDie) DieRelease() corev1.ISCSIVolumeSource {
 func (d *ISCSIVolumeSourceDie) DieReleasePtr() *corev1.ISCSIVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ISCSIVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -45884,6 +48566,15 @@ func (d *GlusterfsVolumeSourceDie) DieFeedPtr(r *corev1.GlusterfsVolumeSource) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GlusterfsVolumeSourceDie) DieFeedDuck(v any) *GlusterfsVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GlusterfsVolumeSourceDie) DieFeedJSON(j []byte) *GlusterfsVolumeSourceDie {
 	r := corev1.GlusterfsVolumeSource{}
@@ -45932,6 +48623,15 @@ func (d *GlusterfsVolumeSourceDie) DieRelease() corev1.GlusterfsVolumeSource {
 func (d *GlusterfsVolumeSourceDie) DieReleasePtr() *corev1.GlusterfsVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GlusterfsVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -46141,6 +48841,15 @@ func (d *PersistentVolumeClaimVolumeSourceDie) DieFeedPtr(r *corev1.PersistentVo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PersistentVolumeClaimVolumeSourceDie) DieFeedDuck(v any) *PersistentVolumeClaimVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PersistentVolumeClaimVolumeSourceDie) DieFeedJSON(j []byte) *PersistentVolumeClaimVolumeSourceDie {
 	r := corev1.PersistentVolumeClaimVolumeSource{}
@@ -46189,6 +48898,15 @@ func (d *PersistentVolumeClaimVolumeSourceDie) DieRelease() corev1.PersistentVol
 func (d *PersistentVolumeClaimVolumeSourceDie) DieReleasePtr() *corev1.PersistentVolumeClaimVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PersistentVolumeClaimVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -46387,6 +49105,15 @@ func (d *RBDVolumeSourceDie) DieFeedPtr(r *corev1.RBDVolumeSource) *RBDVolumeSou
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RBDVolumeSourceDie) DieFeedDuck(v any) *RBDVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RBDVolumeSourceDie) DieFeedJSON(j []byte) *RBDVolumeSourceDie {
 	r := corev1.RBDVolumeSource{}
@@ -46435,6 +49162,15 @@ func (d *RBDVolumeSourceDie) DieRelease() corev1.RBDVolumeSource {
 func (d *RBDVolumeSourceDie) DieReleasePtr() *corev1.RBDVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RBDVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -46722,6 +49458,15 @@ func (d *FlexVolumeSourceDie) DieFeedPtr(r *corev1.FlexVolumeSource) *FlexVolume
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FlexVolumeSourceDie) DieFeedDuck(v any) *FlexVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FlexVolumeSourceDie) DieFeedJSON(j []byte) *FlexVolumeSourceDie {
 	r := corev1.FlexVolumeSource{}
@@ -46770,6 +49515,15 @@ func (d *FlexVolumeSourceDie) DieRelease() corev1.FlexVolumeSource {
 func (d *FlexVolumeSourceDie) DieReleasePtr() *corev1.FlexVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FlexVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -47018,6 +49772,15 @@ func (d *CinderVolumeSourceDie) DieFeedPtr(r *corev1.CinderVolumeSource) *Cinder
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CinderVolumeSourceDie) DieFeedDuck(v any) *CinderVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CinderVolumeSourceDie) DieFeedJSON(j []byte) *CinderVolumeSourceDie {
 	r := corev1.CinderVolumeSource{}
@@ -47066,6 +49829,15 @@ func (d *CinderVolumeSourceDie) DieRelease() corev1.CinderVolumeSource {
 func (d *CinderVolumeSourceDie) DieReleasePtr() *corev1.CinderVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CinderVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -47301,6 +50073,15 @@ func (d *CephFSVolumeSourceDie) DieFeedPtr(r *corev1.CephFSVolumeSource) *CephFS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CephFSVolumeSourceDie) DieFeedDuck(v any) *CephFSVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CephFSVolumeSourceDie) DieFeedJSON(j []byte) *CephFSVolumeSourceDie {
 	r := corev1.CephFSVolumeSource{}
@@ -47349,6 +50130,15 @@ func (d *CephFSVolumeSourceDie) DieRelease() corev1.CephFSVolumeSource {
 func (d *CephFSVolumeSourceDie) DieReleasePtr() *corev1.CephFSVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CephFSVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -47596,6 +50386,15 @@ func (d *FlockerVolumeSourceDie) DieFeedPtr(r *corev1.FlockerVolumeSource) *Floc
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FlockerVolumeSourceDie) DieFeedDuck(v any) *FlockerVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FlockerVolumeSourceDie) DieFeedJSON(j []byte) *FlockerVolumeSourceDie {
 	r := corev1.FlockerVolumeSource{}
@@ -47644,6 +50443,15 @@ func (d *FlockerVolumeSourceDie) DieRelease() corev1.FlockerVolumeSource {
 func (d *FlockerVolumeSourceDie) DieReleasePtr() *corev1.FlockerVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FlockerVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -47840,6 +50648,15 @@ func (d *DownwardAPIVolumeSourceDie) DieFeedPtr(r *corev1.DownwardAPIVolumeSourc
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DownwardAPIVolumeSourceDie) DieFeedDuck(v any) *DownwardAPIVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DownwardAPIVolumeSourceDie) DieFeedJSON(j []byte) *DownwardAPIVolumeSourceDie {
 	r := corev1.DownwardAPIVolumeSource{}
@@ -47888,6 +50705,15 @@ func (d *DownwardAPIVolumeSourceDie) DieRelease() corev1.DownwardAPIVolumeSource
 func (d *DownwardAPIVolumeSourceDie) DieReleasePtr() *corev1.DownwardAPIVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DownwardAPIVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -48116,6 +50942,15 @@ func (d *DownwardAPIVolumeFileDie) DieFeedPtr(r *corev1.DownwardAPIVolumeFile) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DownwardAPIVolumeFileDie) DieFeedDuck(v any) *DownwardAPIVolumeFileDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DownwardAPIVolumeFileDie) DieFeedJSON(j []byte) *DownwardAPIVolumeFileDie {
 	r := corev1.DownwardAPIVolumeFile{}
@@ -48164,6 +50999,15 @@ func (d *DownwardAPIVolumeFileDie) DieRelease() corev1.DownwardAPIVolumeFile {
 func (d *DownwardAPIVolumeFileDie) DieReleasePtr() *corev1.DownwardAPIVolumeFile {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DownwardAPIVolumeFileDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -48408,6 +51252,15 @@ func (d *FCVolumeSourceDie) DieFeedPtr(r *corev1.FCVolumeSource) *FCVolumeSource
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FCVolumeSourceDie) DieFeedDuck(v any) *FCVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FCVolumeSourceDie) DieFeedJSON(j []byte) *FCVolumeSourceDie {
 	r := corev1.FCVolumeSource{}
@@ -48456,6 +51309,15 @@ func (d *FCVolumeSourceDie) DieRelease() corev1.FCVolumeSource {
 func (d *FCVolumeSourceDie) DieReleasePtr() *corev1.FCVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FCVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -48681,6 +51543,15 @@ func (d *AzureFileVolumeSourceDie) DieFeedPtr(r *corev1.AzureFileVolumeSource) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AzureFileVolumeSourceDie) DieFeedDuck(v any) *AzureFileVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AzureFileVolumeSourceDie) DieFeedJSON(j []byte) *AzureFileVolumeSourceDie {
 	r := corev1.AzureFileVolumeSource{}
@@ -48729,6 +51600,15 @@ func (d *AzureFileVolumeSourceDie) DieRelease() corev1.AzureFileVolumeSource {
 func (d *AzureFileVolumeSourceDie) DieReleasePtr() *corev1.AzureFileVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AzureFileVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -48932,6 +51812,15 @@ func (d *ConfigMapVolumeSourceDie) DieFeedPtr(r *corev1.ConfigMapVolumeSource) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ConfigMapVolumeSourceDie) DieFeedDuck(v any) *ConfigMapVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ConfigMapVolumeSourceDie) DieFeedJSON(j []byte) *ConfigMapVolumeSourceDie {
 	r := corev1.ConfigMapVolumeSource{}
@@ -48980,6 +51869,15 @@ func (d *ConfigMapVolumeSourceDie) DieRelease() corev1.ConfigMapVolumeSource {
 func (d *ConfigMapVolumeSourceDie) DieReleasePtr() *corev1.ConfigMapVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ConfigMapVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -49243,6 +52141,15 @@ func (d *VsphereVirtualDiskVolumeSourceDie) DieFeedPtr(r *corev1.VsphereVirtualD
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VsphereVirtualDiskVolumeSourceDie) DieFeedDuck(v any) *VsphereVirtualDiskVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VsphereVirtualDiskVolumeSourceDie) DieFeedJSON(j []byte) *VsphereVirtualDiskVolumeSourceDie {
 	r := corev1.VsphereVirtualDiskVolumeSource{}
@@ -49291,6 +52198,15 @@ func (d *VsphereVirtualDiskVolumeSourceDie) DieRelease() corev1.VsphereVirtualDi
 func (d *VsphereVirtualDiskVolumeSourceDie) DieReleasePtr() *corev1.VsphereVirtualDiskVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VsphereVirtualDiskVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -49503,6 +52419,15 @@ func (d *QuobyteVolumeSourceDie) DieFeedPtr(r *corev1.QuobyteVolumeSource) *Quob
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *QuobyteVolumeSourceDie) DieFeedDuck(v any) *QuobyteVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *QuobyteVolumeSourceDie) DieFeedJSON(j []byte) *QuobyteVolumeSourceDie {
 	r := corev1.QuobyteVolumeSource{}
@@ -49551,6 +52476,15 @@ func (d *QuobyteVolumeSourceDie) DieRelease() corev1.QuobyteVolumeSource {
 func (d *QuobyteVolumeSourceDie) DieReleasePtr() *corev1.QuobyteVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *QuobyteVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -49785,6 +52719,15 @@ func (d *AzureDiskVolumeSourceDie) DieFeedPtr(r *corev1.AzureDiskVolumeSource) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *AzureDiskVolumeSourceDie) DieFeedDuck(v any) *AzureDiskVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *AzureDiskVolumeSourceDie) DieFeedJSON(j []byte) *AzureDiskVolumeSourceDie {
 	r := corev1.AzureDiskVolumeSource{}
@@ -49833,6 +52776,15 @@ func (d *AzureDiskVolumeSourceDie) DieRelease() corev1.AzureDiskVolumeSource {
 func (d *AzureDiskVolumeSourceDie) DieReleasePtr() *corev1.AzureDiskVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *AzureDiskVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -50061,6 +53013,15 @@ func (d *PhotonPersistentDiskVolumeSourceDie) DieFeedPtr(r *corev1.PhotonPersist
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PhotonPersistentDiskVolumeSourceDie) DieFeedDuck(v any) *PhotonPersistentDiskVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PhotonPersistentDiskVolumeSourceDie) DieFeedJSON(j []byte) *PhotonPersistentDiskVolumeSourceDie {
 	r := corev1.PhotonPersistentDiskVolumeSource{}
@@ -50109,6 +53070,15 @@ func (d *PhotonPersistentDiskVolumeSourceDie) DieRelease() corev1.PhotonPersiste
 func (d *PhotonPersistentDiskVolumeSourceDie) DieReleasePtr() *corev1.PhotonPersistentDiskVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PhotonPersistentDiskVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -50307,6 +53277,15 @@ func (d *ProjectedVolumeSourceDie) DieFeedPtr(r *corev1.ProjectedVolumeSource) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ProjectedVolumeSourceDie) DieFeedDuck(v any) *ProjectedVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ProjectedVolumeSourceDie) DieFeedJSON(j []byte) *ProjectedVolumeSourceDie {
 	r := corev1.ProjectedVolumeSource{}
@@ -50355,6 +53334,15 @@ func (d *ProjectedVolumeSourceDie) DieRelease() corev1.ProjectedVolumeSource {
 func (d *ProjectedVolumeSourceDie) DieReleasePtr() *corev1.ProjectedVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ProjectedVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -50575,6 +53563,15 @@ func (d *VolumeProjectionDie) DieFeedPtr(r *corev1.VolumeProjection) *VolumeProj
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeProjectionDie) DieFeedDuck(v any) *VolumeProjectionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeProjectionDie) DieFeedJSON(j []byte) *VolumeProjectionDie {
 	r := corev1.VolumeProjection{}
@@ -50623,6 +53620,15 @@ func (d *VolumeProjectionDie) DieRelease() corev1.VolumeProjection {
 func (d *VolumeProjectionDie) DieReleasePtr() *corev1.VolumeProjection {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeProjectionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -50929,6 +53935,15 @@ func (d *SecretProjectionDie) DieFeedPtr(r *corev1.SecretProjection) *SecretProj
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SecretProjectionDie) DieFeedDuck(v any) *SecretProjectionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SecretProjectionDie) DieFeedJSON(j []byte) *SecretProjectionDie {
 	r := corev1.SecretProjection{}
@@ -50977,6 +53992,15 @@ func (d *SecretProjectionDie) DieRelease() corev1.SecretProjection {
 func (d *SecretProjectionDie) DieReleasePtr() *corev1.SecretProjection {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SecretProjectionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -51221,6 +54245,15 @@ func (d *DownwardAPIProjectionDie) DieFeedPtr(r *corev1.DownwardAPIProjection) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DownwardAPIProjectionDie) DieFeedDuck(v any) *DownwardAPIProjectionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DownwardAPIProjectionDie) DieFeedJSON(j []byte) *DownwardAPIProjectionDie {
 	r := corev1.DownwardAPIProjection{}
@@ -51269,6 +54302,15 @@ func (d *DownwardAPIProjectionDie) DieRelease() corev1.DownwardAPIProjection {
 func (d *DownwardAPIProjectionDie) DieReleasePtr() *corev1.DownwardAPIProjection {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DownwardAPIProjectionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -51476,6 +54518,15 @@ func (d *ConfigMapProjectionDie) DieFeedPtr(r *corev1.ConfigMapProjection) *Conf
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ConfigMapProjectionDie) DieFeedDuck(v any) *ConfigMapProjectionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ConfigMapProjectionDie) DieFeedJSON(j []byte) *ConfigMapProjectionDie {
 	r := corev1.ConfigMapProjection{}
@@ -51524,6 +54575,15 @@ func (d *ConfigMapProjectionDie) DieRelease() corev1.ConfigMapProjection {
 func (d *ConfigMapProjectionDie) DieReleasePtr() *corev1.ConfigMapProjection {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ConfigMapProjectionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -51768,6 +54828,15 @@ func (d *ServiceAccountTokenProjectionDie) DieFeedPtr(r *corev1.ServiceAccountTo
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceAccountTokenProjectionDie) DieFeedDuck(v any) *ServiceAccountTokenProjectionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceAccountTokenProjectionDie) DieFeedJSON(j []byte) *ServiceAccountTokenProjectionDie {
 	r := corev1.ServiceAccountTokenProjection{}
@@ -51816,6 +54885,15 @@ func (d *ServiceAccountTokenProjectionDie) DieRelease() corev1.ServiceAccountTok
 func (d *ServiceAccountTokenProjectionDie) DieReleasePtr() *corev1.ServiceAccountTokenProjection {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceAccountTokenProjectionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -52035,6 +55113,15 @@ func (d *ClusterTrustBundleProjectionDie) DieFeedPtr(r *corev1.ClusterTrustBundl
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ClusterTrustBundleProjectionDie) DieFeedDuck(v any) *ClusterTrustBundleProjectionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ClusterTrustBundleProjectionDie) DieFeedJSON(j []byte) *ClusterTrustBundleProjectionDie {
 	r := corev1.ClusterTrustBundleProjection{}
@@ -52083,6 +55170,15 @@ func (d *ClusterTrustBundleProjectionDie) DieRelease() corev1.ClusterTrustBundle
 func (d *ClusterTrustBundleProjectionDie) DieReleasePtr() *corev1.ClusterTrustBundleProjection {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ClusterTrustBundleProjectionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -52335,6 +55431,15 @@ func (d *PortworxVolumeSourceDie) DieFeedPtr(r *corev1.PortworxVolumeSource) *Po
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PortworxVolumeSourceDie) DieFeedDuck(v any) *PortworxVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PortworxVolumeSourceDie) DieFeedJSON(j []byte) *PortworxVolumeSourceDie {
 	r := corev1.PortworxVolumeSource{}
@@ -52383,6 +55488,15 @@ func (d *PortworxVolumeSourceDie) DieRelease() corev1.PortworxVolumeSource {
 func (d *PortworxVolumeSourceDie) DieReleasePtr() *corev1.PortworxVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PortworxVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -52590,6 +55704,15 @@ func (d *ScaleIOVolumeSourceDie) DieFeedPtr(r *corev1.ScaleIOVolumeSource) *Scal
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ScaleIOVolumeSourceDie) DieFeedDuck(v any) *ScaleIOVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ScaleIOVolumeSourceDie) DieFeedJSON(j []byte) *ScaleIOVolumeSourceDie {
 	r := corev1.ScaleIOVolumeSource{}
@@ -52638,6 +55761,15 @@ func (d *ScaleIOVolumeSourceDie) DieRelease() corev1.ScaleIOVolumeSource {
 func (d *ScaleIOVolumeSourceDie) DieReleasePtr() *corev1.ScaleIOVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ScaleIOVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -52915,6 +56047,15 @@ func (d *StorageOSVolumeSourceDie) DieFeedPtr(r *corev1.StorageOSVolumeSource) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StorageOSVolumeSourceDie) DieFeedDuck(v any) *StorageOSVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StorageOSVolumeSourceDie) DieFeedJSON(j []byte) *StorageOSVolumeSourceDie {
 	r := corev1.StorageOSVolumeSource{}
@@ -52963,6 +56104,15 @@ func (d *StorageOSVolumeSourceDie) DieRelease() corev1.StorageOSVolumeSource {
 func (d *StorageOSVolumeSourceDie) DieReleasePtr() *corev1.StorageOSVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StorageOSVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -53211,6 +56361,15 @@ func (d *CSIVolumeSourceDie) DieFeedPtr(r *corev1.CSIVolumeSource) *CSIVolumeSou
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSIVolumeSourceDie) DieFeedDuck(v any) *CSIVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSIVolumeSourceDie) DieFeedJSON(j []byte) *CSIVolumeSourceDie {
 	r := corev1.CSIVolumeSource{}
@@ -53259,6 +56418,15 @@ func (d *CSIVolumeSourceDie) DieRelease() corev1.CSIVolumeSource {
 func (d *CSIVolumeSourceDie) DieReleasePtr() *corev1.CSIVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSIVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -53511,6 +56679,15 @@ func (d *EphemeralVolumeSourceDie) DieFeedPtr(r *corev1.EphemeralVolumeSource) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EphemeralVolumeSourceDie) DieFeedDuck(v any) *EphemeralVolumeSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EphemeralVolumeSourceDie) DieFeedJSON(j []byte) *EphemeralVolumeSourceDie {
 	r := corev1.EphemeralVolumeSource{}
@@ -53559,6 +56736,15 @@ func (d *EphemeralVolumeSourceDie) DieRelease() corev1.EphemeralVolumeSource {
 func (d *EphemeralVolumeSourceDie) DieReleasePtr() *corev1.EphemeralVolumeSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EphemeralVolumeSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -53825,6 +57011,15 @@ func (d *KeyToPathDie) DieFeedPtr(r *corev1.KeyToPath) *KeyToPathDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *KeyToPathDie) DieFeedDuck(v any) *KeyToPathDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *KeyToPathDie) DieFeedJSON(j []byte) *KeyToPathDie {
 	r := corev1.KeyToPath{}
@@ -53873,6 +57068,15 @@ func (d *KeyToPathDie) DieRelease() corev1.KeyToPath {
 func (d *KeyToPathDie) DieReleasePtr() *corev1.KeyToPath {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *KeyToPathDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/discovery/v1/zz_generated.die.go
+++ b/apis/discovery/v1/zz_generated.die.go
@@ -83,6 +83,15 @@ func (d *EndpointSliceDie) DieFeedPtr(r *discoveryv1.EndpointSlice) *EndpointSli
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointSliceDie) DieFeedDuck(v any) *EndpointSliceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointSliceDie) DieFeedJSON(j []byte) *EndpointSliceDie {
 	r := discoveryv1.EndpointSlice{}
@@ -143,6 +152,15 @@ func (d *EndpointSliceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointSliceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -480,6 +498,15 @@ func (d *EndpointDie) DieFeedPtr(r *discoveryv1.Endpoint) *EndpointDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointDie) DieFeedDuck(v any) *EndpointDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointDie) DieFeedJSON(j []byte) *EndpointDie {
 	r := discoveryv1.Endpoint{}
@@ -528,6 +555,15 @@ func (d *EndpointDie) DieRelease() discoveryv1.Endpoint {
 func (d *EndpointDie) DieReleasePtr() *discoveryv1.Endpoint {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -835,6 +871,15 @@ func (d *EndpointConditionsDie) DieFeedPtr(r *discoveryv1.EndpointConditions) *E
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointConditionsDie) DieFeedDuck(v any) *EndpointConditionsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointConditionsDie) DieFeedJSON(j []byte) *EndpointConditionsDie {
 	r := discoveryv1.EndpointConditions{}
@@ -883,6 +928,15 @@ func (d *EndpointConditionsDie) DieRelease() discoveryv1.EndpointConditions {
 func (d *EndpointConditionsDie) DieReleasePtr() *discoveryv1.EndpointConditions {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointConditionsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1106,6 +1160,15 @@ func (d *EndpointHintsDie) DieFeedPtr(r *discoveryv1.EndpointHints) *EndpointHin
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointHintsDie) DieFeedDuck(v any) *EndpointHintsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointHintsDie) DieFeedJSON(j []byte) *EndpointHintsDie {
 	r := discoveryv1.EndpointHints{}
@@ -1154,6 +1217,15 @@ func (d *EndpointHintsDie) DieRelease() discoveryv1.EndpointHints {
 func (d *EndpointHintsDie) DieReleasePtr() *discoveryv1.EndpointHints {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointHintsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1357,6 +1429,15 @@ func (d *ForZoneDie) DieFeedPtr(r *discoveryv1.ForZone) *ForZoneDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ForZoneDie) DieFeedDuck(v any) *ForZoneDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ForZoneDie) DieFeedJSON(j []byte) *ForZoneDie {
 	r := discoveryv1.ForZone{}
@@ -1405,6 +1486,15 @@ func (d *ForZoneDie) DieRelease() discoveryv1.ForZone {
 func (d *ForZoneDie) DieReleasePtr() *discoveryv1.ForZone {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ForZoneDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1592,6 +1682,15 @@ func (d *EndpointPortDie) DieFeedPtr(r *discoveryv1.EndpointPort) *EndpointPortD
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EndpointPortDie) DieFeedDuck(v any) *EndpointPortDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EndpointPortDie) DieFeedJSON(j []byte) *EndpointPortDie {
 	r := discoveryv1.EndpointPort{}
@@ -1640,6 +1739,15 @@ func (d *EndpointPortDie) DieRelease() discoveryv1.EndpointPort {
 func (d *EndpointPortDie) DieReleasePtr() *discoveryv1.EndpointPort {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EndpointPortDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/events/v1/zz_generated.die.go
+++ b/apis/events/v1/zz_generated.die.go
@@ -83,6 +83,15 @@ func (d *EventDie) DieFeedPtr(r *eventsv1.Event) *EventDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EventDie) DieFeedDuck(v any) *EventDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EventDie) DieFeedJSON(j []byte) *EventDie {
 	r := eventsv1.Event{}
@@ -143,6 +152,15 @@ func (d *EventDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EventDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -573,6 +591,15 @@ func (d *EventSeriesDie) DieFeedPtr(r *eventsv1.EventSeries) *EventSeriesDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *EventSeriesDie) DieFeedDuck(v any) *EventSeriesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *EventSeriesDie) DieFeedJSON(j []byte) *EventSeriesDie {
 	r := eventsv1.EventSeries{}
@@ -621,6 +648,15 @@ func (d *EventSeriesDie) DieRelease() eventsv1.EventSeries {
 func (d *EventSeriesDie) DieReleasePtr() *eventsv1.EventSeries {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *EventSeriesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/meta/v1/zz_generated.die.go
+++ b/apis/meta/v1/zz_generated.die.go
@@ -74,6 +74,15 @@ func (d *ConditionDie) DieFeedPtr(r *metav1.Condition) *ConditionDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ConditionDie) DieFeedDuck(v any) *ConditionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ConditionDie) DieFeedJSON(j []byte) *ConditionDie {
 	r := metav1.Condition{}
@@ -122,6 +131,15 @@ func (d *ConditionDie) DieRelease() metav1.Condition {
 func (d *ConditionDie) DieReleasePtr() *metav1.Condition {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ConditionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -368,6 +386,15 @@ func (d *GroupResourceDie) DieFeedPtr(r *metav1.GroupResource) *GroupResourceDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GroupResourceDie) DieFeedDuck(v any) *GroupResourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GroupResourceDie) DieFeedJSON(j []byte) *GroupResourceDie {
 	r := metav1.GroupResource{}
@@ -416,6 +443,15 @@ func (d *GroupResourceDie) DieRelease() metav1.GroupResource {
 func (d *GroupResourceDie) DieReleasePtr() *metav1.GroupResource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GroupResourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -608,6 +644,15 @@ func (d *GroupVersionDie) DieFeedPtr(r *metav1.GroupVersion) *GroupVersionDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GroupVersionDie) DieFeedDuck(v any) *GroupVersionDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GroupVersionDie) DieFeedJSON(j []byte) *GroupVersionDie {
 	r := metav1.GroupVersion{}
@@ -656,6 +701,15 @@ func (d *GroupVersionDie) DieRelease() metav1.GroupVersion {
 func (d *GroupVersionDie) DieReleasePtr() *metav1.GroupVersion {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GroupVersionDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -848,6 +902,15 @@ func (d *GroupVersionKindDie) DieFeedPtr(r *metav1.GroupVersionKind) *GroupVersi
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GroupVersionKindDie) DieFeedDuck(v any) *GroupVersionKindDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GroupVersionKindDie) DieFeedJSON(j []byte) *GroupVersionKindDie {
 	r := metav1.GroupVersionKind{}
@@ -896,6 +959,15 @@ func (d *GroupVersionKindDie) DieRelease() metav1.GroupVersionKind {
 func (d *GroupVersionKindDie) DieReleasePtr() *metav1.GroupVersionKind {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GroupVersionKindDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1094,6 +1166,15 @@ func (d *GroupVersionResourceDie) DieFeedPtr(r *metav1.GroupVersionResource) *Gr
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GroupVersionResourceDie) DieFeedDuck(v any) *GroupVersionResourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GroupVersionResourceDie) DieFeedJSON(j []byte) *GroupVersionResourceDie {
 	r := metav1.GroupVersionResource{}
@@ -1142,6 +1223,15 @@ func (d *GroupVersionResourceDie) DieRelease() metav1.GroupVersionResource {
 func (d *GroupVersionResourceDie) DieReleasePtr() *metav1.GroupVersionResource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GroupVersionResourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1340,6 +1430,15 @@ func (d *GroupVersionForDiscoveryDie) DieFeedPtr(r *metav1.GroupVersionForDiscov
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *GroupVersionForDiscoveryDie) DieFeedDuck(v any) *GroupVersionForDiscoveryDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *GroupVersionForDiscoveryDie) DieFeedJSON(j []byte) *GroupVersionForDiscoveryDie {
 	r := metav1.GroupVersionForDiscovery{}
@@ -1388,6 +1487,15 @@ func (d *GroupVersionForDiscoveryDie) DieRelease() metav1.GroupVersionForDiscove
 func (d *GroupVersionForDiscoveryDie) DieReleasePtr() *metav1.GroupVersionForDiscovery {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *GroupVersionForDiscoveryDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1584,6 +1692,15 @@ func (d *ListMetaDie) DieFeedPtr(r *metav1.ListMeta) *ListMetaDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ListMetaDie) DieFeedDuck(v any) *ListMetaDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ListMetaDie) DieFeedJSON(j []byte) *ListMetaDie {
 	r := metav1.ListMeta{}
@@ -1632,6 +1749,15 @@ func (d *ListMetaDie) DieRelease() metav1.ListMeta {
 func (d *ListMetaDie) DieReleasePtr() *metav1.ListMeta {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ListMetaDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1878,6 +2004,15 @@ func (d *ObjectMetaDie) DieFeedPtr(r *metav1.ObjectMeta) *ObjectMetaDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ObjectMetaDie) DieFeedDuck(v any) *ObjectMetaDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ObjectMetaDie) DieFeedJSON(j []byte) *ObjectMetaDie {
 	r := metav1.ObjectMeta{}
@@ -1926,6 +2061,15 @@ func (d *ObjectMetaDie) DieRelease() metav1.ObjectMeta {
 func (d *ObjectMetaDie) DieReleasePtr() *metav1.ObjectMeta {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ObjectMetaDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2407,6 +2551,15 @@ func (d *ManagedFieldsEntryDie) DieFeedPtr(r *metav1.ManagedFieldsEntry) *Manage
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ManagedFieldsEntryDie) DieFeedDuck(v any) *ManagedFieldsEntryDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ManagedFieldsEntryDie) DieFeedJSON(j []byte) *ManagedFieldsEntryDie {
 	r := metav1.ManagedFieldsEntry{}
@@ -2455,6 +2608,15 @@ func (d *ManagedFieldsEntryDie) DieRelease() metav1.ManagedFieldsEntry {
 func (d *ManagedFieldsEntryDie) DieReleasePtr() *metav1.ManagedFieldsEntry {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ManagedFieldsEntryDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2714,6 +2876,15 @@ func (d *LabelSelectorDie) DieFeedPtr(r *metav1.LabelSelector) *LabelSelectorDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LabelSelectorDie) DieFeedDuck(v any) *LabelSelectorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LabelSelectorDie) DieFeedJSON(j []byte) *LabelSelectorDie {
 	r := metav1.LabelSelector{}
@@ -2762,6 +2933,15 @@ func (d *LabelSelectorDie) DieRelease() metav1.LabelSelector {
 func (d *LabelSelectorDie) DieReleasePtr() *metav1.LabelSelector {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LabelSelectorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2960,6 +3140,15 @@ func (d *LabelSelectorRequirementDie) DieFeedPtr(r *metav1.LabelSelectorRequirem
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *LabelSelectorRequirementDie) DieFeedDuck(v any) *LabelSelectorRequirementDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *LabelSelectorRequirementDie) DieFeedJSON(j []byte) *LabelSelectorRequirementDie {
 	r := metav1.LabelSelectorRequirement{}
@@ -3008,6 +3197,15 @@ func (d *LabelSelectorRequirementDie) DieRelease() metav1.LabelSelectorRequireme
 func (d *LabelSelectorRequirementDie) DieReleasePtr() *metav1.LabelSelectorRequirement {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *LabelSelectorRequirementDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3217,6 +3415,15 @@ func (d *FieldSelectorRequirementDie) DieFeedPtr(r *metav1.FieldSelectorRequirem
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *FieldSelectorRequirementDie) DieFeedDuck(v any) *FieldSelectorRequirementDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *FieldSelectorRequirementDie) DieFeedJSON(j []byte) *FieldSelectorRequirementDie {
 	r := metav1.FieldSelectorRequirement{}
@@ -3265,6 +3472,15 @@ func (d *FieldSelectorRequirementDie) DieRelease() metav1.FieldSelectorRequireme
 func (d *FieldSelectorRequirementDie) DieReleasePtr() *metav1.FieldSelectorRequirement {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *FieldSelectorRequirementDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3474,6 +3690,15 @@ func (d *StatusDie) DieFeedPtr(r *metav1.Status) *StatusDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatusDie) DieFeedDuck(v any) *StatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatusDie) DieFeedJSON(j []byte) *StatusDie {
 	r := metav1.Status{}
@@ -3522,6 +3747,15 @@ func (d *StatusDie) DieRelease() metav1.Status {
 func (d *StatusDie) DieReleasePtr() *metav1.Status {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3798,6 +4032,15 @@ func (d *StatusDetailsDie) DieFeedPtr(r *metav1.StatusDetails) *StatusDetailsDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatusDetailsDie) DieFeedDuck(v any) *StatusDetailsDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatusDetailsDie) DieFeedJSON(j []byte) *StatusDetailsDie {
 	r := metav1.StatusDetails{}
@@ -3846,6 +4089,15 @@ func (d *StatusDetailsDie) DieRelease() metav1.StatusDetails {
 func (d *StatusDetailsDie) DieReleasePtr() *metav1.StatusDetails {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatusDetailsDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4098,6 +4350,15 @@ func (d *StatusCauseDie) DieFeedPtr(r *metav1.StatusCause) *StatusCauseDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StatusCauseDie) DieFeedDuck(v any) *StatusCauseDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StatusCauseDie) DieFeedJSON(j []byte) *StatusCauseDie {
 	r := metav1.StatusCause{}
@@ -4146,6 +4407,15 @@ func (d *StatusCauseDie) DieRelease() metav1.StatusCause {
 func (d *StatusCauseDie) DieReleasePtr() *metav1.StatusCause {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StatusCauseDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/networking/v1/zz_generated.die.go
+++ b/apis/networking/v1/zz_generated.die.go
@@ -84,6 +84,15 @@ func (d *IngressDie) DieFeedPtr(r *networkingv1.Ingress) *IngressDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressDie) DieFeedDuck(v any) *IngressDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressDie) DieFeedJSON(j []byte) *IngressDie {
 	r := networkingv1.Ingress{}
@@ -144,6 +153,15 @@ func (d *IngressDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -440,6 +458,15 @@ func (d *IngressSpecDie) DieFeedPtr(r *networkingv1.IngressSpec) *IngressSpecDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressSpecDie) DieFeedDuck(v any) *IngressSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressSpecDie) DieFeedJSON(j []byte) *IngressSpecDie {
 	r := networkingv1.IngressSpec{}
@@ -488,6 +515,15 @@ func (d *IngressSpecDie) DieRelease() networkingv1.IngressSpec {
 func (d *IngressSpecDie) DieReleasePtr() *networkingv1.IngressSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -781,6 +817,15 @@ func (d *IngressBackendDie) DieFeedPtr(r *networkingv1.IngressBackend) *IngressB
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressBackendDie) DieFeedDuck(v any) *IngressBackendDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressBackendDie) DieFeedJSON(j []byte) *IngressBackendDie {
 	r := networkingv1.IngressBackend{}
@@ -829,6 +874,15 @@ func (d *IngressBackendDie) DieRelease() networkingv1.IngressBackend {
 func (d *IngressBackendDie) DieReleasePtr() *networkingv1.IngressBackend {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressBackendDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1061,6 +1115,15 @@ func (d *IngressServiceBackendDie) DieFeedPtr(r *networkingv1.IngressServiceBack
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressServiceBackendDie) DieFeedDuck(v any) *IngressServiceBackendDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressServiceBackendDie) DieFeedJSON(j []byte) *IngressServiceBackendDie {
 	r := networkingv1.IngressServiceBackend{}
@@ -1109,6 +1172,15 @@ func (d *IngressServiceBackendDie) DieRelease() networkingv1.IngressServiceBacke
 func (d *IngressServiceBackendDie) DieReleasePtr() *networkingv1.IngressServiceBackend {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressServiceBackendDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1320,6 +1392,15 @@ func (d *ServiceBackendPortDie) DieFeedPtr(r *networkingv1.ServiceBackendPort) *
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *ServiceBackendPortDie) DieFeedDuck(v any) *ServiceBackendPortDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *ServiceBackendPortDie) DieFeedJSON(j []byte) *ServiceBackendPortDie {
 	r := networkingv1.ServiceBackendPort{}
@@ -1368,6 +1449,15 @@ func (d *ServiceBackendPortDie) DieRelease() networkingv1.ServiceBackendPort {
 func (d *ServiceBackendPortDie) DieReleasePtr() *networkingv1.ServiceBackendPort {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *ServiceBackendPortDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1566,6 +1656,15 @@ func (d *IngressTLSDie) DieFeedPtr(r *networkingv1.IngressTLS) *IngressTLSDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressTLSDie) DieFeedDuck(v any) *IngressTLSDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressTLSDie) DieFeedJSON(j []byte) *IngressTLSDie {
 	r := networkingv1.IngressTLS{}
@@ -1614,6 +1713,15 @@ func (d *IngressTLSDie) DieRelease() networkingv1.IngressTLS {
 func (d *IngressTLSDie) DieReleasePtr() *networkingv1.IngressTLS {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressTLSDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1822,6 +1930,15 @@ func (d *IngressRuleDie) DieFeedPtr(r *networkingv1.IngressRule) *IngressRuleDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressRuleDie) DieFeedDuck(v any) *IngressRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressRuleDie) DieFeedJSON(j []byte) *IngressRuleDie {
 	r := networkingv1.IngressRule{}
@@ -1870,6 +1987,15 @@ func (d *IngressRuleDie) DieRelease() networkingv1.IngressRule {
 func (d *IngressRuleDie) DieReleasePtr() *networkingv1.IngressRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2121,6 +2247,15 @@ func (d *HTTPIngressRuleValueDie) DieFeedPtr(r *networkingv1.HTTPIngressRuleValu
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HTTPIngressRuleValueDie) DieFeedDuck(v any) *HTTPIngressRuleValueDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HTTPIngressRuleValueDie) DieFeedJSON(j []byte) *HTTPIngressRuleValueDie {
 	r := networkingv1.HTTPIngressRuleValue{}
@@ -2169,6 +2304,15 @@ func (d *HTTPIngressRuleValueDie) DieRelease() networkingv1.HTTPIngressRuleValue
 func (d *HTTPIngressRuleValueDie) DieReleasePtr() *networkingv1.HTTPIngressRuleValue {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HTTPIngressRuleValueDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2368,6 +2512,15 @@ func (d *HTTPIngressPathDie) DieFeedPtr(r *networkingv1.HTTPIngressPath) *HTTPIn
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *HTTPIngressPathDie) DieFeedDuck(v any) *HTTPIngressPathDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *HTTPIngressPathDie) DieFeedJSON(j []byte) *HTTPIngressPathDie {
 	r := networkingv1.HTTPIngressPath{}
@@ -2416,6 +2569,15 @@ func (d *HTTPIngressPathDie) DieRelease() networkingv1.HTTPIngressPath {
 func (d *HTTPIngressPathDie) DieReleasePtr() *networkingv1.HTTPIngressPath {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *HTTPIngressPathDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2664,6 +2826,15 @@ func (d *IngressStatusDie) DieFeedPtr(r *networkingv1.IngressStatus) *IngressSta
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressStatusDie) DieFeedDuck(v any) *IngressStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressStatusDie) DieFeedJSON(j []byte) *IngressStatusDie {
 	r := networkingv1.IngressStatus{}
@@ -2712,6 +2883,15 @@ func (d *IngressStatusDie) DieRelease() networkingv1.IngressStatus {
 func (d *IngressStatusDie) DieReleasePtr() *networkingv1.IngressStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2910,6 +3090,15 @@ func (d *IngressLoadBalancerStatusDie) DieFeedPtr(r *networkingv1.IngressLoadBal
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressLoadBalancerStatusDie) DieFeedDuck(v any) *IngressLoadBalancerStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressLoadBalancerStatusDie) DieFeedJSON(j []byte) *IngressLoadBalancerStatusDie {
 	r := networkingv1.IngressLoadBalancerStatus{}
@@ -2958,6 +3147,15 @@ func (d *IngressLoadBalancerStatusDie) DieRelease() networkingv1.IngressLoadBala
 func (d *IngressLoadBalancerStatusDie) DieReleasePtr() *networkingv1.IngressLoadBalancerStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressLoadBalancerStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3157,6 +3355,15 @@ func (d *IngressLoadBalancerIngressDie) DieFeedPtr(r *networkingv1.IngressLoadBa
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressLoadBalancerIngressDie) DieFeedDuck(v any) *IngressLoadBalancerIngressDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressLoadBalancerIngressDie) DieFeedJSON(j []byte) *IngressLoadBalancerIngressDie {
 	r := networkingv1.IngressLoadBalancerIngress{}
@@ -3205,6 +3412,15 @@ func (d *IngressLoadBalancerIngressDie) DieRelease() networkingv1.IngressLoadBal
 func (d *IngressLoadBalancerIngressDie) DieReleasePtr() *networkingv1.IngressLoadBalancerIngress {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressLoadBalancerIngressDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3418,6 +3634,15 @@ func (d *IngressPortStatusDie) DieFeedPtr(r *networkingv1.IngressPortStatus) *In
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressPortStatusDie) DieFeedDuck(v any) *IngressPortStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressPortStatusDie) DieFeedJSON(j []byte) *IngressPortStatusDie {
 	r := networkingv1.IngressPortStatus{}
@@ -3466,6 +3691,15 @@ func (d *IngressPortStatusDie) DieRelease() networkingv1.IngressPortStatus {
 func (d *IngressPortStatusDie) DieReleasePtr() *networkingv1.IngressPortStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressPortStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3686,6 +3920,15 @@ func (d *IngressClassDie) DieFeedPtr(r *networkingv1.IngressClass) *IngressClass
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressClassDie) DieFeedDuck(v any) *IngressClassDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressClassDie) DieFeedJSON(j []byte) *IngressClassDie {
 	r := networkingv1.IngressClass{}
@@ -3746,6 +3989,15 @@ func (d *IngressClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressClassDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4024,6 +4276,15 @@ func (d *IngressClassSpecDie) DieFeedPtr(r *networkingv1.IngressClassSpec) *Ingr
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressClassSpecDie) DieFeedDuck(v any) *IngressClassSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressClassSpecDie) DieFeedJSON(j []byte) *IngressClassSpecDie {
 	r := networkingv1.IngressClassSpec{}
@@ -4072,6 +4333,15 @@ func (d *IngressClassSpecDie) DieRelease() networkingv1.IngressClassSpec {
 func (d *IngressClassSpecDie) DieReleasePtr() *networkingv1.IngressClassSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressClassSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4295,6 +4565,15 @@ func (d *IngressClassParametersReferenceDie) DieFeedPtr(r *networkingv1.IngressC
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IngressClassParametersReferenceDie) DieFeedDuck(v any) *IngressClassParametersReferenceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IngressClassParametersReferenceDie) DieFeedJSON(j []byte) *IngressClassParametersReferenceDie {
 	r := networkingv1.IngressClassParametersReference{}
@@ -4343,6 +4622,15 @@ func (d *IngressClassParametersReferenceDie) DieRelease() networkingv1.IngressCl
 func (d *IngressClassParametersReferenceDie) DieReleasePtr() *networkingv1.IngressClassParametersReference {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IngressClassParametersReferenceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4571,6 +4859,15 @@ func (d *NetworkPolicyDie) DieFeedPtr(r *networkingv1.NetworkPolicy) *NetworkPol
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NetworkPolicyDie) DieFeedDuck(v any) *NetworkPolicyDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NetworkPolicyDie) DieFeedJSON(j []byte) *NetworkPolicyDie {
 	r := networkingv1.NetworkPolicy{}
@@ -4631,6 +4928,15 @@ func (d *NetworkPolicyDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NetworkPolicyDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4907,6 +5213,15 @@ func (d *NetworkPolicySpecDie) DieFeedPtr(r *networkingv1.NetworkPolicySpec) *Ne
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NetworkPolicySpecDie) DieFeedDuck(v any) *NetworkPolicySpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NetworkPolicySpecDie) DieFeedJSON(j []byte) *NetworkPolicySpecDie {
 	r := networkingv1.NetworkPolicySpec{}
@@ -4955,6 +5270,15 @@ func (d *NetworkPolicySpecDie) DieRelease() networkingv1.NetworkPolicySpec {
 func (d *NetworkPolicySpecDie) DieReleasePtr() *networkingv1.NetworkPolicySpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NetworkPolicySpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5284,6 +5608,15 @@ func (d *NetworkPolicyIngressRuleDie) DieFeedPtr(r *networkingv1.NetworkPolicyIn
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NetworkPolicyIngressRuleDie) DieFeedDuck(v any) *NetworkPolicyIngressRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NetworkPolicyIngressRuleDie) DieFeedJSON(j []byte) *NetworkPolicyIngressRuleDie {
 	r := networkingv1.NetworkPolicyIngressRule{}
@@ -5332,6 +5665,15 @@ func (d *NetworkPolicyIngressRuleDie) DieRelease() networkingv1.NetworkPolicyIng
 func (d *NetworkPolicyIngressRuleDie) DieReleasePtr() *networkingv1.NetworkPolicyIngressRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NetworkPolicyIngressRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5582,6 +5924,15 @@ func (d *NetworkPolicyEgressRuleDie) DieFeedPtr(r *networkingv1.NetworkPolicyEgr
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NetworkPolicyEgressRuleDie) DieFeedDuck(v any) *NetworkPolicyEgressRuleDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NetworkPolicyEgressRuleDie) DieFeedJSON(j []byte) *NetworkPolicyEgressRuleDie {
 	r := networkingv1.NetworkPolicyEgressRule{}
@@ -5630,6 +5981,15 @@ func (d *NetworkPolicyEgressRuleDie) DieRelease() networkingv1.NetworkPolicyEgre
 func (d *NetworkPolicyEgressRuleDie) DieReleasePtr() *networkingv1.NetworkPolicyEgressRule {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NetworkPolicyEgressRuleDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -5880,6 +6240,15 @@ func (d *NetworkPolicyPortDie) DieFeedPtr(r *networkingv1.NetworkPolicyPort) *Ne
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NetworkPolicyPortDie) DieFeedDuck(v any) *NetworkPolicyPortDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NetworkPolicyPortDie) DieFeedJSON(j []byte) *NetworkPolicyPortDie {
 	r := networkingv1.NetworkPolicyPort{}
@@ -5928,6 +6297,15 @@ func (d *NetworkPolicyPortDie) DieRelease() networkingv1.NetworkPolicyPort {
 func (d *NetworkPolicyPortDie) DieReleasePtr() *networkingv1.NetworkPolicyPort {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NetworkPolicyPortDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6175,6 +6553,15 @@ func (d *NetworkPolicyPeerDie) DieFeedPtr(r *networkingv1.NetworkPolicyPeer) *Ne
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *NetworkPolicyPeerDie) DieFeedDuck(v any) *NetworkPolicyPeerDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *NetworkPolicyPeerDie) DieFeedJSON(j []byte) *NetworkPolicyPeerDie {
 	r := networkingv1.NetworkPolicyPeer{}
@@ -6223,6 +6610,15 @@ func (d *NetworkPolicyPeerDie) DieRelease() networkingv1.NetworkPolicyPeer {
 func (d *NetworkPolicyPeerDie) DieReleasePtr() *networkingv1.NetworkPolicyPeer {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *NetworkPolicyPeerDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -6493,6 +6889,15 @@ func (d *IPBlockDie) DieFeedPtr(r *networkingv1.IPBlock) *IPBlockDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *IPBlockDie) DieFeedDuck(v any) *IPBlockDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *IPBlockDie) DieFeedJSON(j []byte) *IPBlockDie {
 	r := networkingv1.IPBlock{}
@@ -6541,6 +6946,15 @@ func (d *IPBlockDie) DieRelease() networkingv1.IPBlock {
 func (d *IPBlockDie) DieReleasePtr() *networkingv1.IPBlock {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *IPBlockDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/node/v1/zz_generated.die.go
+++ b/apis/node/v1/zz_generated.die.go
@@ -84,6 +84,15 @@ func (d *RuntimeClassDie) DieFeedPtr(r *nodev1.RuntimeClass) *RuntimeClassDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *RuntimeClassDie) DieFeedDuck(v any) *RuntimeClassDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *RuntimeClassDie) DieFeedJSON(j []byte) *RuntimeClassDie {
 	r := nodev1.RuntimeClass{}
@@ -144,6 +153,15 @@ func (d *RuntimeClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *RuntimeClassDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -453,6 +471,15 @@ func (d *OverheadDie) DieFeedPtr(r *nodev1.Overhead) *OverheadDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *OverheadDie) DieFeedDuck(v any) *OverheadDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *OverheadDie) DieFeedJSON(j []byte) *OverheadDie {
 	r := nodev1.Overhead{}
@@ -501,6 +528,15 @@ func (d *OverheadDie) DieRelease() nodev1.Overhead {
 func (d *OverheadDie) DieReleasePtr() *nodev1.Overhead {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *OverheadDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -708,6 +744,15 @@ func (d *SchedulingDie) DieFeedPtr(r *nodev1.Scheduling) *SchedulingDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *SchedulingDie) DieFeedDuck(v any) *SchedulingDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *SchedulingDie) DieFeedJSON(j []byte) *SchedulingDie {
 	r := nodev1.Scheduling{}
@@ -756,6 +801,15 @@ func (d *SchedulingDie) DieRelease() nodev1.Scheduling {
 func (d *SchedulingDie) DieReleasePtr() *nodev1.Scheduling {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *SchedulingDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/policy/v1/zz_generated.die.go
+++ b/apis/policy/v1/zz_generated.die.go
@@ -82,6 +82,15 @@ func (d *PodDisruptionBudgetDie) DieFeedPtr(r *policyv1.PodDisruptionBudget) *Po
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodDisruptionBudgetDie) DieFeedDuck(v any) *PodDisruptionBudgetDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodDisruptionBudgetDie) DieFeedJSON(j []byte) *PodDisruptionBudgetDie {
 	r := policyv1.PodDisruptionBudget{}
@@ -142,6 +151,15 @@ func (d *PodDisruptionBudgetDie) DieReleaseUnstructured() *unstructured.Unstruct
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodDisruptionBudgetDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -434,6 +452,15 @@ func (d *PodDisruptionBudgetSpecDie) DieFeedPtr(r *policyv1.PodDisruptionBudgetS
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodDisruptionBudgetSpecDie) DieFeedDuck(v any) *PodDisruptionBudgetSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodDisruptionBudgetSpecDie) DieFeedJSON(j []byte) *PodDisruptionBudgetSpecDie {
 	r := policyv1.PodDisruptionBudgetSpec{}
@@ -482,6 +509,15 @@ func (d *PodDisruptionBudgetSpecDie) DieRelease() policyv1.PodDisruptionBudgetSp
 func (d *PodDisruptionBudgetSpecDie) DieReleasePtr() *policyv1.PodDisruptionBudgetSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodDisruptionBudgetSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -810,6 +846,15 @@ func (d *PodDisruptionBudgetStatusDie) DieFeedPtr(r *policyv1.PodDisruptionBudge
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PodDisruptionBudgetStatusDie) DieFeedDuck(v any) *PodDisruptionBudgetStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PodDisruptionBudgetStatusDie) DieFeedJSON(j []byte) *PodDisruptionBudgetStatusDie {
 	r := policyv1.PodDisruptionBudgetStatus{}
@@ -858,6 +903,15 @@ func (d *PodDisruptionBudgetStatusDie) DieRelease() policyv1.PodDisruptionBudget
 func (d *PodDisruptionBudgetStatusDie) DieReleasePtr() *policyv1.PodDisruptionBudgetStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PodDisruptionBudgetStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/scheduling/v1/zz_generated.die.go
+++ b/apis/scheduling/v1/zz_generated.die.go
@@ -82,6 +82,15 @@ func (d *PriorityClassDie) DieFeedPtr(r *schedulingv1.PriorityClass) *PriorityCl
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *PriorityClassDie) DieFeedDuck(v any) *PriorityClassDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *PriorityClassDie) DieFeedJSON(j []byte) *PriorityClassDie {
 	r := schedulingv1.PriorityClass{}
@@ -142,6 +151,15 @@ func (d *PriorityClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *PriorityClassDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/storage/v1/zz_generated.die.go
+++ b/apis/storage/v1/zz_generated.die.go
@@ -84,6 +84,15 @@ func (d *CSIDriverDie) DieFeedPtr(r *storagev1.CSIDriver) *CSIDriverDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSIDriverDie) DieFeedDuck(v any) *CSIDriverDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSIDriverDie) DieFeedJSON(j []byte) *CSIDriverDie {
 	r := storagev1.CSIDriver{}
@@ -144,6 +153,15 @@ func (d *CSIDriverDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSIDriverDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -420,6 +438,15 @@ func (d *CSIDriverSpecDie) DieFeedPtr(r *storagev1.CSIDriverSpec) *CSIDriverSpec
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSIDriverSpecDie) DieFeedDuck(v any) *CSIDriverSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSIDriverSpecDie) DieFeedJSON(j []byte) *CSIDriverSpecDie {
 	r := storagev1.CSIDriverSpec{}
@@ -468,6 +495,15 @@ func (d *CSIDriverSpecDie) DieRelease() storagev1.CSIDriverSpec {
 func (d *CSIDriverSpecDie) DieReleasePtr() *storagev1.CSIDriverSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSIDriverSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -918,6 +954,15 @@ func (d *TokenRequestDie) DieFeedPtr(r *storagev1.TokenRequest) *TokenRequestDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *TokenRequestDie) DieFeedDuck(v any) *TokenRequestDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *TokenRequestDie) DieFeedJSON(j []byte) *TokenRequestDie {
 	r := storagev1.TokenRequest{}
@@ -966,6 +1011,15 @@ func (d *TokenRequestDie) DieRelease() storagev1.TokenRequest {
 func (d *TokenRequestDie) DieReleasePtr() *storagev1.TokenRequest {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *TokenRequestDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1167,6 +1221,15 @@ func (d *CSINodeDie) DieFeedPtr(r *storagev1.CSINode) *CSINodeDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSINodeDie) DieFeedDuck(v any) *CSINodeDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSINodeDie) DieFeedJSON(j []byte) *CSINodeDie {
 	r := storagev1.CSINode{}
@@ -1227,6 +1290,15 @@ func (d *CSINodeDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSINodeDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1503,6 +1575,15 @@ func (d *CSINodeSpecDie) DieFeedPtr(r *storagev1.CSINodeSpec) *CSINodeSpecDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSINodeSpecDie) DieFeedDuck(v any) *CSINodeSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSINodeSpecDie) DieFeedJSON(j []byte) *CSINodeSpecDie {
 	r := storagev1.CSINodeSpec{}
@@ -1551,6 +1632,15 @@ func (d *CSINodeSpecDie) DieRelease() storagev1.CSINodeSpec {
 func (d *CSINodeSpecDie) DieReleasePtr() *storagev1.CSINodeSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSINodeSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -1754,6 +1844,15 @@ func (d *CSINodeDriverDie) DieFeedPtr(r *storagev1.CSINodeDriver) *CSINodeDriver
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSINodeDriverDie) DieFeedDuck(v any) *CSINodeDriverDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSINodeDriverDie) DieFeedJSON(j []byte) *CSINodeDriverDie {
 	r := storagev1.CSINodeDriver{}
@@ -1802,6 +1901,15 @@ func (d *CSINodeDriverDie) DieRelease() storagev1.CSINodeDriver {
 func (d *CSINodeDriverDie) DieReleasePtr() *storagev1.CSINodeDriver {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSINodeDriverDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2063,6 +2171,15 @@ func (d *VolumeNodeResourcesDie) DieFeedPtr(r *storagev1.VolumeNodeResources) *V
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeNodeResourcesDie) DieFeedDuck(v any) *VolumeNodeResourcesDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeNodeResourcesDie) DieFeedJSON(j []byte) *VolumeNodeResourcesDie {
 	r := storagev1.VolumeNodeResources{}
@@ -2111,6 +2228,15 @@ func (d *VolumeNodeResourcesDie) DieRelease() storagev1.VolumeNodeResources {
 func (d *VolumeNodeResourcesDie) DieReleasePtr() *storagev1.VolumeNodeResources {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeNodeResourcesDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2307,6 +2433,15 @@ func (d *CSIStorageCapacityDie) DieFeedPtr(r *storagev1.CSIStorageCapacity) *CSI
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSIStorageCapacityDie) DieFeedDuck(v any) *CSIStorageCapacityDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSIStorageCapacityDie) DieFeedJSON(j []byte) *CSIStorageCapacityDie {
 	r := storagev1.CSIStorageCapacity{}
@@ -2367,6 +2502,15 @@ func (d *CSIStorageCapacityDie) DieReleaseUnstructured() *unstructured.Unstructu
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSIStorageCapacityDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -2767,6 +2911,15 @@ func (d *StorageClassDie) DieFeedPtr(r *storagev1.StorageClass) *StorageClassDie
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *StorageClassDie) DieFeedDuck(v any) *StorageClassDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *StorageClassDie) DieFeedJSON(j []byte) *StorageClassDie {
 	r := storagev1.StorageClass{}
@@ -2827,6 +2980,15 @@ func (d *StorageClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *StorageClassDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3175,6 +3337,15 @@ func (d *VolumeAttachmentDie) DieFeedPtr(r *storagev1.VolumeAttachment) *VolumeA
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeAttachmentDie) DieFeedDuck(v any) *VolumeAttachmentDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeAttachmentDie) DieFeedJSON(j []byte) *VolumeAttachmentDie {
 	r := storagev1.VolumeAttachment{}
@@ -3235,6 +3406,15 @@ func (d *VolumeAttachmentDie) DieReleaseUnstructured() *unstructured.Unstructure
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeAttachmentDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3533,6 +3713,15 @@ func (d *VolumeAttachmentSpecDie) DieFeedPtr(r *storagev1.VolumeAttachmentSpec) 
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeAttachmentSpecDie) DieFeedDuck(v any) *VolumeAttachmentSpecDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeAttachmentSpecDie) DieFeedJSON(j []byte) *VolumeAttachmentSpecDie {
 	r := storagev1.VolumeAttachmentSpec{}
@@ -3581,6 +3770,15 @@ func (d *VolumeAttachmentSpecDie) DieRelease() storagev1.VolumeAttachmentSpec {
 func (d *VolumeAttachmentSpecDie) DieReleasePtr() *storagev1.VolumeAttachmentSpec {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeAttachmentSpecDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -3795,6 +3993,15 @@ func (d *VolumeAttachmentSourceDie) DieFeedPtr(r *storagev1.VolumeAttachmentSour
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeAttachmentSourceDie) DieFeedDuck(v any) *VolumeAttachmentSourceDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeAttachmentSourceDie) DieFeedJSON(j []byte) *VolumeAttachmentSourceDie {
 	r := storagev1.VolumeAttachmentSource{}
@@ -3843,6 +4050,15 @@ func (d *VolumeAttachmentSourceDie) DieRelease() storagev1.VolumeAttachmentSourc
 func (d *VolumeAttachmentSourceDie) DieReleasePtr() *storagev1.VolumeAttachmentSource {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeAttachmentSourceDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4068,6 +4284,15 @@ func (d *VolumeAttachmentStatusDie) DieFeedPtr(r *storagev1.VolumeAttachmentStat
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeAttachmentStatusDie) DieFeedDuck(v any) *VolumeAttachmentStatusDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeAttachmentStatusDie) DieFeedJSON(j []byte) *VolumeAttachmentStatusDie {
 	r := storagev1.VolumeAttachmentStatus{}
@@ -4116,6 +4341,15 @@ func (d *VolumeAttachmentStatusDie) DieRelease() storagev1.VolumeAttachmentStatu
 func (d *VolumeAttachmentStatusDie) DieReleasePtr() *storagev1.VolumeAttachmentStatus {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeAttachmentStatusDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.
@@ -4374,6 +4608,15 @@ func (d *VolumeErrorDie) DieFeedPtr(r *storagev1.VolumeError) *VolumeErrorDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *VolumeErrorDie) DieFeedDuck(v any) *VolumeErrorDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *VolumeErrorDie) DieFeedJSON(j []byte) *VolumeErrorDie {
 	r := storagev1.VolumeError{}
@@ -4422,6 +4665,15 @@ func (d *VolumeErrorDie) DieRelease() storagev1.VolumeError {
 func (d *VolumeErrorDie) DieReleasePtr() *storagev1.VolumeError {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *VolumeErrorDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/apis/storage/v1beta1/zz_generated.die.go
+++ b/apis/storage/v1beta1/zz_generated.die.go
@@ -82,6 +82,15 @@ func (d *CSIStorageCapacityDie) DieFeedPtr(r *storagev1beta1.CSIStorageCapacity)
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *CSIStorageCapacityDie) DieFeedDuck(v any) *CSIStorageCapacityDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *CSIStorageCapacityDie) DieFeedJSON(j []byte) *CSIStorageCapacityDie {
 	r := storagev1beta1.CSIStorageCapacity{}
@@ -142,6 +151,15 @@ func (d *CSIStorageCapacityDie) DieReleaseUnstructured() *unstructured.Unstructu
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *CSIStorageCapacityDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.

--- a/diegen/die/traverse.go
+++ b/diegen/die/traverse.go
@@ -318,6 +318,16 @@ func (c *copyMethodMaker) generateDieFeedMethodFor(die Die) {
 	c.Linef("}")
 
 	c.Linef("")
+	c.Linef("// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.")
+	c.Linef("func (d *%s) DieFeedDuck(v any) *%s {", die.Type, die.Type)
+	c.Linef("	data, err := %s(v)", c.AliasedRef("k8s.io/apimachinery/pkg/util/json", "Marshal"))
+	c.Linef("	if err != nil {")
+	c.Linef("		panic(err)")
+	c.Linef("	}")
+	c.Linef("	return d.DieFeedJSON(data)")
+	c.Linef("}")
+
+	c.Linef("")
 	c.Linef("// DieFeedJSON returns a new die with the provided JSON. Panics on error.")
 	c.Linef("func (d *%s) DieFeedJSON(j []byte) *%s {", die.Type, die.Type)
 	c.Linef("	r := %s{}", c.AliasedRef(die.TargetPackage, die.TargetType))
@@ -388,6 +398,16 @@ func (c *copyMethodMaker) generateDieReleaseMethodFor(die Die) {
 		c.Linef("	}")
 		c.Linef("}")
 	}
+
+	c.Linef("")
+	c.Linef("// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.")
+	c.Linef("func (d *%s) DieReleaseDuck(v any) any {", die.Type)
+	c.Linef("	data := d.DieReleaseJSON()")
+	c.Linef("	if err := %s(data, v); err != nil {", c.AliasedRef("k8s.io/apimachinery/pkg/util/json", "Unmarshal"))
+	c.Linef("		panic(err)")
+	c.Linef("	}")
+	c.Linef("	return v")
+	c.Linef("}")
 
 	c.Linef("")
 	c.Linef("// DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.")

--- a/testing/sandbox/zz_generated.die.go
+++ b/testing/sandbox/zz_generated.die.go
@@ -73,6 +73,15 @@ func (d *DirectDie) DieFeedPtr(r *Direct) *DirectDie {
 	return d.DieFeed(*r)
 }
 
+// DieFeedDuck returns a new die with the provided value converted into the underlying type. Panics on error.
+func (d *DirectDie) DieFeedDuck(v any) *DirectDie {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return d.DieFeedJSON(data)
+}
+
 // DieFeedJSON returns a new die with the provided JSON. Panics on error.
 func (d *DirectDie) DieFeedJSON(j []byte) *DirectDie {
 	r := Direct{}
@@ -121,6 +130,15 @@ func (d *DirectDie) DieRelease() Direct {
 func (d *DirectDie) DieReleasePtr() *Direct {
 	r := d.DieRelease()
 	return &r
+}
+
+// DieReleaseDuck releases the value into the passed value and returns the same. Panics on error.
+func (d *DirectDie) DieReleaseDuck(v any) any {
+	data := d.DieReleaseJSON()
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // DieReleaseJSON returns the resource managed by the die as JSON. Panics on error.


### PR DESCRIPTION
DieFeedDuck accepts any value and attempts to feed it into the die. Internally, it marshals the value and feeds the resulting json. DieReleaseDuck is similar, but take the value from the die and releases it into the passed value, returning the same value for convenience.

These methods are particularly useful when converting between types with similar shapes. Values will be lost where the json structures are not compatible. Any error will result in a panic.